### PR TITLE
feat: metadata-compartida tracker — shared metadata via .git/git-courer/ + refs

### DIFF
--- a/.git-courer/branches/feat-metadata-compartida-p1/commits.json
+++ b/.git-courer/branches/feat-metadata-compartida-p1/commits.json
@@ -1,0 +1,8 @@
+[
+  {
+    "sha": "89c0698c621fd0d3f302200e66a2090ce304af90",
+    "message": "feat!: refactor git adapter and relocate commit metadata\n\nWHY\nThe commit store lacked access to git adapter functionality, preventing branch-aware context resolution. Additionally, storing metadata in the project root caused workspace clutter and potential version control issues. The git adapter also lacked essential methods for stdin injection, object hashing, and reference inspection.\n\nWHAT\n* Relocated commit store metadata to .git/git-courer to align with standard Git directory structure.\n* Updated FilesystemCommitStore to accept the git adapter as a dependency.\n* Added runGitWithStdin, HashObject, and ShowRef to the ExecAdapter and Git port interface.\n* Implemented stdin data injection and pattern-based reference lookups.",
+    "author": "Alejandro",
+    "date": "2026-06-16T10:02:36Z"
+  }
+]

--- a/.git-courer/branches/feat-metadata-compartida-p2/commits.json
+++ b/.git-courer/branches/feat-metadata-compartida-p2/commits.json
@@ -1,0 +1,14 @@
+[
+  {
+    "sha": "aeccca3ae0513d202589367e9792280b325302c5",
+    "message": "feat!: refactor git adapter and relocate commit metadata",
+    "author": "Alejandro",
+    "date": "2026-06-16"
+  },
+  {
+    "sha": "4a76276d0817aa89baf2c1477d0986115aca57af",
+    "message": "feat: refactor metadata paths and implement sidecar ref syncing\n\nWHY\nProject configuration and release paths were hardcoded to a top-level .git-courer directory, causing structural inconsistencies and preventing metadata from being nested within the .git folder. Additionally, branch-scoped metadata and sidecar references were not being synchronized to the remote origin, making it difficult to track appended data or share branch-specific state with downstream tools.\n\nWHAT\n* Replaced hardcoded \".git-courer\" strings with the MetadataDir constant across config, release, and project services.\n* Implemented updateCourerRef to create git blobs and update refs/courer/\u003cbranch\u003e during the append process.\n* Added logic to push sidecar references to origin during PUSH and AUTO operations.\n* Integrated branch detection to synchronize the current branch to origin/refs/courer/ during commit execution.",
+    "author": "Alejandro",
+    "date": "2026-06-16T10:09:01Z"
+  }
+]

--- a/.git-courer/branches/feat-metadata-compartida-p3/commits.json
+++ b/.git-courer/branches/feat-metadata-compartida-p3/commits.json
@@ -1,0 +1,20 @@
+[
+  {
+    "sha": "4ad6c50c4ac0603e81950e43f5bbce1a94022bb0",
+    "message": "feat: refactor metadata paths and implement sidecar ref syncing",
+    "author": "Alejandro",
+    "date": "2026-06-16"
+  },
+  {
+    "sha": "aeccca3ae0513d202589367e9792280b325302c5",
+    "message": "feat!: refactor git adapter and relocate commit metadata",
+    "author": "Alejandro",
+    "date": "2026-06-16"
+  },
+  {
+    "sha": "4e25ddcd1884662ac2b55ebc00487780779947df",
+    "message": "feat: implement metadata migration and ref-based commit retrieval\n\nWHY\nMetadata stored in legacy directories was lost during restructuring, and commit history was difficult to track accurately after squash merges or when relying solely on the CommitStore.\n\nWHAT\n* Added migration logic to move and deduplicate branch metadata from .git-courer/branches to the new metadata directory.\n* Implemented commitsFromRefs to extract commit history directly from git refs/courer/* blobs.\n* Updated release workflow to prioritize git refs for commit retrieval before falling back to the local store.\n* Added logic to cleanup refs/courer/* after successful release.\n* Fixed CatFile to fallback to git show when path is empty.\n* Added logic to handle empty commit hash in UpdateRef by executing git update-ref -d.\n* Configured remote origin fetch refspec on init to track courer-specific references.",
+    "author": "Alejandro",
+    "date": "2026-06-16T10:14:21Z"
+  }
+]

--- a/.git-courer/branches/feat-metadata-compartida-p4/commits.json
+++ b/.git-courer/branches/feat-metadata-compartida-p4/commits.json
@@ -1,0 +1,38 @@
+[
+  {
+    "sha": "1c5175c0b2c529c8099ca2f38ba8c789c67417ba",
+    "message": "fix: fix commit storage paths and git configuration logic",
+    "author": "Alejandro",
+    "date": "2026-06-16"
+  },
+  {
+    "sha": "9354a377eeaf1ef2d2d9a37ce114d6f5e0c7be65",
+    "message": "feat!: migrate local config and commit storage to .git directory",
+    "author": "Alejandro",
+    "date": "2026-06-16"
+  },
+  {
+    "sha": "fabad395349563c11e90ad721f8bd61ac35dc4ae",
+    "message": "feat: implement metadata migration and ref-based commit retrieval",
+    "author": "Alejandro",
+    "date": "2026-06-16"
+  },
+  {
+    "sha": "4ad6c50c4ac0603e81950e43f5bbce1a94022bb0",
+    "message": "feat: refactor metadata paths and implement sidecar ref syncing",
+    "author": "Alejandro",
+    "date": "2026-06-16"
+  },
+  {
+    "sha": "aeccca3ae0513d202589367e9792280b325302c5",
+    "message": "feat!: refactor git adapter and relocate commit metadata",
+    "author": "Alejandro",
+    "date": "2026-06-16"
+  },
+  {
+    "sha": "5affe8cb7928bf5fd3c1ef071b0f9de35273b8b5",
+    "message": "fix: relocate project configuration to .git directory\n\nWHY\nThe configuration file path was incorrectly documented and implemented as being in the project root or the .git-courer directory, leading to potential configuration fragmentation and user confusion.\n\nWHAT\n* Updated the configuration file path to reside within .git/git-courer/config.json\n* Corrected documentation and internal comments to reflect the new directory structure\n* Updated the test command configuration lookup path",
+    "author": "Alejandro",
+    "date": "2026-06-16T10:22:15Z"
+  }
+]

--- a/.git-courer/branches/feat-metadata-compartida/commits.json
+++ b/.git-courer/branches/feat-metadata-compartida/commits.json
@@ -1,0 +1,14 @@
+[
+  {
+    "sha": "4ad6c50c4ac0603e81950e43f5bbce1a94022bb0",
+    "message": "feat: refactor metadata paths and implement sidecar ref syncing",
+    "author": "Alejandro",
+    "date": "2026-06-16"
+  },
+  {
+    "sha": "aeccca3ae0513d202589367e9792280b325302c5",
+    "message": "feat!: refactor git adapter and relocate commit metadata",
+    "author": "Alejandro",
+    "date": "2026-06-16"
+  }
+]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 | **[Architecture](docs/architecture.md)** | Codebase structure, patterns, and how to add features |
 | **[Troubleshooting](docs/troubleshooting.md)** | Fix: Ollama not running, MCP not detected, permission errors |
 | **[MCP Clients](docs/mcp-clients.md)** | All 14 supported clients, config formats, manual setup |
-| **[Config Options](docs/config.md)** | All `~/.config/git-courer/config.yaml` and `.git-courer/config.json` settings |
+| **[Config Options](docs/config.md)** | All `~/.config/git-courer/config.yaml` and `.git/git-courer/config.json` settings |
 | **[Commands](docs/commands.md)** | Complete reference for all 22 MCP tools |
 | **[Models Guide](docs/models.md)** | Tested models, token usage, and which one to pick |
 | **[Contributing](CONTRIBUTING.md)** | Setup, running tests, and how to collaborate |
@@ -116,15 +116,15 @@ Preview the change → review proposed commits → apply. git-courer splits your
 
 ### Before any PR or merge
 Call `pr-review` — a pre-PR gate that runs in one shot:
-1. **Tests** — runs `test_command` from `.git-courer/config.json` (e.g. `go test ./...`)
+1. **Tests** — runs `test_command` from `.git/git-courer/config.json` (e.g. `go test ./...`)
 2. **Conflicts** — detects merge conflicts with the target branch and returns AST-annotated hunks (`[NEW_FUNC]`, `[MOD_SIG ⚠BREAKING]`)
 3. **Diff stats** — files changed, additions, deletions
 4. **Divergence** — ahead/behind count, mergeable status
 
-If it's not green, you don't merge. Set `test_command` via `git-config SET_TEST_COMMAND` or edit `.git-courer/config.json` directly.
+If it's not green, you don't merge. Set `test_command` via `git-config SET_TEST_COMMAND` or edit `.git/git-courer/config.json` directly.
 
 ### Release (CLI)
