### PR TITLE
feat: Core — ref sidecar + push sidecar + config paths

### DIFF
--- a/.git-courer/branches/feat-metadata-compartida-p2/commits.json
+++ b/.git-courer/branches/feat-metadata-compartida-p2/commits.json
@@ -1,0 +1,14 @@
+[
+  {
+    "sha": "aeccca3ae0513d202589367e9792280b325302c5",
+    "message": "feat!: refactor git adapter and relocate commit metadata",
+    "author": "Alejandro",
+    "date": "2026-06-16"
+  },
+  {
+    "sha": "4a76276d0817aa89baf2c1477d0986115aca57af",
+    "message": "feat: refactor metadata paths and implement sidecar ref syncing\n\nWHY\nProject configuration and release paths were hardcoded to a top-level .git-courer directory, causing structural inconsistencies and preventing metadata from being nested within the .git folder. Additionally, branch-scoped metadata and sidecar references were not being synchronized to the remote origin, making it difficult to track appended data or share branch-specific state with downstream tools.\n\nWHAT\n* Replaced hardcoded \".git-courer\" strings with the MetadataDir constant across config, release, and project services.\n* Implemented updateCourerRef to create git blobs and update refs/courer/\u003cbranch\u003e during the append process.\n* Added logic to push sidecar references to origin during PUSH and AUTO operations.\n* Integrated branch detection to synchronize the current branch to origin/refs/courer/ during commit execution.",
+    "author": "Alejandro",
+    "date": "2026-06-16T10:09:01Z"
+  }
+]

--- a/internal/adapters/commitstore/adapter.go
+++ b/internal/adapters/commitstore/adapter.go
@@ -92,7 +92,26 @@ func (s *FilesystemCommitStore) Append(entries ...domain.CommitEntry) error {
 		return fmt.Errorf("commit store: write file: %w", s.sanitizePathError(err))
 	}
 
+	s.updateCourerRef(data)
+
 	return nil
+}
+
+// updateCourerRef creates a git blob from the written data and updates
+// refs/courer/<branch> when running in branch-scoped mode. Failures are logged
+// but never fail Append.
+func (s *FilesystemCommitStore) updateCourerRef(data []byte) {
+	if s.branch == "" || s.git == nil {
+		return
+	}
+	blobSHA, err := s.git.HashObject(data)
+	if err != nil {
+		log.Printf("[WARN] commit store: failed to create blob for refs/courer/%s: %v", s.branch, err)
+		return
+	}
+	if _, err := s.git.UpdateRef(fmt.Sprintf("refs/courer/%s", s.branch), blobSHA); err != nil {
+		log.Printf("[WARN] commit store: failed to update refs/courer/%s: %v", s.branch, err)
+	}
 }
 
 // Read returns all stored CommitEntry values.

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/blak0p/git-courer/internal/core/domain"
 )
 