-Run `git-courer release`. The CLI reads commits from `.git-courer/commits.json` (captured during each `git-commit APPLY` on this branch) and groups them by the `areas` defined in `.git-courer/con[...]
+Run `git-courer release`. The CLI reads commits from `.git/git-courer/branches/` (captured during each `git-commit APPLY` on this branch) and also from `refs/courer/*` — per-branch commit blobs that survive squash merges and deleted branches
 
 ### Undo
 Every destructive operation has an automatic backup. One command restores the previous state.
@@ -216,7 +216,7 @@ git-courer uses two config levels:
 
 **Global** (`~/.config/git-courer/config.yaml`) — personal settings: LLM backend, model.
 
-**Per-project** (`.git-courer/config.json`) — committable, shared with team. Stores description, areas, test_command, excluded. Better results = edit this file per project.
+**Per-project** (`.git/git-courer/config.json`) — committable, shared with team. Stores description, areas, test_command, excluded. Better results = edit this file per project.
 
 All options: **[docs/config.md](docs/config.md)**
 
@@ -231,7 +231,7 @@ When you call `git-commit PREVIEW`, the server may return immediately (FAST) or 
 
 The agent continues working — it does NOT block waiting for the job.
 
-Every successful commit via `git-commit APPLY` is captured to `.git-courer/commits.json` (branch-scoped under `.git-courer/branches/<branch>/commits.json`). When you later run `git-courer release[...]
+Every successful commit via `git-commit APPLY` is captured to `.git/git-courer/branches/<branch>/commits.json` and a `refs/courer/<branch>` blob is created. When you later run `git-courer release`, it reads commits from both the local store and the refs — so squash-merged PRs still produce accurate changelogs
 
 **Why this matters:** Git history is frequently rewritten — PR squashes, rebases, force-pushes — destroying the real commit narrative. The CommitStore preserves every commit message as it was[...]
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -274,7 +274,7 @@ func runRelease(args []string) {
 	gitAdapter := gitadapter.New(".")
 
 	// Create branch-scoped commit store
-	commitStore := commitstore.NewFilesystemCommitStore(".")
+	commitStore := commitstore.NewFilesystemCommitStore(".", gitAdapter)
 	currentBranch, branchErr := gitAdapter.CurrentBranch()
 	if branchErr == nil && currentBranch != "" {
 		if err := commitStore.SetBranch(currentBranch); err != nil {

--- a/docs/config.md
+++ b/docs/config.md
@@ -23,7 +23,7 @@ git:
   workdir: .
 ```
 
-## Per-project config (`.git-courer/config.json`)
+## Per-project config (`.git/git-courer/config.json`)
 
 This file is **committable** and **shared by your team**. It lives in your repo and travels with it. Editing it per project gives significantly better results.
 

--- a/internal/adapters/commitstore/adapter.go
+++ b/internal/adapters/commitstore/adapter.go
@@ -92,7 +92,26 @@ func (s *FilesystemCommitStore) Append(entries ...domain.CommitEntry) error {
 		return fmt.Errorf("commit store: write file: %w", s.sanitizePathError(err))
 	}
 
+	s.updateCourerRef(data)
+
 	return nil
+}
+
+// updateCourerRef creates a git blob from the written data and updates
+// refs/courer/<branch> when running in branch-scoped mode. Failures are logged
+// but never fail Append.
+func (s *FilesystemCommitStore) updateCourerRef(data []byte) {
+	if s.branch == "" || s.git == nil {
+		return
+	}
+	blobSHA, err := s.git.HashObject(data)
+	if err != nil {
+		log.Printf("[WARN] commit store: failed to create blob for refs/courer/%s: %v", s.branch, err)
+		return
+	}
+	if _, err := s.git.UpdateRef(fmt.Sprintf("refs/courer/%s", s.branch), blobSHA); err != nil {
+		log.Printf("[WARN] commit store: failed to update refs/courer/%s: %v", s.branch, err)
+	}
 }
 
 // Read returns all stored CommitEntry values.

--- a/internal/adapters/commitstore/adapter.go
+++ b/internal/adapters/commitstore/adapter.go
@@ -1,5 +1,5 @@
 // Package commitstore provides a filesystem-backed CommitStore adapter
-// that persists commit entries as JSONL in .git-courer/commits.json.
+// that persists commit entries as JSONL in workDir/.git/git-courer/commits.json.
 package commitstore
 
 import (
@@ -14,6 +14,7 @@ import (
 	"sync"
 
 	"github.com/blak0p/git-courer/internal/core/domain"
+	"github.com/blak0p/git-courer/internal/core/ports"
 )
 
 // jsonEntry is the JSON serialization format for CommitEntry.
@@ -31,21 +32,23 @@ type jsonEntry struct {
 // Operations are serialized with a mutex for concurrent safety.
 type FilesystemCommitStore struct {
 	mu         sync.Mutex
-	baseDir    string // workDir + "/.git-courer" — immutable after construction
+	git        ports.Git
+	baseDir    string // workDir + domain.MetadataDir — immutable after construction
 	currentDir string // active directory: baseDir (legacy) or baseDir + "/branches/<sanitized>"
 	path       string // active file path: currentDir + "/commits.json"
 	branch     string // current unsanitized branch name (empty = legacy mode)
 }
 
 // NewFilesystemCommitStore creates a FilesystemCommitStore that persists
-// entries in workDir/.git-courer/commits.json (legacy path).
-// When SetBranch is called, the path switches to workDir/.git-courer/branches/<sanitized>/commits.json.
+// entries in workDir/.git/git-courer/commits.json (legacy global path).
+// When SetBranch is called, the path switches to workDir/.git/git-courer/branches/<sanitized>/commits.json.
 // The directory and file are created lazily on first Append.
-func NewFilesystemCommitStore(workDir string) *FilesystemCommitStore {
-	baseDir := filepath.Join(workDir, ".git-courer")
+func NewFilesystemCommitStore(workDir string, git ports.Git) *FilesystemCommitStore {
+	baseDir := filepath.Join(workDir, domain.MetadataDir)
 	return &FilesystemCommitStore{
+		git:        git,
 		baseDir:    baseDir,
-		currentDir: baseDir, // legacy: writes to .git-courer/commits.json
+		currentDir: baseDir, // legacy: writes to .git/git-courer/commits.json
 		path:       filepath.Join(baseDir, "commits.json"),
 	}
 }
@@ -278,7 +281,7 @@ func (s *FilesystemCommitStore) Clear() error {
 
 // SetBranch switches the store to read/write from a branch-scoped path:
 //
-//	.git-courer/branches/<sanitized>/commits.json
+//	.git/git-courer/branches/<sanitized>/commits.json
 //
 // If name is empty, returns an error.
 // After calling SetBranch, Append/Read/Clear operate on the branch path.
@@ -298,7 +301,7 @@ func (s *FilesystemCommitStore) SetBranch(name string) error {
 
 // RemoveBranch removes the branch's store directory and all contents:
 //
-//	.git-courer/branches/<sanitized>/
+//	.git/git-courer/branches/<sanitized>/
 //
 // If the directory does not exist, returns nil (idempotent).
 // If name is empty, returns an error.

--- a/internal/adapters/commitstore/adapter_test.go
+++ b/internal/adapters/commitstore/adapter_test.go
@@ -36,7 +36,7 @@ func TestFilesystemCommitStore_AppendCreatesFileAndDir(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	entry := makeEntry(t, validSHA("aa000000000000000000000000000000000000"), "feat: first commit")
 
@@ -45,18 +45,18 @@ func TestFilesystemCommitStore_AppendCreatesFileAndDir(t *testing.T) {
 		t.Fatalf("Append() error: %v", err)
 	}
 
-	// Verify .git-courer/ directory was created
-	dirPath := filepath.Join(tmpDir, ".git-courer")
+	// Verify .git/git-courer/ directory was created
+	dirPath := filepath.Join(tmpDir, ".git/git-courer")
 	info, err := os.Stat(dirPath)
 	if err != nil {
-		t.Fatalf("expected .git-courer/ dir to exist: %v", err)
+		t.Fatalf("expected .git/git-courer/ dir to exist: %v", err)
 	}
 	if !info.IsDir() {
-		t.Errorf(".git-courer is not a directory")
+		t.Errorf(".git/git-courer is not a directory")
 	}
 
 	// Verify file was created
-	filePath := filepath.Join(tmpDir, ".git-courer", "commits.json")
+	filePath := filepath.Join(tmpDir, ".git/git-courer", "commits.json")
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		t.Fatalf("ReadFile() error: %v", err)
@@ -82,7 +82,7 @@ func TestFilesystemCommitStore_AppendAddsToExistingFile(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	e1 := makeEntry(t, validSHA("a1000000000000000000000000000000000000"), "feat: first")
 	e2 := makeEntry(t, validSHA("b2000000000000000000000000000000000000"), "fix: second")
@@ -94,7 +94,7 @@ func TestFilesystemCommitStore_AppendAddsToExistingFile(t *testing.T) {
 		t.Fatalf("second Append() error: %v", err)
 	}
 
-	filePath := filepath.Join(tmpDir, ".git-courer", "commits.json")
+	filePath := filepath.Join(tmpDir, ".git/git-courer", "commits.json")
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		t.Fatalf("ReadFile() error: %v", err)
@@ -113,7 +113,7 @@ func TestFilesystemCommitStore_ReadReturnsAllEntries(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	e1 := makeEntry(t, validSHA("10000000000000000000000000000000000000"), "feat: first", domain.WithAuthor("Alice"), domain.WithDate("2026-05-23T10:00:00Z"))
 	e2 := makeEntry(t, validSHA("20000000000000000000000000000000000000"), "fix: second")
@@ -148,7 +148,7 @@ func TestFilesystemCommitStore_ReadOnMissingFile(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	entries, err := store.Read()
 	if err != nil {
@@ -163,10 +163,10 @@ func TestFilesystemCommitStore_ReadWithCorruptedLine(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	// Manually write a file with a corrupted line
-	dirPath := filepath.Join(tmpDir, ".git-courer")
+	dirPath := filepath.Join(tmpDir, ".git/git-courer")
 	if err := os.MkdirAll(dirPath, 0o755); err != nil {
 		t.Fatalf("MkdirAll() error: %v", err)
 	}
@@ -198,7 +198,7 @@ func TestFilesystemCommitStore_ClearTruncatesFile(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	entry := makeEntry(t, validSHA("cc000000000000000000000000000000000000"), "feat: to be cleared")
 	store.Append(entry)
@@ -209,7 +209,7 @@ func TestFilesystemCommitStore_ClearTruncatesFile(t *testing.T) {
 	}
 
 	// Verify file exists but is empty
-	filePath := filepath.Join(tmpDir, ".git-courer", "commits.json")
+	filePath := filepath.Join(tmpDir, ".git/git-courer", "commits.json")
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		t.Fatalf("ReadFile() after Clear() error: %v", err)
@@ -232,7 +232,7 @@ func TestFilesystemCommitStore_ClearOnAlreadyEmpty(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	// Clear on store that was never written to — no file exists
 	err := store.Clear()
@@ -255,7 +255,7 @@ func TestFilesystemCommitStore_ConcurrentAppendSafety(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	var wg sync.WaitGroup
 	goroutines := 2
@@ -291,7 +291,7 @@ func TestFilesystemCommitStore_AppendMultiple(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	e1 := makeEntry(t, validSHA("10000000000000000000000000000000000001"), "feat: batch one")
 	e2 := makeEntry(t, validSHA("20000000000000000000000000000000000002"), "fix: batch two")
@@ -324,7 +324,7 @@ func TestFilesystemCommitStore_SetBranch_SetsPath(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	err := store.SetBranch("feat/auth")
 	if err != nil {
@@ -332,7 +332,7 @@ func TestFilesystemCommitStore_SetBranch_SetsPath(t *testing.T) {
 	}
 
 	// Verify path is branch-scoped
-	expectedDir := filepath.Join(tmpDir, ".git-courer", "branches", "feat-auth")
+	expectedDir := filepath.Join(tmpDir, ".git/git-courer", "branches", "feat-auth")
 	expectedPath := filepath.Join(expectedDir, "commits.json")
 
 	if store.currentDir != expectedDir {
@@ -350,7 +350,7 @@ func TestFilesystemCommitStore_SetBranch_EmptyName(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	err := store.SetBranch("")
 	if err == nil {
@@ -365,7 +365,7 @@ func TestFilesystemCommitStore_SetBranch_SwitchesPaths(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	err := store.SetBranch("feat/auth")
 	if err != nil {
@@ -391,7 +391,7 @@ func TestFilesystemCommitStore_RemoveBranch_DeletesDirectory(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	// SetBranch and Append to create the directory and file
 	if err := store.SetBranch("feat/auth"); err != nil {
@@ -403,7 +403,7 @@ func TestFilesystemCommitStore_RemoveBranch_DeletesDirectory(t *testing.T) {
 	}
 
 	// Verify directory exists
-	branchDir := filepath.Join(tmpDir, ".git-courer", "branches", "feat-auth")
+	branchDir := filepath.Join(tmpDir, ".git/git-courer", "branches", "feat-auth")
 	if _, err := os.Stat(branchDir); os.IsNotExist(err) {
 		t.Fatalf("branch directory should exist after Append: %v", err)
 	}
@@ -423,7 +423,7 @@ func TestFilesystemCommitStore_RemoveBranch_NonexistentBranch(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	// Removing a branch that was never created should return nil (idempotent)
 	err := store.RemoveBranch("nonexistent")
@@ -436,7 +436,7 @@ func TestFilesystemCommitStore_RemoveBranch_EmptyName(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	err := store.RemoveBranch("")
 	if err == nil {
@@ -451,7 +451,7 @@ func TestFilesystemCommitStore_NoSetBranch_LegacyPath(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	// No SetBranch call — should write to legacy path
 	entry := makeEntry(t, validSHA("aa000000000000000000000000000000000000"), "feat: first commit")
@@ -460,7 +460,7 @@ func TestFilesystemCommitStore_NoSetBranch_LegacyPath(t *testing.T) {
 	}
 
 	// Verify file was created at legacy path
-	legacyPath := filepath.Join(tmpDir, ".git-courer", "commits.json")
+	legacyPath := filepath.Join(tmpDir, ".git/git-courer", "commits.json")
 	if _, err := os.Stat(legacyPath); os.IsNotExist(err) {
 		t.Fatalf("legacy file should exist at %s", legacyPath)
 	}
@@ -476,7 +476,7 @@ func TestFilesystemCommitStore_NoSetBranch_LegacyPath(t *testing.T) {
 
 func TestFilesystemCommitStore_SetBranch_ConcurrentAccess(t *testing.T) {
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	var wg sync.WaitGroup
 	errCh := make(chan error, 100)
@@ -519,14 +519,14 @@ func TestFilesystemCommitStore_SanitizePathError_WithBranch(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	if err := store.SetBranch("feat/auth"); err != nil {
 		t.Fatalf("SetBranch() error: %v", err)
 	}
 
 	// Trigger an error by making the path unwritable
-	branchDir := filepath.Join(tmpDir, ".git-courer", "branches", "feat-auth")
+	branchDir := filepath.Join(tmpDir, ".git/git-courer", "branches", "feat-auth")
 	if err := os.MkdirAll(branchDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll() error: %v", err)
 	}
@@ -555,7 +555,7 @@ func TestFilesystemCommitStore_AfterSetBranch_AppendWritesToBranchFile(t *testin
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	if err := store.SetBranch("feat/auth"); err != nil {
 		t.Fatalf("SetBranch() error: %v", err)
@@ -567,7 +567,7 @@ func TestFilesystemCommitStore_AfterSetBranch_AppendWritesToBranchFile(t *testin
 	}
 
 	// Verify the file exists at the branch-scoped path
-	branchFilePath := filepath.Join(tmpDir, ".git-courer", "branches", "feat-auth", "commits.json")
+	branchFilePath := filepath.Join(tmpDir, ".git/git-courer", "branches", "feat-auth", "commits.json")
 	data, err := os.ReadFile(branchFilePath)
 	if err != nil {
 		t.Fatalf("branch file should exist at %s: %v", branchFilePath, err)
@@ -577,7 +577,7 @@ func TestFilesystemCommitStore_AfterSetBranch_AppendWritesToBranchFile(t *testin
 	}
 
 	// Verify the legacy file does NOT exist
-	legacyPath := filepath.Join(tmpDir, ".git-courer", "commits.json")
+	legacyPath := filepath.Join(tmpDir, ".git/git-courer", "commits.json")
 	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
 		t.Errorf("legacy file should not exist when SetBranch was called")
 	}
@@ -587,7 +587,7 @@ func TestFilesystemCommitStore_AfterSetBranch_ReadReturnsBranchEntries(t *testin
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	if err := store.SetBranch("feat/auth"); err != nil {
 		t.Fatalf("SetBranch() error: %v", err)
@@ -617,7 +617,7 @@ func TestFilesystemCommitStore_AfterSetBranch_ClearTruncatesBranchFile(t *testin
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	if err := store.SetBranch("feat/auth"); err != nil {
 		t.Fatalf("SetBranch() error: %v", err)
@@ -639,7 +639,7 @@ func TestFilesystemCommitStore_AfterSetBranch_ClearTruncatesBranchFile(t *testin
 	}
 
 	// Verify branch directory still exists (only file truncated, dir preserved)
-	branchDir := filepath.Join(tmpDir, ".git-courer", "branches", "feat-auth")
+	branchDir := filepath.Join(tmpDir, ".git/git-courer", "branches", "feat-auth")
 	info, err := os.Stat(branchDir)
 	if err != nil {
 		t.Fatalf("branch directory should still exist: %v", err)
@@ -653,14 +653,14 @@ func TestFilesystemCommitStore_AfterSetBranch_MkdirAllLazy(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	if err := store.SetBranch("feat/auth"); err != nil {
 		t.Fatalf("SetBranch() error: %v", err)
 	}
 
 	// Directory should NOT exist yet (lazy creation)
-	branchDir := filepath.Join(tmpDir, ".git-courer", "branches", "feat-auth")
+	branchDir := filepath.Join(tmpDir, ".git/git-courer", "branches", "feat-auth")
 	if _, err := os.Stat(branchDir); !os.IsNotExist(err) {
 		t.Errorf("branch directory should not exist before Append, got err: %v", err)
 	}
@@ -682,13 +682,13 @@ func TestFilesystemCommitStore_BranchIsolation(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Create store for feat/auth branch
-	storeAuth := NewFilesystemCommitStore(tmpDir)
+	storeAuth := NewFilesystemCommitStore(tmpDir, nil)
 	if err := storeAuth.SetBranch("feat/auth"); err != nil {
 		t.Fatalf("SetBranch(feat/auth) error: %v", err)
 	}
 
 	// Create store for main branch
-	storeMain := NewFilesystemCommitStore(tmpDir)
+	storeMain := NewFilesystemCommitStore(tmpDir, nil)
 	if err := storeMain.SetBranch("main"); err != nil {
 		t.Fatalf("SetBranch(main) error: %v", err)
 	}
@@ -744,7 +744,7 @@ type testJSON struct {
 func TestFilesystemCommitStore_JSONFormatAndFallback(t *testing.T) {
 	t.Run("JSON array format on write", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		store := NewFilesystemCommitStore(tmpDir)
+		store := NewFilesystemCommitStore(tmpDir, nil)
 
 		e1 := makeEntry(t, validSHA("a1000000000000000000000000000000000000"), "feat: first")
 		e2 := makeEntry(t, validSHA("b2000000000000000000000000000000000000"), "fix: second")
@@ -753,7 +753,7 @@ func TestFilesystemCommitStore_JSONFormatAndFallback(t *testing.T) {
 			t.Fatalf("Append error: %v", err)
 		}
 
-		filePath := filepath.Join(tmpDir, ".git-courer", "commits.json")
+		filePath := filepath.Join(tmpDir, ".git/git-courer", "commits.json")
 		data, err := os.ReadFile(filePath)
 		if err != nil {
 			t.Fatalf("ReadFile error: %v", err)
@@ -778,13 +778,13 @@ func TestFilesystemCommitStore_JSONFormatAndFallback(t *testing.T) {
 
 	t.Run("Fallback to reading legacy JSONL", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		store := NewFilesystemCommitStore(tmpDir)
+		store := NewFilesystemCommitStore(tmpDir, nil)
 
 		// Create legacy JSONL content manually
 		legacyContent := `{"sha":"a100000000000000000000000000000000000000","message":"feat: legacy first","author":"Alice","date":""}
 {"sha":"b200000000000000000000000000000000000000","message":"fix: legacy second","author":"Bob","date":""}`
 
-		filePath := filepath.Join(tmpDir, ".git-courer", "commits.json")
+		filePath := filepath.Join(tmpDir, ".git/git-courer", "commits.json")
 		if err := os.MkdirAll(filepath.Dir(filePath), 0o755); err != nil {
 			t.Fatalf("MkdirAll error: %v", err)
 		}
@@ -816,7 +816,7 @@ func TestFilesystemCommitStore_StackFieldsRoundTrip(t *testing.T) {
 
 	t.Run("entries with StackID and StackBranch round-trip correctly", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		store := NewFilesystemCommitStore(tmpDir)
+		store := NewFilesystemCommitStore(tmpDir, nil)
 
 		e1 := makeEntry(t, validSHA("a1000000000000000000000000000000000000"), "feat: first",
 			domain.WithAuthor("Alice"),
@@ -857,7 +857,7 @@ func TestFilesystemCommitStore_StackFieldsRoundTrip(t *testing.T) {
 
 	t.Run("entries without stack fields default to empty strings", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		store := NewFilesystemCommitStore(tmpDir)
+		store := NewFilesystemCommitStore(tmpDir, nil)
 
 		e1 := makeEntry(t, validSHA("c3000000000000000000000000000000000000"), "chore: no stack",
 			domain.WithAuthor("Bob"),
@@ -886,7 +886,7 @@ func TestFilesystemCommitStore_StackFieldsRoundTrip(t *testing.T) {
 	t.Run("old commits.json without stack fields loads as empty strings", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		// Manually write a JSON file that has no stack_id or stack_branch fields
-		dirPath := filepath.Join(tmpDir, ".git-courer")
+		dirPath := filepath.Join(tmpDir, ".git/git-courer")
 		if err := os.MkdirAll(dirPath, 0o755); err != nil {
 			t.Fatalf("MkdirAll() error: %v", err)
 		}
@@ -897,7 +897,7 @@ func TestFilesystemCommitStore_StackFieldsRoundTrip(t *testing.T) {
 			t.Fatalf("WriteFile() error: %v", err)
 		}
 
-		store := NewFilesystemCommitStore(tmpDir)
+		store := NewFilesystemCommitStore(tmpDir, nil)
 		entries, err := store.Read()
 		if err != nil {
 			t.Fatalf("Read() error: %v", err)
@@ -924,7 +924,7 @@ func TestFilesystemCommitStore_StackFieldsRoundTrip(t *testing.T) {
 
 	t.Run("reconcile preserves stack fields", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		store := NewFilesystemCommitStore(tmpDir)
+		store := NewFilesystemCommitStore(tmpDir, nil)
 
 		e1 := makeEntry(t, validSHA("d4000000000000000000000000000000000000"), "feat: stack entry",
 			domain.WithStackID("mergebaseSHA0000000000000000000000000000"),
@@ -957,7 +957,7 @@ func TestFilesystemCommitStore_ReadAllBranches_EmptyDir(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	result, err := store.ReadAllBranches()
 	if err != nil {
@@ -972,7 +972,7 @@ func TestFilesystemCommitStore_ReadAllBranches_SingleBranch(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	if err := store.SetBranch("main"); err != nil {
 		t.Fatalf("SetBranch() error: %v", err)
@@ -1006,7 +1006,7 @@ func TestFilesystemCommitStore_ReadAllBranches_MultipleBranches_Dedup(t *testing
 	tmpDir := t.TempDir()
 
 	// Create two branch stores with entries, one SHA shared
-	storeA := NewFilesystemCommitStore(tmpDir)
+	storeA := NewFilesystemCommitStore(tmpDir, nil)
 	if err := storeA.SetBranch("feature-a"); err != nil {
 		t.Fatalf("SetBranch(feature-a) error: %v", err)
 	}
@@ -1015,7 +1015,7 @@ func TestFilesystemCommitStore_ReadAllBranches_MultipleBranches_Dedup(t *testing
 	eA2 := makeEntry(t, validSHA("a2000000000000000000000000000000000000"), "feat: feature-a only")
 	storeA.Append(eA1, eA2)
 
-	storeB := NewFilesystemCommitStore(tmpDir)
+	storeB := NewFilesystemCommitStore(tmpDir, nil)
 	if err := storeB.SetBranch("feature-b"); err != nil {
 		t.Fatalf("SetBranch(feature-b) error: %v", err)
 	}
@@ -1024,7 +1024,7 @@ func TestFilesystemCommitStore_ReadAllBranches_MultipleBranches_Dedup(t *testing
 	storeB.Append(eB1, eB2)
 
 	// Now read from a fresh store (to ensure path is not set to a particular branch)
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 	result, err := store.ReadAllBranches()
 	if err != nil {
 		t.Fatalf("ReadAllBranches() error: %v", err)
@@ -1055,10 +1055,10 @@ func TestFilesystemCommitStore_ReadAllBranches_CorruptBranchDir(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	baseDir := filepath.Join(tmpDir, ".git-courer", "branches")
+	baseDir := filepath.Join(tmpDir, ".git/git-courer", "branches")
 
 	// Create a valid branch
-	storeValid := NewFilesystemCommitStore(tmpDir)
+	storeValid := NewFilesystemCommitStore(tmpDir, nil)
 	if err := storeValid.SetBranch("valid-branch"); err != nil {
 		t.Fatalf("SetBranch() error: %v", err)
 	}
@@ -1074,7 +1074,7 @@ func TestFilesystemCommitStore_ReadAllBranches_CorruptBranchDir(t *testing.T) {
 		t.Fatalf("WriteFile() error: %v", err)
 	}
 
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 	result, err := store.ReadAllBranches()
 	if err != nil {
 		t.Fatalf("ReadAllBranches() with corrupt branch should not error: %v", err)
@@ -1105,19 +1105,19 @@ func TestFilesystemCommitStore_RemoveAllBranchDirs_RemovesDir(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	// Create some branch directories
-	storeA := NewFilesystemCommitStore(tmpDir)
+	storeA := NewFilesystemCommitStore(tmpDir, nil)
 	storeA.SetBranch("feature-a")
 	storeA.Append(makeEntry(t, validSHA("aa000000000000000000000000000000000000"), "feat: a"))
 
-	storeB := NewFilesystemCommitStore(tmpDir)
+	storeB := NewFilesystemCommitStore(tmpDir, nil)
 	storeB.SetBranch("feature-b")
 	storeB.Append(makeEntry(t, validSHA("bb000000000000000000000000000000000000"), "feat: b"))
 
 	// Verify branches directory exists
-	branchesDir := filepath.Join(tmpDir, ".git-courer", "branches")
+	branchesDir := filepath.Join(tmpDir, ".git/git-courer", "branches")
 	if _, err := os.Stat(branchesDir); os.IsNotExist(err) {
 		t.Fatalf("branches directory should exist before RemoveAllBranchDirs")
 	}
@@ -1137,7 +1137,7 @@ func TestFilesystemCommitStore_RemoveAllBranchDirs_Idempotent(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir)
+	store := NewFilesystemCommitStore(tmpDir, nil)
 
 	// Calling RemoveAllBranchDirs on a non-existent directory should not error
 	err := store.RemoveAllBranchDirs()

--- a/internal/adapters/commitstore/reconcile_test.go
+++ b/internal/adapters/commitstore/reconcile_test.go
@@ -13,7 +13,7 @@ func TestFilesystemCommitStore_Reconcile(t *testing.T) {
 
 	t.Run("Reconcile empty store with empty git log is no-op", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		store := NewFilesystemCommitStore(tmpDir)
+		store := NewFilesystemCommitStore(tmpDir, nil)
 
 		err := store.Reconcile([]domain.CommitEntry{})
 		if err != nil {
@@ -21,7 +21,7 @@ func TestFilesystemCommitStore_Reconcile(t *testing.T) {
 		}
 
 		// Verify no file was created
-		filePath := filepath.Join(tmpDir, ".git-courer", "commits.json")
+		filePath := filepath.Join(tmpDir, ".git/git-courer", "commits.json")
 		if _, err := os.Stat(filePath); !os.IsNotExist(err) {
 			t.Errorf("expected no file to be created for empty reconcile, but it exists")
 		}
@@ -29,7 +29,7 @@ func TestFilesystemCommitStore_Reconcile(t *testing.T) {
 
 	t.Run("Reconcile add missing entries to empty store", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		store := NewFilesystemCommitStore(tmpDir)
+		store := NewFilesystemCommitStore(tmpDir, nil)
 
 		gitEntries := []domain.CommitEntry{
 			makeEntry(t, validSHA("1111"), "feat: add user auth"),
@@ -56,7 +56,7 @@ func TestFilesystemCommitStore_Reconcile(t *testing.T) {
 
 	t.Run("Reconcile delete stale entries and keep matching ones", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		store := NewFilesystemCommitStore(tmpDir)
+		store := NewFilesystemCommitStore(tmpDir, nil)
 
 		e1 := makeEntry(t, validSHA("1111"), "feat: add user auth")
 		e2 := makeEntry(t, validSHA("2222"), "fix: session timeout")
@@ -88,7 +88,7 @@ func TestFilesystemCommitStore_Reconcile(t *testing.T) {
 
 	t.Run("Reconcile update modified entries", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		store := NewFilesystemCommitStore(tmpDir)
+		store := NewFilesystemCommitStore(tmpDir, nil)
 
 		e1 := makeEntry(t, validSHA("1111"), "feat: add user auth")
 		if err := store.Append(e1); err != nil {
@@ -115,7 +115,7 @@ func TestFilesystemCommitStore_Reconcile(t *testing.T) {
 
 	t.Run("Reconcile skips write if contents are identical", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		store := NewFilesystemCommitStore(tmpDir)
+		store := NewFilesystemCommitStore(tmpDir, nil)
 
 		e1 := makeEntry(t, validSHA("1111"), "feat: add user auth")
 		e2 := makeEntry(t, validSHA("2222"), "fix: session timeout")
@@ -123,7 +123,7 @@ func TestFilesystemCommitStore_Reconcile(t *testing.T) {
 			t.Fatalf("Append error: %v", err)
 		}
 
-		filePath := filepath.Join(tmpDir, ".git-courer", "commits.json")
+		filePath := filepath.Join(tmpDir, ".git/git-courer", "commits.json")
 
 		// Change file permissions to 0400 (read-only)
 		if err := os.Chmod(filePath, 0400); err != nil {

--- a/internal/adapters/commitstore/sanitize.go
+++ b/internal/adapters/commitstore/sanitize.go
@@ -1,5 +1,5 @@
 // Package commitstore provides a filesystem-backed CommitStore adapter
-// that persists commit entries as JSONL in .git-courer/commits.json.
+// that persists commit entries as JSONL in .git/git-courer/commits.json.
 package commitstore
 
 import "strings"

--- a/internal/adapters/git/exec.go
+++ b/internal/adapters/git/exec.go
@@ -47,6 +47,30 @@ func findGitRoot(dir string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+func (a *ExecAdapter) runGitWithStdin(args []string, stdinData string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = a.workDir
+	cmd.Env = append(os.Environ(), "LC_ALL=C")
+	cmd.Stdin = strings.NewReader(stdinData)
+	out, err := cmd.Output()
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("git command timed out after 300s")
+		}
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			stderr := string(exitErr.Stderr)
+			if stderr == "" {
+				return "", fmt.Errorf("git error (empty stderr). Command: git %v. Stdout: %s", args, string(out))
+			}
+			return "", fmt.Errorf("git error: %s", stderr)
+		}
+		return "", fmt.Errorf("git error: %w", err)
+	}
+	return string(out), nil
+}
+
 func (a *ExecAdapter) runGit(args ...string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
 	defer cancel()

--- a/internal/adapters/git/exec_read_advanced.go
+++ b/internal/adapters/git/exec_read_advanced.go
@@ -207,7 +207,7 @@ func (a *ExecAdapter) CatFile(revision, path string) (string, error) {
 		revision = "HEAD"
 	}
 	if path == "" {
-		return "", fmt.Errorf("path is required for CatFile")
+		return a.runGit("show", revision)
 	}
 	ref := revision + ":" + path
 	return a.runGit("show", ref)

--- a/internal/adapters/git/exec_read_info.go
+++ b/internal/adapters/git/exec_read_info.go
@@ -155,3 +155,15 @@ func (a *ExecAdapter) SymbolicRef(ref string) (string, error) {
 	}
 	return strings.TrimSpace(out), nil
 }
+
+func (a *ExecAdapter) ShowRef(pattern string) (string, error) {
+	args := []string{"show-ref"}
+	if pattern != "" {
+		args = append(args, pattern)
+	}
+	out, err := a.runGit(args...)
+	if err != nil {
+		return "", nil
+	}
+	return strings.TrimSpace(out), nil
+}

--- a/internal/adapters/git/exec_write_commit.go
+++ b/internal/adapters/git/exec_write_commit.go
@@ -123,6 +123,10 @@ func (a *ExecAdapter) CommitTree(treeHash, parentHash, message string) (string, 
 }
 
 func (a *ExecAdapter) UpdateRef(ref, commitHash string) (string, error) {
+	if commitHash == "" {
+		_, err := a.runGit("update-ref", "-d", ref)
+		return "", err
+	}
 	_, err := a.runGit("update-ref", ref, commitHash)
 	return "", err
 }

--- a/internal/adapters/git/exec_write_commit.go
+++ b/internal/adapters/git/exec_write_commit.go
@@ -134,3 +134,11 @@ func (a *ExecAdapter) Head() (string, error) {
 	}
 	return strings.TrimSpace(out), nil
 }
+
+func (a *ExecAdapter) HashObject(data []byte) (string, error) {
+	out, err := a.runGitWithStdin([]string{"hash-object", "--stdin", "-w"}, string(data))
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -47,7 +47,7 @@ func LoadProjectConfig(workDir string) (*ProjectConfig, error) {
 	return cfg, nil
 }
 
-// SaveProjectConfig writes .git-courer/config.json to the given working directory.
+// SaveProjectConfig writes the project config to .git/git-courer/config.json.
 // It performs a load-merge-write cycle to preserve unknown fields:
 // 1. Read existing file (if any) as a raw map
 // 2. Merge the structured fields from cfg into the map

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/blak0p/git-courer/internal/core/domain"
 )
 
-// ProjectConfig holds per-project settings stored in .git-courer/config.json.
+// ProjectConfig holds per-project settings stored in .git/git-courer/config.json.
 // These values are committable and shared by the team.
 // Legacy configs may contain "areas" field — it is silently ignored on load and not written on save.
 type ProjectConfig struct {
@@ -20,10 +22,10 @@ type ProjectConfig struct {
 	Excluded    []string            `json:"excluded,omitempty"`
 }
 
-// LoadProjectConfig reads .git-courer/config.json from the given working directory.
+// LoadProjectConfig reads .git/git-courer/config.json from the given working directory.
 // Returns an error if the config file does not exist.
 func LoadProjectConfig(workDir string) (*ProjectConfig, error) {
-	configPath := filepath.Join(workDir, ".git-courer", "config.json")
+	configPath := filepath.Join(workDir, domain.MetadataDir, "config.json")
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -51,9 +53,9 @@ func LoadProjectConfig(workDir string) (*ProjectConfig, error) {
 // 2. Merge the structured fields from cfg into the map
 // 3. Write back with json.MarshalIndent
 func SaveProjectConfig(workDir string, cfg *ProjectConfig) error {
-	gitcourerDir := filepath.Join(workDir, ".git-courer")
+	gitcourerDir := filepath.Join(workDir, domain.MetadataDir)
 	if err := os.MkdirAll(gitcourerDir, 0755); err != nil {
-		return fmt.Errorf("failed to create .git-courer dir: %w", err)
+		return fmt.Errorf("failed to create .git/git-courer dir: %w", err)
 	}
 
 	configPath := filepath.Join(gitcourerDir, "config.json")

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/blak0p/git-courer/internal/core/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -15,7 +16,7 @@ import (
 // Legacy configs with "areas" field load without error.
 func TestProjectConfig_LoadExisting(t *testing.T) {
 	tmpDir := t.TempDir()
-	gitcourerDir := filepath.Join(tmpDir, ".git-courer")
+	gitcourerDir := filepath.Join(tmpDir, domain.MetadataDir)
 	require.NoError(t, os.MkdirAll(gitcourerDir, 0755))
 
 	existing := map[string]interface{}{
@@ -38,7 +39,7 @@ func TestProjectConfig_LoadExisting(t *testing.T) {
 // TestProjectConfig_LoadWithTestCommand verifies loading config with test_command set.
 func TestProjectConfig_LoadWithTestCommand(t *testing.T) {
 	tmpDir := t.TempDir()
-	gitcourerDir := filepath.Join(tmpDir, ".git-courer")
+	gitcourerDir := filepath.Join(tmpDir, domain.MetadataDir)
 	require.NoError(t, os.MkdirAll(gitcourerDir, 0755))
 
 	existing := map[string]interface{}{
@@ -77,7 +78,7 @@ func TestProjectConfig_SaveNew(t *testing.T) {
 // Legacy "areas" field in file is ignored on load and not written on save.
 func TestProjectConfig_SavePreservesExistingFields(t *testing.T) {
 	tmpDir := t.TempDir()
-	gitcourerDir := filepath.Join(tmpDir, ".git-courer")
+	gitcourerDir := filepath.Join(tmpDir, domain.MetadataDir)
 	require.NoError(t, os.MkdirAll(gitcourerDir, 0755))
 
 	existing := map[string]interface{}{
@@ -107,9 +108,9 @@ func TestProjectConfig_SavePreservesExistingFields(t *testing.T) {
 	// Legacy "areas" is not loaded into struct
 }
 
-// TestProjectConfig_LoadNonExistent returns an error when .git-courer/config.json doesn't exist.
+// TestProjectConfig_LoadNonExistent returns an error when .git/git-courer/config.json doesn't exist.
 func TestProjectConfig_LoadNonExistent(t *testing.T) {
-	tmpDir := t.TempDir() // no .git-courer directory
+	tmpDir := t.TempDir() // no .git/git-courer directory
 
 	_, err := LoadProjectConfig(tmpDir)
 	assert.Error(t, err)
@@ -120,7 +121,7 @@ func TestProjectConfig_LoadNonExistent(t *testing.T) {
 // load without error — the field is silently ignored.
 func TestProjectConfig_LoadLegacyAreas(t *testing.T) {
 	tmpDir := t.TempDir()
-	gitcourerDir := filepath.Join(tmpDir, ".git-courer")
+	gitcourerDir := filepath.Join(tmpDir, domain.MetadataDir)
 	require.NoError(t, os.MkdirAll(gitcourerDir, 0755))
 
 	existing := map[string]interface{}{
@@ -143,7 +144,7 @@ func TestProjectConfig_LoadLegacyAreas(t *testing.T) {
 // are preserved across a load-save cycle.
 func TestProjectConfig_SaveRoundTripUnknownFields(t *testing.T) {
 	tmpDir := t.TempDir()
-	gitcourerDir := filepath.Join(tmpDir, ".git-courer")
+	gitcourerDir := filepath.Join(tmpDir, domain.MetadataDir)
 	require.NoError(t, os.MkdirAll(gitcourerDir, 0755))
 
 	// Write config with an unknown field
@@ -172,7 +173,7 @@ func TestProjectConfig_SaveRoundTripUnknownFields(t *testing.T) {
 
 func TestProjectConfig_LoadExcluded(t *testing.T) {
 	tmpDir := t.TempDir()
-	gitcourerDir := filepath.Join(tmpDir, ".git-courer")
+	gitcourerDir := filepath.Join(tmpDir, domain.MetadataDir)
 	require.NoError(t, os.MkdirAll(gitcourerDir, 0755))
 
 	existing := map[string]interface{}{
@@ -191,7 +192,7 @@ func TestProjectConfig_LoadExcluded(t *testing.T) {
 
 func TestProjectConfig_LoadExcludedNil(t *testing.T) {
 	tmpDir := t.TempDir()
-	gitcourerDir := filepath.Join(tmpDir, ".git-courer")
+	gitcourerDir := filepath.Join(tmpDir, domain.MetadataDir)
 	require.NoError(t, os.MkdirAll(gitcourerDir, 0755))
 
 	existing := map[string]interface{}{
@@ -226,7 +227,7 @@ func TestProjectConfig_SaveExcluded(t *testing.T) {
 
 func TestProjectConfig_SaveExcludedPreservesUnknownFields(t *testing.T) {
 	tmpDir := t.TempDir()
-	gitcourerDir := filepath.Join(tmpDir, ".git-courer")
+	gitcourerDir := filepath.Join(tmpDir, domain.MetadataDir)
 	require.NoError(t, os.MkdirAll(gitcourerDir, 0755))
 
 	content := `{

--- a/internal/core/domain/metadata.go
+++ b/internal/core/domain/metadata.go
@@ -5,7 +5,7 @@ import (
 )
 
 // MetadataDir defines the location of git-courer metadata files.
-const MetadataDir = ".git-courer"
+const MetadataDir = ".git/git-courer"
 
 // IsMetadataPath returns true if the given path is the metadata directory or located within it.
 func IsMetadataPath(path string) bool {

--- a/internal/core/domain/metadata_test.go
+++ b/internal/core/domain/metadata_test.go
@@ -11,13 +11,14 @@ func TestIsMetadataPath(t *testing.T) {
 		path string
 		want bool
 	}{
-		{".git-courer", true},
-		{".git-courer/", true},
-		{".git-courer/config.json", true},
-		{".git-courer/branches/feat-add-pi/commits.json", true},
+		{".git/git-courer", true},
+		{".git/git-courer/", true},
+		{".git/git-courer/config.json", true},
+		{".git/git-courer/branches/feat-add-pi/commits.json", true},
 		{"internal/core/domain/metadata.go", false},
 		{"git-courer", false},
 		{"foo/.git-courer", false},
+		{"foo/.git/git-courer", false},
 		{"", false},
 	}
 
@@ -33,7 +34,7 @@ func TestIsMetadataPath(t *testing.T) {
 }
 
 func TestMetadataDirConstant(t *testing.T) {
-	if MetadataDir != ".git-courer" {
-		t.Errorf("MetadataDir = %q; want %q", MetadataDir, ".git-courer")
+	if MetadataDir != ".git/git-courer" {
+		t.Errorf("MetadataDir = %q; want %q", MetadataDir, ".git/git-courer")
 	}
 }

--- a/internal/core/domain/project_config.go
+++ b/internal/core/domain/project_config.go
@@ -39,7 +39,7 @@ type ProjectConfig struct {
 // If the config file does not exist, it returns an empty config.
 // Legacy configs with "areas" field load successfully — the field is ignored.
 func LoadProjectConfig(repoRoot string) (*ProjectConfig, error) {
-	path := filepath.Join(repoRoot, ".git-courer", "config.json")
+	path := filepath.Join(repoRoot, MetadataDir, "config.json")
 
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return &ProjectConfig{}, nil
@@ -65,7 +65,7 @@ func LoadProjectConfig(repoRoot string) (*ProjectConfig, error) {
 
 // Save writes the project configuration to disk.
 func (c *ProjectConfig) Save(repoRoot string) error {
-	dir := filepath.Join(repoRoot, ".git-courer")
+	dir := filepath.Join(repoRoot, MetadataDir)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("mkdir %s: %w", dir, err)
 	}

--- a/internal/core/domain/project_config_test.go
+++ b/internal/core/domain/project_config_test.go
@@ -51,7 +51,7 @@ func TestProjectConfig_MissingConfig(t *testing.T) {
 func TestProjectConfig_MalformedJSON(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
-	repoDir := filepath.Join(tmpDir, ".git-courer")
+	repoDir := filepath.Join(tmpDir, MetadataDir)
 	if err := os.MkdirAll(repoDir, 0755); err != nil {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}
@@ -276,7 +276,7 @@ func TestProjectConfig_BaseBranch_RoundTrip(t *testing.T) {
 func TestProjectConfig_BaseBranch_DefaultEmpty(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
-	repoDir := filepath.Join(tmpDir, ".git-courer")
+	repoDir := filepath.Join(tmpDir, MetadataDir)
 	if err := os.MkdirAll(repoDir, 0755); err != nil {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}

--- a/internal/core/ports/commit_store.go
+++ b/internal/core/ports/commit_store.go
@@ -10,10 +10,10 @@ import "github.com/blak0p/git-courer/internal/core/domain"
 //
 // SetBranch switches the store to a branch-scoped path:
 //
-//	.git-courer/branches/<sanitized>/commits.json
+//	.git/git-courer/branches/<sanitized>/commits.json
 //
 // If SetBranch is never called, the store uses the legacy global
-// path .git-courer/commits.json.
+// path .git/git-courer/commits.json.
 //
 // RemoveBranch deletes the branch's store directory and all contents.
 type CommitStore interface {
@@ -29,14 +29,14 @@ type CommitStore interface {
 	Clear() error
 
 	// SetBranch switches the store to read/write from a branch-scoped path:
-	//   .git-courer/branches/<sanitized>/commits.json
+	//   .git/git-courer/branches/<sanitized>/commits.json
 	// If name is empty, returns an error.
 	// After calling SetBranch, Append/Read/Clear operate on the branch path.
 	// Thread-safe: serialized by the adapter's mutex.
 	SetBranch(name string) error
 
 	// RemoveBranch removes the branch's store directory and all contents:
-	//   .git-courer/branches/<sanitized>/
+	//   .git/git-courer/branches/<sanitized>/
 	// If the directory does not exist, returns nil (idempotent).
 	// If name is empty, returns an error.
 	// Thread-safe: serialized by the adapter's mutex.
@@ -54,7 +54,7 @@ type CommitStore interface {
 	// Returns an error only if scanning fails or the branch directory structure is corrupt.
 	ReadAllBranches() (map[string][]domain.CommitEntry, error)
 
-	// RemoveAllBranchDirs removes all branch directories under .git-courer/branches/.
+	// RemoveAllBranchDirs removes all branch directories under .git/git-courer/branches/.
 	// It is idempotent: if no directories exist, it returns nil.
 	// It removes the entire branches/ directory tree, not individual branch directories.
 	RemoveAllBranchDirs() error

--- a/internal/core/ports/git.go
+++ b/internal/core/ports/git.go
@@ -114,4 +114,11 @@ type Git interface {
 	CommitTree(treeHash, parentHash, message string) (string, error)
 	UpdateRef(ref, commitHash string) (string, error)
 	Head() (string, error)
+
+	// HashObject writes data as a Git blob and returns the blob SHA.
+	HashObject(data []byte) (string, error)
+
+	// ShowRef lists refs matching the given pattern.
+	// Empty pattern lists all refs.
+	ShowRef(pattern string) (string, error)
 }

--- a/internal/delivery/cli/release_test.go
+++ b/internal/delivery/cli/release_test.go
@@ -488,7 +488,7 @@ func TestReleaseCommand_Apply_ClearsBranchStore(t *testing.T) {
 	// AC-2.5: After `gcourer release apply` on `feat/auth`,
 	// `.git-courer/branches/feat-auth/commits.json` is empty.
 	dir := t.TempDir()
-	store := commitstore.NewFilesystemCommitStore(dir)
+	store := commitstore.NewFilesystemCommitStore(dir, nil)
 	store.SetBranch("feat/auth")
 
 	// Write some entries
@@ -526,10 +526,10 @@ func TestReleaseCommand_ReleaseOnBranchDoesNotClearOtherBranch(t *testing.T) {
 	dir := t.TempDir()
 
 	// Create two branch stores
-	featStore := commitstore.NewFilesystemCommitStore(dir)
+	featStore := commitstore.NewFilesystemCommitStore(dir, nil)
 	featStore.SetBranch("feat/auth")
 
-	mainStore := commitstore.NewFilesystemCommitStore(dir)
+	mainStore := commitstore.NewFilesystemCommitStore(dir, nil)
 	mainStore.SetBranch("main")
 
 	// Write entries on feat/auth
@@ -577,7 +577,7 @@ func TestReleaseCommand_BranchStoreAfterSetBranchAndAppend(t *testing.T) {
 	// This test verifies the store path resolution.
 	dir := t.TempDir()
 
-	store := commitstore.NewFilesystemCommitStore(dir)
+	store := commitstore.NewFilesystemCommitStore(dir, nil)
 	store.SetBranch("feat/auth")
 
 	// Append and verify

--- a/internal/delivery/mcp/branching/mock_test.go
+++ b/internal/delivery/mcp/branching/mock_test.go
@@ -258,3 +258,11 @@ func (m *MockGit) Head() (string, error) {
 	args := m.Called()
 	return args.String(0), args.Error(1)
 }
+func (m *MockGit) HashObject(data []byte) (string, error) {
+	args := m.Called(data)
+	return args.String(0), args.Error(1)
+}
+func (m *MockGit) ShowRef(pattern string) (string, error) {
+	args := m.Called(pattern)
+	return args.String(0), args.Error(1)
+}

--- a/internal/delivery/mcp/core/commit_handler.go
+++ b/internal/delivery/mcp/core/commit_handler.go
@@ -410,7 +410,7 @@ func (h *Handler) handlePreview(ctx context.Context, params map[string]any, why 
 
 	// 3. Stage metadata before WriteTree
 	if err := h.git.Add([]string{domain.MetadataDir}); err != nil {
-		// Log but do not block — if .git-courer doesn	 exist, we don	 fail
+		// Log but do not block — if metadata dir doesn't exist, we don't fail
 		log.Printf("[DEBUG] Failed to stage metadata directory: %v", err)
 	}
 
@@ -702,10 +702,10 @@ func (h *Handler) applyPlumbing(ctx context.Context, jobID string, pushAfter boo
 	// Pass stack metadata from PREVIEW to preserve grouping information
 	h.commitSvc.CaptureCommit(message, job.StackID, job.StackBranch)
 
-	// Bug 3: Plumbing amend — stage .git-courer/, write new tree, create replacement commit, update HEAD
+	// Plumbing amend — stage metadata dir, write new tree, create replacement commit, update HEAD
 	// This ensures the pushed commit includes the latest metadata entry
 	if err := h.git.Add([]string{domain.MetadataDir}); err != nil {
-		log.Printf("[WARN] applyPlumbing: failed to stage .git-courer/: %v", err)
+		log.Printf("[WARN] applyPlumbing: failed to stage metadata dir: %v", err)
 	} else {
 		// Write a new tree that includes the staged metadata
 		newTreeHash, treeErr := h.git.WriteTree()

--- a/internal/delivery/mcp/core/handler_test.go
+++ b/internal/delivery/mcp/core/handler_test.go
@@ -200,6 +200,14 @@ func (m *mockGit) Head() (string, error) {
 	args := m.Called()
 	return args.String(0), args.Error(1)
 }
+func (m *mockGit) HashObject(data []byte) (string, error) {
+	args := m.Called(data)
+	return args.String(0), args.Error(1)
+}
+func (m *mockGit) ShowRef(pattern string) (string, error) {
+	args := m.Called(pattern)
+	return args.String(0), args.Error(1)
+}
 
 var _ ports.Git = (*mockGit)(nil)
 

--- a/internal/delivery/mcp/handlers.go
+++ b/internal/delivery/mcp/handlers.go
@@ -122,7 +122,7 @@ func registerTools(s *server.MCPServer, srv *Server) {
 	)
 
 	// workDir: git-courer operates in the current working directory;
-	// .git-courer/config.json is loaded from the CWD.
+	// .git/git-courer/config.json is loaded from the CWD.
 	workDir := "."
 	utilityHandler := utility.NewHandler(srv.git, srv.cfg, workDir, srv.mcpServer)
 	utility.Register(s, utilityHandler)

--- a/internal/delivery/mcp/mock_test.go
+++ b/internal/delivery/mcp/mock_test.go
@@ -465,3 +465,13 @@ func (m *MockGit) Head() (string, error) {
 	args := m.Called()
 	return args.String(0), args.Error(1)
 }
+
+func (m *MockGit) HashObject(data []byte) (string, error) {
+	args := m.Called(data)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockGit) ShowRef(pattern string) (string, error) {
+	args := m.Called(pattern)
+	return args.String(0), args.Error(1)
+}

--- a/internal/delivery/mcp/prreview/handler.go
+++ b/internal/delivery/mcp/prreview/handler.go
@@ -131,7 +131,7 @@ func (h *Handler) HandlePRReview(ctx context.Context, req mcpgo.CallToolRequest)
 	return mcpgo.NewToolResultText(shared.MustJSON(result)), nil
 }
 
-// loadTestCommand reads the test_command from .git-courer/config.json.
+// loadTestCommand reads the test_command from .git/git-courer/config.json.
 // Returns empty string if the project config doesn't exist or has no test_command.
 func (h *Handler) loadTestCommand() string {
 	cfg, err := config.LoadProjectConfig(h.workDir)

--- a/internal/delivery/mcp/prreview/handler_test.go
+++ b/internal/delivery/mcp/prreview/handler_test.go
@@ -143,6 +143,8 @@ func (m *mockGit) CommitTree(treeHash, parentHash, message string) (string, erro
 }
 func (m *mockGit) UpdateRef(ref, commitHash string) (string, error) { panic("not implemented") }
 func (m *mockGit) Head() (string, error)                            { panic("not implemented") }
+func (m *mockGit) HashObject(data []byte) (string, error)          { return "mock-blob-sha", nil }
+func (m *mockGit) ShowRef(pattern string) (string, error)         { return "", nil }
 
 func newTestHandler(git *mockGit, workDir string, testRunner func(ctx context.Context, command string) TestResult) *Handler {
 	chunker := chunkers.NewDiffChunker(

--- a/internal/delivery/mcp/server.go
+++ b/internal/delivery/mcp/server.go
@@ -110,7 +110,7 @@ func New(cfg *config.Config, git ports.Git, llm ports.LLM, lifecycle ports.Lifec
 	releaseCfg.ReleaseType = cfg.Release.Type
 
 	// Create specialized services.
-	commitStore := commitstore.NewFilesystemCommitStore(".")
+	commitStore := commitstore.NewFilesystemCommitStore(".", git)
 	// Branch-scope the store: if on a real branch, write to per-branch path.
 	// Detached HEAD (empty branch) falls back to the legacy global path.
 	if git != nil {

--- a/internal/delivery/mcp/stage/handler_test.go
+++ b/internal/delivery/mcp/stage/handler_test.go
@@ -199,6 +199,8 @@ func (m *mockGitForStage) CommitTree(treeHash, parentHash, message string) (stri
 }
 func (m *mockGitForStage) UpdateRef(ref, commitHash string) (string, error) { panic("not implemented") }
 func (m *mockGitForStage) Head() (string, error)                            { panic("not implemented") }
+func (m *mockGitForStage) HashObject(data []byte) (string, error)          { return "mock-blob-sha", nil }
+func (m *mockGitForStage) ShowRef(pattern string) (string, error)         { return "", nil }
 func (m *mockGitForStage) Version() (string, error)                         { panic("not implemented") }
 func (m *mockGitForStage) WorkDir() string                                  { panic("not implemented") }
 func (m *mockGitForStage) WithWorkDir(dir string) interface {

--- a/internal/delivery/mcp/sync/mock_test.go
+++ b/internal/delivery/mcp/sync/mock_test.go
@@ -64,7 +64,10 @@ func (m *MockGit) DiffRange(base, target, mode string, paths ...string) (string,
 func (m *MockGit) ListUntracked() ([]string, error)                               { return nil, nil }
 func (m *MockGit) Log(limit int, pattern string, paths ...string) (string, error) { return "", nil }
 func (m *MockGit) LogFull(limit int) (string, error)                              { return "", nil }
-func (m *MockGit) CurrentBranch() (string, error)                                 { return "", nil }
+func (m *MockGit) CurrentBranch() (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
 func (m *MockGit) ListBranches(pattern ...string) (string, error)                 { return "", nil }
 func (m *MockGit) ListTags(pattern ...string) ([]string, error)                   { return nil, nil }
 func (m *MockGit) IsRepo() bool                                                   { return true }

--- a/internal/delivery/mcp/sync/mock_test.go
+++ b/internal/delivery/mcp/sync/mock_test.go
@@ -159,3 +159,11 @@ func (m *MockGit) Head() (string, error) {
 	args := m.Called()
 	return args.String(0), args.Error(1)
 }
+func (m *MockGit) HashObject(data []byte) (string, error) {
+	args := m.Called(data)
+	return args.String(0), args.Error(1)
+}
+func (m *MockGit) ShowRef(pattern string) (string, error) {
+	args := m.Called(pattern)
+	return args.String(0), args.Error(1)
+}

--- a/internal/delivery/mcp/sync/sync.go
+++ b/internal/delivery/mcp/sync/sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/blak0p/git-courer/internal/core/domain"
@@ -83,7 +84,16 @@ func (h *Handler) HandleSync(_ context.Context, req mcpgo.CallToolRequest) (*mcp
 		} else {
 			_, err = h.git.PushTo(remote)
 		}
+		if err == nil {
+			// Non-blocking: push refs/courer/<branch> as sidecar
+			if refBranch := branch; refBranch != "" {
+				if _, refErr := h.git.PushToBranch("origin", "refs/courer/"+refBranch); refErr != nil {
+					log.Printf("[WARN] sync: failed to push refs/courer/%s: %v", refBranch, refErr)
+				}
+			}
+		}
 		result = shared.WriteResultJSON("PUSH", err == nil, "Pushed to "+remote+" — changes are now on remote. Remember: call pr-review before creating a PR.")
+		// branch=="" means no ref push sidecar; do not call CurrentBranch
 	case "AUTO":
 		var outputs []string
 		// 1. Fetch
@@ -105,14 +115,26 @@ func (h *Handler) HandleSync(_ context.Context, req mcpgo.CallToolRequest) (*mcp
 			outputs = append(outputs, pOut)
 		}
 		// 3. Push
+		var pushedBranch string
 		if uOut, uErr := h.git.Push(); uErr != nil {
 			if strings.Contains(uErr.Error(), "NO_UPSTREAM") {
 				outputs = append(outputs, "[INFO] No upstream to push to")
 			} else {
-				return shared.JSONErrorResult("AUTO_PUSH", uErr)
+				return shared.JSONErrorResult("AUTO_SYNC", uErr)
 			}
-		} else if uOut != "" {
-			outputs = append(outputs, uOut)
+		} else {
+			if uOut != "" {
+				outputs = append(outputs, uOut)
+			}
+			if currentBranch, branchErr := h.git.CurrentBranch(); branchErr == nil && currentBranch != "" {
+				pushedBranch = currentBranch
+			}
+		}
+		// Non-blocking: push refs/courer/<branch> as sidecar
+		if pushedBranch != "" {
+			if _, refErr := h.git.PushToBranch("origin", "refs/courer/"+pushedBranch); refErr != nil {
+				log.Printf("[WARN] sync: failed to push refs/courer/%s: %v", pushedBranch, refErr)
+			}
 		}
 		result = shared.WriteResultJSON("AUTO_SYNC", true, strings.Join(outputs, "\n"))
 	}

--- a/internal/delivery/mcp/sync/sync_test.go
+++ b/internal/delivery/mcp/sync/sync_test.go
@@ -65,7 +65,8 @@ func TestHandleSync_PushWithBranch(t *testing.T) {
 	gitMock := new(MockGit)
 	backup := domain.Backup{Ref: "ref", Operation: "PUSH"}
 	gitMock.On("CreateBackup", "PUSH", domain.StashNone).Return(backup, nil)
-	gitMock.On("PushToBranch", "origin", "feature").Return("pushed feature to origin", nil)
+	gitMock.On("PushToBranch", "origin", "feature").Return("pushed feature to origin", nil).Once()
+	gitMock.On("PushToBranch", "origin", "refs/courer/feature").Return("pushed ref", nil)
 
 	h := NewHandler(gitMock)
 

--- a/internal/delivery/mcp/utility/handler_test.go
+++ b/internal/delivery/mcp/utility/handler_test.go
@@ -168,8 +168,10 @@ func (m *mockGitForUtility) CommitTree(treeHash, parentHash, message string) (st
 func (m *mockGitForUtility) UpdateRef(ref, commitHash string) (string, error) {
 	panic("not implemented")
 }
-func (m *mockGitForUtility) Head() (string, error)    { panic("not implemented") }
-func (m *mockGitForUtility) Version() (string, error) { panic("not implemented") }
+func (m *mockGitForUtility) Head() (string, error)                    { panic("not implemented") }
+func (m *mockGitForUtility) HashObject(data []byte) (string, error)  { return "mock-blob-sha", nil }
+func (m *mockGitForUtility) ShowRef(pattern string) (string, error) { return "", nil }
+func (m *mockGitForUtility) Version() (string, error)                 { panic("not implemented") }
 func (m *mockGitForUtility) WorkDir() string          { panic("not implemented") }
 func (m *mockGitForUtility) WithWorkDir(dir string) interface {
 	Git() interface{}

--- a/internal/delivery/mcp/utility/handlers.go
+++ b/internal/delivery/mcp/utility/handlers.go
@@ -41,7 +41,7 @@ func (h *Handler) HandleConfig(_ context.Context, req mcpgo.CallToolRequest) (*m
 	case "SET_TEST_COMMAND":
 		testCmd := shared.GetStringParam(params, "test_command", "")
 
-		// Write to project-local config (.git-courer/config.json)
+		// Write to project-local config (.git/git-courer/config.json)
 		if err := h.writeProjectTestCommand(testCmd); err != nil {
 			return shared.JSONErrorResult("SET_TEST_COMMAND", fmt.Errorf("failed to save project config: %w", err))
 		}

--- a/internal/infra/chunkers/diff_test.go
+++ b/internal/infra/chunkers/diff_test.go
@@ -222,17 +222,17 @@ func TestDiffChunker_Chunk_FiltersMetadataFiles(t *testing.T) {
 	// Metadata files should be filtered out.
 	diff := `diff --git a/auth.go b/auth.go
 --- a/auth.go
-+++ b/auth.go
++++ a/auth.go
 @@ -1 +1,3 @@
 + func Auth() {}
-diff --git a/.git-courer/config.json b/.git-courer/config.json
---- a/.git-courer/config.json
-+++ b/.git-courer/config.json
+diff --git a/.git/git-courer/config.json b/.git/git-courer/config.json
+--- a/.git/git-courer/config.json
++++ b/.git/git-courer/config.json
 @@ -1 +1,3 @@
 + { "some": "config" }
-diff --git a/.git-courer/branches/main/commits.json b/.git-courer/branches/main/commits.json
---- a/.git-courer/branches/main/commits.json
-+++ b/.git-courer/branches/main/commits.json
+diff --git a/.git/git-courer/branches/main/commits.json b/.git/git-courer/branches/main/commits.json
+--- a/.git/git-courer/branches/main/commits.json
++++ b/.git/git-courer/branches/main/commits.json
 @@ -1 +1,3 @@
 + []`
 
@@ -245,7 +245,7 @@ diff --git a/.git-courer/branches/main/commits.json b/.git-courer/branches/main/
 		t.Errorf("Expected 1 chunk (code only), got %d", len(chunks))
 	} else {
 		for _, f := range chunks[0].Files {
-			if strings.HasPrefix(f, ".git-courer") {
+			if strings.HasPrefix(f, ".git/git-courer") {
 				t.Errorf("Metadata file %q should have been filtered out", f)
 			}
 		}
@@ -258,11 +258,11 @@ func TestDiffChunker_Chunk_FallbackFiltersMetadataFiles(t *testing.T) {
 	// Malformed diff to force fallback path
 	diff := `diff --git a/auth.go b/auth.go
 --- a/auth.go
-+++ b/auth.go
++++ a/auth.go
 + func Auth() {}
-diff --git a/.git-courer/config.json b/.git-courer/config.json
---- a/.git-courer/config.json
-+++ b/.git-courer/config.json
+diff --git a/.git/git-courer/config.json b/.git/git-courer/config.json
+--- a/.git/git-courer/config.json
++++ b/.git/git-courer/config.json
 + { "some": "config" }`
 
 	chunks, err := c.Chunk(diff, 4096)
@@ -274,7 +274,7 @@ diff --git a/.git-courer/config.json b/.git-courer/config.json
 		t.Errorf("Expected 1 chunk (code only), got %d", len(chunks))
 	} else {
 		for _, f := range chunks[0].Files {
-			if strings.HasPrefix(f, ".git-courer") {
+			if strings.HasPrefix(f, ".git/git-courer") {
 				t.Errorf("Fallback metadata file %q should have been filtered out", f)
 			}
 		}

--- a/internal/infra/classifier/classifier_test.go
+++ b/internal/infra/classifier/classifier_test.go
@@ -513,6 +513,8 @@ func (m *mockGit) WriteTree() (string, error)                                   
 func (m *mockGit) CommitTree(treeHash, parentHash, message string) (string, error) { return "", nil }
 func (m *mockGit) UpdateRef(ref, commitHash string) (string, error)                { return "", nil }
 func (m *mockGit) Head() (string, error)                                           { return "", nil }
+func (m *mockGit) HashObject(data []byte) (string, error)                          { return "mock-blob-sha", nil }
+func (m *mockGit) ShowRef(pattern string) (string, error)                           { return "", nil }
 
 // TestLearnFromHistory_confidence_boost verifies that after learning from a
 // history where "feat" is dominant, the classifier boosts confidence for

--- a/internal/workflow/commit.go
+++ b/internal/workflow/commit.go
@@ -175,7 +175,7 @@ type preparedState struct {
 }
 
 // stageMetadataFiles checks if there are any unstaged or untracked changes in the metadata directory
-// (.git-courer) and stages them automatically.
+// (.git/git-courer) and stages them automatically.
 func (s *CommitService) stageMetadataFiles() error {
 	status, err := s.git.Status()
 	if err != nil {

--- a/internal/workflow/commit_execute.go
+++ b/internal/workflow/commit_execute.go
@@ -77,6 +77,11 @@ func (s *CommitService) ExecuteFromPlan(messages []string, chunkFiles [][]string
 		if err != nil {
 			return "", fmt.Errorf("push failed: %w", err)
 		}
+		if currentBranch, branchErr := s.git.CurrentBranch(); branchErr == nil && currentBranch != "" {
+			if _, refErr := s.git.PushToBranch("origin", "refs/courer/"+currentBranch); refErr != nil {
+				log.Printf("[WARN] commit execute: failed to push refs/courer/%s: %v", currentBranch, refErr)
+			}
+		}
 	}
 
 	log.Printf("[DEBUG] ExecuteFromPlan: handling deleted files")
@@ -150,6 +155,11 @@ func (s *CommitService) executeSync(instruction string, chunks []domain.DiffChun
 		_, err := s.git.Push()
 		if err != nil {
 			return "", fmt.Errorf("push failed: %w", err)
+		}
+		if currentBranch, branchErr := s.git.CurrentBranch(); branchErr == nil && currentBranch != "" {
+			if _, refErr := s.git.PushToBranch("origin", "refs/courer/"+currentBranch); refErr != nil {
+				log.Printf("[WARN] commit execute: failed to push refs/courer/%s: %v", currentBranch, refErr)
+			}
 		}
 	}
 

--- a/internal/workflow/commit_service_test.go
+++ b/internal/workflow/commit_service_test.go
@@ -158,6 +158,8 @@ func (s *stubGit) WriteTree() (string, error)                                   
 func (s *stubGit) CommitTree(treeHash, parentHash, message string) (string, error) { return "", nil }
 func (s *stubGit) UpdateRef(ref, commitHash string) (string, error)                { return "", nil }
 func (s *stubGit) Head() (string, error)                                           { return "", nil }
+func (s *stubGit) HashObject(data []byte) (string, error)                          { return "mock-blob-sha", nil }
+func (s *stubGit) ShowRef(pattern string) (string, error)                           { return "", nil }
 func (s *stubGit) Reset(mode string, commit string) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/workflow/commit_test.go
+++ b/internal/workflow/commit_test.go
@@ -210,7 +210,7 @@ func TestPrepareStages_AutoStagesMetadata(t *testing.T) {
 			name: "unstaged_metadata_changes_are_staged",
 			files: []domain.FileStatus{
 				{Path: "a.go", Status: "M ", Staged: true},
-				{Path: ".git-courer/branches/some-branch/commits.json", Status: " M", Staged: false},
+				{Path: ".git/git-courer/branches/some-branch/commits.json", Status: " M", Staged: false},
 			},
 			expectStaged: true,
 		},
@@ -225,7 +225,7 @@ func TestPrepareStages_AutoStagesMetadata(t *testing.T) {
 			name: "already_staged_metadata_does_not_stage_again",
 			files: []domain.FileStatus{
 				{Path: "a.go", Status: "M ", Staged: true},
-				{Path: ".git-courer/branches/some-branch/commits.json", Status: "M ", Staged: true},
+				{Path: ".git/git-courer/branches/some-branch/commits.json", Status: "M ", Staged: true},
 			},
 			expectStaged: false,
 		},
@@ -261,18 +261,20 @@ func TestPrepareStages_AutoStagesMetadata(t *testing.T) {
 			defer git.mu.Unlock()
 			found := false
 			for _, call := range git.addCalls {
-				if len(call) == 1 && call[0] == ".git-courer" {
+				if len(call) == 1 && call[0] == domain.MetadataDir {
 					found = true
 					break
 				}
 			}
 
 			if tt.expectStaged && !found {
-				t.Errorf("expected metadata directory '.git-courer' to be staged, but it was not")
+				t.Errorf("expected metadata directory %q to be staged, but it was not", domain.MetadataDir)
 			}
 			if !tt.expectStaged && found {
-				t.Errorf("expected metadata directory '.git-courer' NOT to be staged, but it was")
+				t.Errorf("expected metadata directory %q NOT to be staged, but it was", domain.MetadataDir)
 			}
 		})
 	}
 }
+
+// TestMetadataDirUsedInAutoStaging verifies the metadata directory constant used in staging.

--- a/internal/workflow/prepare_test.go
+++ b/internal/workflow/prepare_test.go
@@ -145,6 +145,8 @@ func (s *stubGitForPrepare) CommitTree(treeHash, parentHash, message string) (st
 }
 func (s *stubGitForPrepare) UpdateRef(ref, commitHash string) (string, error) { return "", nil }
 func (s *stubGitForPrepare) Head() (string, error)                            { return "", nil }
+func (s *stubGitForPrepare) HashObject(data []byte) (string, error)         { return "mock-blob-sha", nil }
+func (s *stubGitForPrepare) ShowRef(pattern string) (string, error)          { return "", nil }
 
 // newWorkflowForPrepareTest builds a minimal Workflow with the given stub.
 func newWorkflowForPrepareTest(stub *stubGitForPrepare) *Workflow {

--- a/internal/workflow/release.go
+++ b/internal/workflow/release.go
@@ -136,6 +136,90 @@ func NewReleaseService(git ports.Git, llm ports.LLM, logChunker LogChunker, cfg 
 	}
 }
 
+// migrationEntry matches the legacy JSON serialization of CommitEntry for metadata migration.
+type migrationEntry struct {
+	SHA     string `json:"sha"`
+	Message string `json:"message"`
+	Author  string `json:"author"`
+	Date    string `json:"date"`
+}
+
+// migrateOldMetadata merges branch entries from oldDir into newDir, deduplicating by SHA.
+func migrateOldMetadata(oldDir, newDir string) error {
+	oldBranches, err := os.ReadDir(oldDir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range oldBranches {
+		if !entry.IsDir() {
+			continue
+		}
+		branchName := entry.Name()
+		oldPath := filepath.Join(oldDir, branchName, "commits.json")
+		newPath := filepath.Join(newDir, branchName, "commits.json")
+
+		oldData, oldErr := os.ReadFile(oldPath)
+		if oldErr != nil {
+			if os.IsNotExist(oldErr) {
+				continue
+			}
+			log.Printf("[WARN] migrate: cannot read %s: %v", oldPath, oldErr)
+			continue
+		}
+
+		var oldEntries []migrationEntry
+		if parseErr := json.Unmarshal(oldData, &oldEntries); parseErr != nil {
+			log.Printf("[WARN] migrate: cannot parse %s: %v", oldPath, parseErr)
+			continue
+		}
+
+		if mkErr := os.MkdirAll(filepath.Dir(newPath), 0o755); mkErr != nil {
+			log.Printf("[WARN] migrate: cannot create %s: %v", filepath.Dir(newPath), mkErr)
+			continue
+		}
+
+		newData, newErr := os.ReadFile(newPath)
+		if os.IsNotExist(newErr) {
+			if wErr := os.WriteFile(newPath, oldData, 0o644); wErr != nil {
+				log.Printf("[WARN] migrate: cannot write %s: %v", newPath, wErr)
+			}
+			continue
+		}
+		if newErr != nil {
+			log.Printf("[WARN] migrate: cannot read %s: %v", newPath, newErr)
+			continue
+		}
+
+		var newEntries []migrationEntry
+		if parseErr := json.Unmarshal(newData, &newEntries); parseErr != nil {
+			log.Printf("[WARN] migrate: cannot parse %s: %v", newPath, parseErr)
+			continue
+		}
+
+		seen := make(map[string]bool, len(newEntries))
+		for _, je := range newEntries {
+			seen[je.SHA] = true
+		}
+		for _, je := range oldEntries {
+			if !seen[je.SHA] {
+				newEntries = append(newEntries, je)
+				seen[je.SHA] = true
+			}
+		}
+
+		mergedData, marshalErr := json.MarshalIndent(newEntries, "", "  ")
+		if marshalErr != nil {
+			log.Printf("[WARN] migrate: cannot marshal %s: %v", branchName, marshalErr)
+			continue
+		}
+		mergedData = append(mergedData, '\n')
+		if wErr := os.WriteFile(newPath, mergedData, 0o644); wErr != nil {
+			log.Printf("[WARN] migrate: cannot write %s: %v", newPath, wErr)
+		}
+	}
+	return nil
+}
+
 func sanitizeBranchName(name string) string {
 	r := strings.ReplaceAll(name, "/", "-")
 	for _, ch := range []string{"~", "^", ":", "\\", " "} {
@@ -149,6 +233,79 @@ func sanitizeBranchName(name string) string {
 		return "HEAD"
 	}
 	return r
+}
+
+// commitsFromRefs reads commit entries from refs/courer/* blobs.
+// Returns empty string and nil error if no refs exist.
+func (s *ReleaseService) commitsFromRefs() (string, error) {
+	if s.git == nil {
+		return "", nil
+	}
+
+	if _, fetchErr := s.git.Fetch(); fetchErr != nil {
+		log.Printf("[WARN] release refs: fetch failed: %v", fetchErr)
+	}
+
+	refsRaw, err := s.git.ShowRef("refs/courer/*")
+	if err != nil {
+		return "", fmt.Errorf("show refs: %w", err)
+	}
+	if refsRaw == "" {
+		return "", nil
+	}
+
+	seen := make(map[string]bool)
+	var entries []domain.CommitEntry
+	for _, line := range strings.Split(strings.TrimSpace(refsRaw), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) < 2 {
+			continue
+		}
+		ref := parts[1]
+
+		blobContent, catErr := s.git.CatFile(ref, "")
+		if catErr != nil {
+			log.Printf("[WARN] release refs: cat-file %s failed: %v", ref, catErr)
+			continue
+		}
+		var jEntries []struct {
+			SHA     string `json:"sha"`
+			Message string `json:"message"`
+			Author  string `json:"author"`
+			Date    string `json:"date"`
+		}
+		if parseErr := json.Unmarshal([]byte(blobContent), &jEntries); parseErr != nil {
+			log.Printf("[WARN] release refs: parse blob %s failed: %v", ref, parseErr)
+			continue
+		}
+		for _, je := range jEntries {
+			if seen[je.SHA] {
+				continue
+			}
+			entry, newErr := domain.NewCommitEntry(je.SHA, je.Message,
+				domain.WithAuthor(je.Author),
+				domain.WithDate(je.Date),
+			)
+			if newErr != nil {
+				log.Printf("[WARN] release refs: invalid entry %s: %v", je.SHA, newErr)
+				continue
+			}
+			entries = append(entries, entry)
+			seen[je.SHA] = true
+		}
+	}
+
+	if len(entries) == 0 {
+		return "", nil
+	}
+
+	s.pendingEntries = entries
+	msgLines := domain.Messages(entries)
+	return strings.Join(msgLines, "\n"), nil
 }
 
 func (s *ReleaseService) getReleaseDir() (string, error) {
@@ -336,11 +493,39 @@ func (s *ReleaseService) Prepare(instruction string, userBump string) (*domain.R
 	// Parse release intent from instruction using regex (NO LLM)
 	intent := parseReleaseIntent(instruction, releasesList)
 
-	// Get commits since last tag — prefer CommitStore aggregated branches if available
+	// Get commits since last tag — prefer refs/courer/*, then CommitStore, then git log
 	var commits string
 	var lastTag string // track the reference tag for error messages
 	var fromStore bool
-	if s.commitStore != nil {
+
+	// Migration: merge legacy .git-courer/branches/ into .git/git-courer/branches/ dedup by SHA
+	if s.cfg.WorkDir != "" {
+		oldBranchesDir := filepath.Join(s.cfg.WorkDir, ".git-courer", "branches")
+		newBranchesDir := filepath.Join(s.cfg.WorkDir, domain.MetadataDir, "branches")
+		if _, statErr := os.Stat(oldBranchesDir); statErr == nil {
+			log.Printf("[INFO] ReleaseService: migrating metadata from %s to %s", oldBranchesDir, newBranchesDir)
+			if mergeErr := migrateOldMetadata(oldBranchesDir, newBranchesDir); mergeErr != nil {
+				log.Printf("[WARN] ReleaseService: metadata migration failed: %v (continuing)", mergeErr)
+			} else {
+				if removeErr := os.RemoveAll(oldBranchesDir); removeErr != nil {
+					log.Printf("[WARN] ReleaseService: failed to remove old metadata: %v", removeErr)
+				}
+			}
+		}
+	}
+
+	// Try refs/courer/* first (survives squash merge)
+	if s.git != nil {
+		if refCommits, err := s.commitsFromRefs(); err == nil && refCommits != "" {
+			fromStore = true
+			commits = refCommits
+			log.Printf("[DEBUG] Using refs/courer/* entries for release")
+		} else if err != nil {
+			log.Printf("[WARN] Refs/courer/* read failed: %v (falling back to CommitStore)", err)
+		}
+	}
+
+	if s.commitStore != nil && !fromStore {
 		// Try ReadAllBranches first (aggregates all branch stores)
 		branchEntries, allBranchesErr := s.commitStore.ReadAllBranches()
 		if allBranchesErr == nil && len(branchEntries) > 0 {

--- a/internal/workflow/release.go
+++ b/internal/workflow/release.go
@@ -155,7 +155,7 @@ func (s *ReleaseService) getReleaseDir() (string, error) {
 	if s.cfg.WorkDir == "" {
 		return "", nil // Fallback to in-memory mode
 	}
-	return filepath.Join(s.cfg.WorkDir, ".git-courer"), nil
+	return filepath.Join(s.cfg.WorkDir, domain.MetadataDir), nil
 }
 
 func (s *ReleaseService) setPendingState(state string) {

--- a/internal/workflow/release_execute.go
+++ b/internal/workflow/release_execute.go
@@ -109,6 +109,32 @@ func (s *ReleaseService) Execute(intent *domain.ReleaseIntent, changelog string)
 		}
 	}
 
+	// Clean up refs/courer/* after successful release
+	if s.git != nil {
+		refsToClean, showErr := s.git.ShowRef("refs/courer/*")
+		if showErr == nil && refsToClean != "" {
+			for _, line := range strings.Split(strings.TrimSpace(refsToClean), "\n") {
+				line = strings.TrimSpace(line)
+				if line == "" {
+					continue
+				}
+				parts := strings.Fields(line)
+				if len(parts) < 2 {
+					continue
+				}
+				ref := parts[1]
+				if _, localErr := s.git.UpdateRef(ref, ""); localErr != nil {
+					log.Printf("[WARN] release: failed to delete local ref %s: %v", ref, localErr)
+				}
+				if remoteErr := s.git.DeleteRemoteBranch(ref); remoteErr != nil {
+					log.Printf("[WARN] release: failed to delete remote ref %s: %v", ref, remoteErr)
+				}
+			}
+		} else if showErr != nil {
+			log.Printf("[WARN] release: failed to list refs/courer/* for cleanup: %v", showErr)
+		}
+	}
+
 	result := ReleaseResult{
 		Operation: "release",
 		TagName:   intent.TagName,

--- a/internal/workflow/release_test.go
+++ b/internal/workflow/release_test.go
@@ -175,6 +175,8 @@ func (m *mockGitForRelease) CommitTree(treeHash, parentHash, message string) (st
 }
 func (m *mockGitForRelease) UpdateRef(ref, commitHash string) (string, error)  { return "", nil }
 func (m *mockGitForRelease) Head() (string, error)                             { return "", nil }
+func (m *mockGitForRelease) HashObject(data []byte) (string, error)             { return "mock-blob-sha", nil }
+func (m *mockGitForRelease) ShowRef(pattern string) (string, error)              { return "", nil }
 func (m *mockGitForRelease) Blame(filepath string) ([]domain.BlameLine, error) { return nil, nil }
 func (m *mockGitForRelease) Show(hash string) (domain.ShowResult, error) {
 	return domain.ShowResult{}, nil

--- a/test/release/e2e_test.go
+++ b/test/release/e2e_test.go
@@ -87,7 +87,7 @@ func setupTestRepo(t *testing.T) (repoDir string, store *commitstore.FilesystemC
 		}
 	}
 
-	store = commitstore.NewFilesystemCommitStore(dir)
+	store = commitstore.NewFilesystemCommitStore(dir, nil)
 	if err := store.SetBranch("e2e/test"); err != nil {
 		t.Fatalf("SetBranch: %v", err)
 	}

--- a/tui/screens/init.go
+++ b/tui/screens/init.go
@@ -3,7 +3,9 @@ package screens
 
 import (
 	"fmt"
+	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -350,6 +352,19 @@ func (m *InitScreen) handleSave() (tea.Model, tea.Cmd) {
 		m.err = err
 		return m, nil
 	}
+
+	// Configure remote.origin.fetch to include refs/courer/* (multi-valued, needs --add)
+	if m.git != nil {
+		existing, getErr := m.git.ConfigGet("remote.origin.fetch")
+		if getErr == nil && !strings.Contains(existing, "refs/courer/*") {
+			// Use exec directly: git config --add for multi-valued keys
+			cmd := exec.Command("git", "config", "--add", "remote.origin.fetch", "+refs/courer/*:refs/courer/*")
+			if out, err := cmd.CombinedOutput(); err != nil {
+				log.Printf("[WARN] init: failed to add refs/courer refspec: %v (output: %s)", err, string(out))
+			}
+		}
+	}
+
 	m.confirmed = true
 	m.step = stepFinish
 	return m, nil

--- a/tui/screens/init_test.go
+++ b/tui/screens/init_test.go
@@ -307,7 +307,7 @@ func TestInitScreen_DescriptionFlowsToReview(t *testing.T) {
 // Triangulation: Config save failure sets error
 func TestInitScreen_SaveFailureSetsError(t *testing.T) {
 	tmpDir := t.TempDir()
-	configDir := filepath.Join(tmpDir, ".git-courer")
+	configDir := filepath.Join(tmpDir, domain.MetadataDir)
 	if err := os.MkdirAll(configDir, 0755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}


### PR DESCRIPTION
## Tracker: metadata-compartida

Move git-courer metadata from `.git-courer/` to `.git/git-courer/` and share per-branch commit summaries via Git blobs + `refs/courer/<branch>`.

### Dependency Diagram

```
📍 feat/metadata-compartida (tracker — this PR, stays draft)
├── PR #1: Foundation — MetadataDir + ports.Git + CommitStore constructor
├── PR #2: Core — ref sidecar + push sidecar + config paths
├── PR #3: Release + Init — refs reading, cleanup, init refspec
└── PR #4: Documentation — README update
```

### Chain Strategy
Feature Branch Chain. Each child PR targets the immediate parent branch. Only this tracker merges to `main`.

### Deliverables
- Metadata under `.git/git-courer/` — invisible to `git status`
- `refs/courer/<branch>` — per-branch commit blobs surviving squash merges
- Automatic migration from `.git-courer/` on release
- Cloud-agnostic (pure Git plumbing, no GitHub API dependency)

### Out of Scope
- No UI for inspecting refs
- No cleanup of refs on branch delete (only on release)
- Stack/group by merge-base for LLM (fields exist but not touched)

**Do not merge until all child PRs are reviewed and integrated.**