-// ProjectConfig holds per-project settings stored in .git-courer/config.json.
+// ProjectConfig holds per-project settings stored in .git/git-courer/config.json.
 // These values are committable and shared by the team.
 // Legacy configs may contain "areas" field — it is silently ignored on load and not written on save.
 type ProjectConfig struct {
@@ -20,10 +22,10 @@ type ProjectConfig struct {
 	Excluded    []string            `json:"excluded,omitempty"`
 }
 
-// LoadProjectConfig reads .git-courer/config.json from the given working directory.
+// LoadProjectConfig reads .git/git-courer/config.json from the given working directory.
 // Returns an error if the config file does not exist.
 func LoadProjectConfig(workDir string) (*ProjectConfig, error) {
-	configPath := filepath.Join(workDir, ".git-courer", "config.json")
+	configPath := filepath.Join(workDir, domain.MetadataDir, "config.json")
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -51,9 +53,9 @@ func LoadProjectConfig(workDir string) (*ProjectConfig, error) {
 // 2. Merge the structured fields from cfg into the map
 // 3. Write back with json.MarshalIndent
 func SaveProjectConfig(workDir string, cfg *ProjectConfig) error {
-	gitcourerDir := filepath.Join(workDir, ".git-courer")
+	gitcourerDir := filepath.Join(workDir, domain.MetadataDir)
 	if err := os.MkdirAll(gitcourerDir, 0755); err != nil {
-		return fmt.Errorf("failed to create .git-courer dir: %w", err)
+		return fmt.Errorf("failed to create .git/git-courer dir: %w", err)
 	}
 
 	configPath := filepath.Join(gitcourerDir, "config.json")

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/blak0p/git-courer/internal/core/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -15,7 +16,7 @@ import (
 // Legacy configs with "areas" field load without error.
 func TestProjectConfig_LoadExisting(t *testing.T) {
 	tmpDir := t.TempDir()
-	gitcourerDir := filepath.Join(tmpDir, ".git-courer")
+	gitcourerDir := filepath.Join(tmpDir, domain.MetadataDir)
 	require.NoError(t, os.MkdirAll(gitcourerDir, 0755))
 
 	existing := map[string]interface{}{
@@ -38,7 +39,7 @@ func TestProjectConfig_LoadExisting(t *testing.T) {
 // TestProjectConfig_LoadWithTestCommand verifies loading config with test_command set.
 func TestProjectConfig_LoadWithTestCommand(t *testing.T) {
 	tmpDir := t.TempDir()
-	gitcourerDir := filepath.Join(tmpDir, ".git-courer")
+	gitcourerDir := filepath.Join(tmpDir, domain.MetadataDir)
 	require.NoError(t, os.MkdirAll(gitcourerDir, 0755))
 
 	existing := map[string]interface{}{
@@ -77,7 +78,7 @@ func TestProjectConfig_SaveNew(t *testing.T) {
 // Legacy "areas" field in file is ignored on load and not written on save.
 func TestProjectConfig_SavePreservesExistingFields(t *testing.T) {
 	tmpDir := t.TempDir()
-	gitcourerDir := filepath.Join(tmpDir, ".git-courer")
+	gitcourerDir := filepath.Join(tmpDir, domain.MetadataDir)
 	require.NoError(t, os.MkdirAll(gitcourerDir, 0755))
 
 	existing := map[string]interface{}{
@@ -107,9 +108,9 @@ func TestProjectConfig_SavePreservesExistingFields(t *testing.T) {
 	// Legacy "areas" is not loaded into struct
 }
 
-// TestProjectConfig_LoadNonExistent returns an error when .git-courer/config.json doesn't exist.
+// TestProjectConfig_LoadNonExistent returns an error when .git/git-courer/config.json doesn't exist.
 func TestProjectConfig_LoadNonExistent(t *testing.T) {
-	tmpDir := t.TempDir() // no .git-courer directory
+	tmpDir := t.TempDir() // no .git/git-courer directory
 
 	_, err := LoadProjectConfig(tmpDir)
 	assert.Error(t, err)
@@ -120,7 +121,7 @@ func TestProjectConfig_LoadNonExistent(t *testing.T) {
 // load without error — the field is silently ignored.
 func TestProjectConfig_LoadLegacyAreas(t *testing.T) {
 	tmpDir := t.TempDir()
-	gitcourerDir := filepath.Join(tmpDir, ".git-courer")
+	gitcourerDir := filepath.Join(tmpDir, domain.MetadataDir)
 	require.NoError(t, os.MkdirAll(gitcourerDir, 0755))
 
 	existing := map[string]interface{}{
@@ -143,7 +144,7 @@ func TestProjectConfig_LoadLegacyAreas(t *testing.T) {
 // are preserved across a load-save cycle.
 func TestProjectConfig_SaveRoundTripUnknownFields(t *testing.T) {
 	tmpDir := t.TempDir()
-	gitcourerDir := filepath.Join(tmpDir, ".git-courer")
+	gitcourerDir := filepath.Join(tmpDir, domain.MetadataDir)
 	require.NoError(t, os.MkdirAll(gitcourerDir, 0755))
 
 	// Write config with an unknown field
@@ -172,7 +173,7 @@ func TestProjectConfig_SaveRoundTripUnknownFields(t *testing.T) {
 
 func TestProjectConfig_LoadExcluded(t *testing.T) {
 	tmpDir := t.TempDir()
-	gitcourerDir := filepath.Join(tmpDir, ".git-courer")
+	gitcourerDir := filepath.Join(tmpDir, domain.MetadataDir)
 	require.NoError(t, os.MkdirAll(gitcourerDir, 0755))
 
 	existing := map[string]interface{}{
@@ -191,7 +192,7 @@ func TestProjectConfig_LoadExcluded(t *testing.T) {
 
 func TestProjectConfig_LoadExcludedNil(t *testing.T) {
 	tmpDir := t.TempDir()
-	gitcourerDir := filepath.Join(tmpDir, ".git-courer")
+	gitcourerDir := filepath.Join(tmpDir, domain.MetadataDir)
 	require.NoError(t, os.MkdirAll(gitcourerDir, 0755))
 
 	existing := map[string]interface{}{
@@ -226,7 +227,7 @@ func TestProjectConfig_SaveExcluded(t *testing.T) {
 
 func TestProjectConfig_SaveExcludedPreservesUnknownFields(t *testing.T) {
 	tmpDir := t.TempDir()
-	gitcourerDir := filepath.Join(tmpDir, ".git-courer")
+	gitcourerDir := filepath.Join(tmpDir, domain.MetadataDir)
 	require.NoError(t, os.MkdirAll(gitcourerDir, 0755))
 
 	content := `{

--- a/internal/core/domain/project_config.go
+++ b/internal/core/domain/project_config.go
@@ -39,7 +39,7 @@ type ProjectConfig struct {
 // If the config file does not exist, it returns an empty config.
 // Legacy configs with "areas" field load successfully — the field is ignored.
 func LoadProjectConfig(repoRoot string) (*ProjectConfig, error) {
-	path := filepath.Join(repoRoot, ".git-courer", "config.json")
+	path := filepath.Join(repoRoot, MetadataDir, "config.json")
 
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return &ProjectConfig{}, nil
@@ -65,7 +65,7 @@ func LoadProjectConfig(repoRoot string) (*ProjectConfig, error) {
 
 // Save writes the project configuration to disk.
 func (c *ProjectConfig) Save(repoRoot string) error {
-	dir := filepath.Join(repoRoot, ".git-courer")
+	dir := filepath.Join(repoRoot, MetadataDir)
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("mkdir %s: %w", dir, err)
 	}

--- a/internal/core/domain/project_config_test.go
+++ b/internal/core/domain/project_config_test.go
@@ -51,7 +51,7 @@ func TestProjectConfig_MissingConfig(t *testing.T) {
 func TestProjectConfig_MalformedJSON(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
-	repoDir := filepath.Join(tmpDir, ".git-courer")
+	repoDir := filepath.Join(tmpDir, MetadataDir)
 	if err := os.MkdirAll(repoDir, 0755); err != nil {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}
@@ -276,7 +276,7 @@ func TestProjectConfig_BaseBranch_RoundTrip(t *testing.T) {
 func TestProjectConfig_BaseBranch_DefaultEmpty(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
-	repoDir := filepath.Join(tmpDir, ".git-courer")
+	repoDir := filepath.Join(tmpDir, MetadataDir)
 	if err := os.MkdirAll(repoDir, 0755); err != nil {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}

--- a/internal/delivery/mcp/sync/mock_test.go
+++ b/internal/delivery/mcp/sync/mock_test.go
@@ -64,7 +64,10 @@ func (m *MockGit) DiffRange(base, target, mode string, paths ...string) (string,
 func (m *MockGit) ListUntracked() ([]string, error)                               { return nil, nil }
 func (m *MockGit) Log(limit int, pattern string, paths ...string) (string, error) { return "", nil }
 func (m *MockGit) LogFull(limit int) (string, error)                              { return "", nil }
-func (m *MockGit) CurrentBranch() (string, error)                                 { return "", nil }
+func (m *MockGit) CurrentBranch() (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
 func (m *MockGit) ListBranches(pattern ...string) (string, error)                 { return "", nil }
 func (m *MockGit) ListTags(pattern ...string) ([]string, error)                   { return nil, nil }
 func (m *MockGit) IsRepo() bool                                                   { return true }

--- a/internal/delivery/mcp/sync/sync.go
+++ b/internal/delivery/mcp/sync/sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/blak0p/git-courer/internal/core/domain"
@@ -83,7 +84,16 @@ func (h *Handler) HandleSync(_ context.Context, req mcpgo.CallToolRequest) (*mcp
 		} else {
 			_, err = h.git.PushTo(remote)
 		}
+		if err == nil {
+			// Non-blocking: push refs/courer/<branch> as sidecar
+			if refBranch := branch; refBranch != "" {
+				if _, refErr := h.git.PushToBranch("origin", "refs/courer/"+refBranch); refErr != nil {
+					log.Printf("[WARN] sync: failed to push refs/courer/%s: %v", refBranch, refErr)
+				}
+			}
+		}
 		result = shared.WriteResultJSON("PUSH", err == nil, "Pushed to "+remote+" — changes are now on remote. Remember: call pr-review before creating a PR.")
+		// branch=="" means no ref push sidecar; do not call CurrentBranch
 	case "AUTO":
 		var outputs []string
 		// 1. Fetch
@@ -105,14 +115,26 @@ func (h *Handler) HandleSync(_ context.Context, req mcpgo.CallToolRequest) (*mcp
 			outputs = append(outputs, pOut)
 		}
 		// 3. Push
+		var pushedBranch string
 		if uOut, uErr := h.git.Push(); uErr != nil {
 			if strings.Contains(uErr.Error(), "NO_UPSTREAM") {
 				outputs = append(outputs, "[INFO] No upstream to push to")
 			} else {
-				return shared.JSONErrorResult("AUTO_PUSH", uErr)
+				return shared.JSONErrorResult("AUTO_SYNC", uErr)
 			}
-		} else if uOut != "" {
-			outputs = append(outputs, uOut)
+		} else {
+			if uOut != "" {
+				outputs = append(outputs, uOut)
+			}
+			if currentBranch, branchErr := h.git.CurrentBranch(); branchErr == nil && currentBranch != "" {
+				pushedBranch = currentBranch
+			}
+		}
+		// Non-blocking: push refs/courer/<branch> as sidecar
+		if pushedBranch != "" {
+			if _, refErr := h.git.PushToBranch("origin", "refs/courer/"+pushedBranch); refErr != nil {
+				log.Printf("[WARN] sync: failed to push refs/courer/%s: %v", pushedBranch, refErr)
+			}
 		}
 		result = shared.WriteResultJSON("AUTO_SYNC", true, strings.Join(outputs, "\n"))
 	}

--- a/internal/delivery/mcp/sync/sync_test.go
+++ b/internal/delivery/mcp/sync/sync_test.go
@@ -65,7 +65,8 @@ func TestHandleSync_PushWithBranch(t *testing.T) {
 	gitMock := new(MockGit)
 	backup := domain.Backup{Ref: "ref", Operation: "PUSH"}
 	gitMock.On("CreateBackup", "PUSH", domain.StashNone).Return(backup, nil)
-	gitMock.On("PushToBranch", "origin", "feature").Return("pushed feature to origin", nil)
+	gitMock.On("PushToBranch", "origin", "feature").Return("pushed feature to origin", nil).Once()
+	gitMock.On("PushToBranch", "origin", "refs/courer/feature").Return("pushed ref", nil)
 
 	h := NewHandler(gitMock)
 

--- a/internal/workflow/commit_execute.go
+++ b/internal/workflow/commit_execute.go
@@ -77,6 +77,11 @@ func (s *CommitService) ExecuteFromPlan(messages []string, chunkFiles [][]string
 		if err != nil {
 			return "", fmt.Errorf("push failed: %w", err)
 		}
+		if currentBranch, branchErr := s.git.CurrentBranch(); branchErr == nil && currentBranch != "" {
+			if _, refErr := s.git.PushToBranch("origin", "refs/courer/"+currentBranch); refErr != nil {
+				log.Printf("[WARN] commit execute: failed to push refs/courer/%s: %v", currentBranch, refErr)
+			}
+		}
 	}
 
 	log.Printf("[DEBUG] ExecuteFromPlan: handling deleted files")
@@ -150,6 +155,11 @@ func (s *CommitService) executeSync(instruction string, chunks []domain.DiffChun
 		_, err := s.git.Push()
 		if err != nil {
 			return "", fmt.Errorf("push failed: %w", err)
+		}
+		if currentBranch, branchErr := s.git.CurrentBranch(); branchErr == nil && currentBranch != "" {
+			if _, refErr := s.git.PushToBranch("origin", "refs/courer/"+currentBranch); refErr != nil {
+				log.Printf("[WARN] commit execute: failed to push refs/courer/%s: %v", currentBranch, refErr)
+			}
 		}
 	}
 

--- a/internal/workflow/release.go
+++ b/internal/workflow/release.go
@@ -155,7 +155,7 @@ func (s *ReleaseService) getReleaseDir() (string, error) {
 	if s.cfg.WorkDir == "" {
 		return "", nil // Fallback to in-memory mode
 	}
-	return filepath.Join(s.cfg.WorkDir, ".git-courer"), nil
+	return filepath.Join(s.cfg.WorkDir, domain.MetadataDir), nil
 }
 
 func (s *ReleaseService) setPendingState(state string) {

--- a/tui/screens/init_test.go
+++ b/tui/screens/init_test.go
@@ -307,7 +307,7 @@ func TestInitScreen_DescriptionFlowsToReview(t *testing.T) {
 // Triangulation: Config save failure sets error
 func TestInitScreen_SaveFailureSetsError(t *testing.T) {
 	tmpDir := t.TempDir()
-	configDir := filepath.Join(tmpDir, ".git-courer")
+	configDir := filepath.Join(tmpDir, domain.MetadataDir)
 	if err := os.MkdirAll(configDir, 0755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}


### PR DESCRIPTION
## PR #2: Core

Part of the metadata-compartida chain (tracks #130).

### What
- Added ref sidecar (`updateCourerRef`) in `CommitStore.Append()` — creates blob + `refs/courer/<branch>` after each write
- Added ref push sidecar non-blocking at all 3 push sites (`executeSync`, `ExecuteFromPlan`, `sync/sync.go` PUSH/AUTO)
- Updated `domain.LoadProjectConfig` and `Save` to use `domain.MetadataDir`
- Updated `config.LoadProjectConfig` and `Save` to use `domain.MetadataDir`
- Updated `getReleaseDir()` in release.go

### Verification
`go build ./...` and `go test ./...` pass.

### Depends on
PR #1 (`feat/metadata-compartida-p1`)