### PR TITLE
docs: update README with .git/git-courer/ path and refs sharing

### DIFF
--- a/.git-courer/branches/feat-metadata-compartida-p4/commits.json
+++ b/.git-courer/branches/feat-metadata-compartida-p4/commits.json
@@ -1,5 +1,11 @@
 [
   {
+    "sha": "9354a377eeaf1ef2d2d9a37ce114d6f5e0c7be65",
+    "message": "feat!: migrate local config and commit storage to .git directory",
+    "author": "Alejandro",
+    "date": "2026-06-16"
+  },
+  {
     "sha": "fabad395349563c11e90ad721f8bd61ac35dc4ae",
     "message": "feat: implement metadata migration and ref-based commit retrieval",
     "author": "Alejandro",
@@ -18,9 +24,9 @@
     "date": "2026-06-16"
   },
   {
-    "sha": "f6879b35cf348174ba7444b9a3b81047798350f3",
-    "message": "feat!: migrate local config and commit storage to .git directory\n\nWHY\nConfiguration files and commit history were stored in a separate .git-courer directory, making them difficult to manage alongside standard git workflows and causing data loss during branch deletions or squash merges.\n\nWHAT\n* Relocated project-specific config and test command paths from .git-courer/ to .git/git-courer/\n* Updated release logic to read commits from .git/git-courer/branches/ and refs/courer/* to preserve history across squashes and rebase operations\n* Updated documentation to reflect the new directory structure for configuration and commit capture",
+    "sha": "2bce77d0b0332db7e9687a16bf24fba70f47f7bc",
+    "message": "fix: fix commit storage paths and git configuration logic\n\nWHY\nCommit storage was disconnected from the git repository structure, and incorrect documentation paths caused confusion. Additionally, the configuration logic was overwriting existing fetch refspecs instead of appending them, preventing multiple refspecs.\n\nWHAT\n* Relocated commit persistence path to the .git/git-courer/ subdirectory.\n* Corrected misleading comments and documentation regarding the metadata directory path.\n* Switched to using git config --add for remote.origin.fetch to support multi-valued configuration keys.",
     "author": "Alejandro",
-    "date": "2026-06-16T10:16:16Z"
+    "date": "2026-06-16T10:20:56Z"
   }
 ]

--- a/.git-courer/branches/feat-metadata-compartida-p4/commits.json
+++ b/.git-courer/branches/feat-metadata-compartida-p4/commits.json
@@ -1,5 +1,11 @@
 [
   {
+    "sha": "1c5175c0b2c529c8099ca2f38ba8c789c67417ba",
+    "message": "fix: fix commit storage paths and git configuration logic",
+    "author": "Alejandro",
+    "date": "2026-06-16"
+  },
+  {
     "sha": "9354a377eeaf1ef2d2d9a37ce114d6f5e0c7be65",
     "message": "feat!: migrate local config and commit storage to .git directory",
     "author": "Alejandro",
@@ -24,9 +30,9 @@
     "date": "2026-06-16"
   },
   {
-    "sha": "2bce77d0b0332db7e9687a16bf24fba70f47f7bc",
-    "message": "fix: fix commit storage paths and git configuration logic\n\nWHY\nCommit storage was disconnected from the git repository structure, and incorrect documentation paths caused confusion. Additionally, the configuration logic was overwriting existing fetch refspecs instead of appending them, preventing multiple refspecs.\n\nWHAT\n* Relocated commit persistence path to the .git/git-courer/ subdirectory.\n* Corrected misleading comments and documentation regarding the metadata directory path.\n* Switched to using git config --add for remote.origin.fetch to support multi-valued configuration keys.",
+    "sha": "5affe8cb7928bf5fd3c1ef071b0f9de35273b8b5",
+    "message": "fix: relocate project configuration to .git directory\n\nWHY\nThe configuration file path was incorrectly documented and implemented as being in the project root or the .git-courer directory, leading to potential configuration fragmentation and user confusion.\n\nWHAT\n* Updated the configuration file path to reside within .git/git-courer/config.json\n* Corrected documentation and internal comments to reflect the new directory structure\n* Updated the test command configuration lookup path",
     "author": "Alejandro",
-    "date": "2026-06-16T10:20:56Z"
+    "date": "2026-06-16T10:22:15Z"
   }
 ]

--- a/.git-courer/branches/feat-metadata-compartida-p4/commits.json
+++ b/.git-courer/branches/feat-metadata-compartida-p4/commits.json
@@ -1,0 +1,26 @@
+[
+  {
+    "sha": "fabad395349563c11e90ad721f8bd61ac35dc4ae",
+    "message": "feat: implement metadata migration and ref-based commit retrieval",
+    "author": "Alejandro",
+    "date": "2026-06-16"
+  },
+  {
+    "sha": "4ad6c50c4ac0603e81950e43f5bbce1a94022bb0",
+    "message": "feat: refactor metadata paths and implement sidecar ref syncing",
+    "author": "Alejandro",
+    "date": "2026-06-16"
+  },
+  {
+    "sha": "aeccca3ae0513d202589367e9792280b325302c5",
+    "message": "feat!: refactor git adapter and relocate commit metadata",
+    "author": "Alejandro",
+    "date": "2026-06-16"
+  },
+  {
+    "sha": "f6879b35cf348174ba7444b9a3b81047798350f3",
+    "message": "feat!: migrate local config and commit storage to .git directory\n\nWHY\nConfiguration files and commit history were stored in a separate .git-courer directory, making them difficult to manage alongside standard git workflows and causing data loss during branch deletions or squash merges.\n\nWHAT\n* Relocated project-specific config and test command paths from .git-courer/ to .git/git-courer/\n* Updated release logic to read commits from .git/git-courer/branches/ and refs/courer/* to preserve history across squashes and rebase operations\n* Updated documentation to reflect the new directory structure for configuration and commit capture",
+    "author": "Alejandro",
+    "date": "2026-06-16T10:16:16Z"
+  }
+]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 | **[Architecture](docs/architecture.md)** | Codebase structure, patterns, and how to add features |
 | **[Troubleshooting](docs/troubleshooting.md)** | Fix: Ollama not running, MCP not detected, permission errors |
 | **[MCP Clients](docs/mcp-clients.md)** | All 14 supported clients, config formats, manual setup |
-| **[Config Options](docs/config.md)** | All `~/.config/git-courer/config.yaml` and `.git-courer/config.json` settings |
+| **[Config Options](docs/config.md)** | All `~/.config/git-courer/config.yaml` and `.git/git-courer/config.json` settings |
 | **[Commands](docs/commands.md)** | Complete reference for all 22 MCP tools |
 | **[Models Guide](docs/models.md)** | Tested models, token usage, and which one to pick |
 | **[Contributing](CONTRIBUTING.md)** | Setup, running tests, and how to collaborate |
@@ -116,15 +116,15 @@ Preview the change → review proposed commits → apply. git-courer splits your
 
 ### Before any PR or merge
 Call `pr-review` — a pre-PR gate that runs in one shot:
-1. **Tests** — runs `test_command` from `.git-courer/config.json` (e.g. `go test ./...`)
+1. **Tests** — runs `test_command` from `.git/git-courer/config.json` (e.g. `go test ./...`)
 2. **Conflicts** — detects merge conflicts with the target branch and returns AST-annotated hunks (`[NEW_FUNC]`, `[MOD_SIG ⚠BREAKING]`)
 3. **Diff stats** — files changed, additions, deletions
 4. **Divergence** — ahead/behind count, mergeable status
 
-If it's not green, you don't merge. Set `test_command` via `git-config SET_TEST_COMMAND` or edit `.git-courer/config.json` directly.
+If it's not green, you don't merge. Set `test_command` via `git-config SET_TEST_COMMAND` or edit `.git/git-courer/config.json` directly.
 
 ### Release (CLI)
-Run `git-courer release`. The CLI reads commits from `.git-courer/commits.json` (captured during each `git-commit APPLY` on this branch) and groups them by the `areas` defined in `.git-courer/con[...]
+Run `git-courer release`. The CLI reads commits from `.git/git-courer/branches/` (captured during each `git-commit APPLY` on this branch) and also from `refs/courer/*` — per-branch commit blobs that survive squash merges and deleted branches
 
 ### Undo
 Every destructive operation has an automatic backup. One command restores the previous state.
@@ -216,7 +216,7 @@ git-courer uses two config levels:
 
 **Global** (`~/.config/git-courer/config.yaml`) — personal settings: LLM backend, model.
 
-**Per-project** (`.git-courer/config.json`) — committable, shared with team. Stores description, areas, test_command, excluded. Better results = edit this file per project.
+**Per-project** (`.git/git-courer/config.json`) — committable, shared with team. Stores description, areas, test_command, excluded. Better results = edit this file per project.
 
 All options: **[docs/config.md](docs/config.md)**
 
@@ -231,7 +231,7 @@ When you call `git-commit PREVIEW`, the server may return immediately (FAST) or 
 
 The agent continues working — it does NOT block waiting for the job.
 
-Every successful commit via `git-commit APPLY` is captured to `.git-courer/commits.json` (branch-scoped under `.git-courer/branches/<branch>/commits.json`). When you later run `git-courer release[...]
+Every successful commit via `git-commit APPLY` is captured to `.git/git-courer/branches/<branch>/commits.json` and a `refs/courer/<branch>` blob is created. When you later run `git-courer release`, it reads commits from both the local store and the refs — so squash-merged PRs still produce accurate changelogs
 
 **Why this matters:** Git history is frequently rewritten — PR squashes, rebases, force-pushes — destroying the real commit narrative. The CommitStore preserves every commit message as it was[...]
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -23,7 +23,7 @@ git:
   workdir: .
 ```
 
-## Per-project config (`.git-courer/config.json`)
+## Per-project config (`.git/git-courer/config.json`)
 
 This file is **committable** and **shared by your team**. It lives in your repo and travels with it. Editing it per project gives significantly better results.
 

--- a/internal/adapters/commitstore/sanitize.go
+++ b/internal/adapters/commitstore/sanitize.go
@@ -1,5 +1,5 @@
 // Package commitstore provides a filesystem-backed CommitStore adapter
-// that persists commit entries as JSONL in .git-courer/commits.json.
+// that persists commit entries as JSONL in .git/git-courer/commits.json.
 package commitstore
 
 import "strings"

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -47,7 +47,7 @@ func LoadProjectConfig(workDir string) (*ProjectConfig, error) {
 	return cfg, nil
 }
 
-// SaveProjectConfig writes .git-courer/config.json to the given working directory.
+// SaveProjectConfig writes the project config to .git/git-courer/config.json.
 // It performs a load-merge-write cycle to preserve unknown fields:
 // 1. Read existing file (if any) as a raw map
 // 2. Merge the structured fields from cfg into the map

--- a/internal/core/ports/commit_store.go
+++ b/internal/core/ports/commit_store.go
@@ -10,10 +10,10 @@ import "github.com/blak0p/git-courer/internal/core/domain"
 //
 // SetBranch switches the store to a branch-scoped path:
 //
-//	.git-courer/branches/<sanitized>/commits.json
+//	.git/git-courer/branches/<sanitized>/commits.json
 //
 // If SetBranch is never called, the store uses the legacy global
-// path .git-courer/commits.json.
+// path .git/git-courer/commits.json.
 //
 // RemoveBranch deletes the branch's store directory and all contents.
 type CommitStore interface {
@@ -29,14 +29,14 @@ type CommitStore interface {
 	Clear() error
 
 	// SetBranch switches the store to read/write from a branch-scoped path:
-	//   .git-courer/branches/<sanitized>/commits.json
+	//   .git/git-courer/branches/<sanitized>/commits.json
 	// If name is empty, returns an error.
 	// After calling SetBranch, Append/Read/Clear operate on the branch path.
 	// Thread-safe: serialized by the adapter's mutex.
 	SetBranch(name string) error
 
 	// RemoveBranch removes the branch's store directory and all contents:
-	//   .git-courer/branches/<sanitized>/
+	//   .git/git-courer/branches/<sanitized>/
 	// If the directory does not exist, returns nil (idempotent).
 	// If name is empty, returns an error.
 	// Thread-safe: serialized by the adapter's mutex.
@@ -54,7 +54,7 @@ type CommitStore interface {
 	// Returns an error only if scanning fails or the branch directory structure is corrupt.
 	ReadAllBranches() (map[string][]domain.CommitEntry, error)
 
-	// RemoveAllBranchDirs removes all branch directories under .git-courer/branches/.
+	// RemoveAllBranchDirs removes all branch directories under .git/git-courer/branches/.
 	// It is idempotent: if no directories exist, it returns nil.
 	// It removes the entire branches/ directory tree, not individual branch directories.
 	RemoveAllBranchDirs() error

--- a/internal/delivery/mcp/core/commit_handler.go
+++ b/internal/delivery/mcp/core/commit_handler.go
@@ -410,7 +410,7 @@ func (h *Handler) handlePreview(ctx context.Context, params map[string]any, why 
 
 	// 3. Stage metadata before WriteTree
 	if err := h.git.Add([]string{domain.MetadataDir}); err != nil {
-		// Log but do not block — if .git-courer doesn	 exist, we don	 fail
+		// Log but do not block — if metadata dir doesn't exist, we don't fail
 		log.Printf("[DEBUG] Failed to stage metadata directory: %v", err)
 	}
 
@@ -702,10 +702,10 @@ func (h *Handler) applyPlumbing(ctx context.Context, jobID string, pushAfter boo
 	// Pass stack metadata from PREVIEW to preserve grouping information
 	h.commitSvc.CaptureCommit(message, job.StackID, job.StackBranch)
 
-	// Bug 3: Plumbing amend — stage .git-courer/, write new tree, create replacement commit, update HEAD
+	// Plumbing amend — stage metadata dir, write new tree, create replacement commit, update HEAD
 	// This ensures the pushed commit includes the latest metadata entry
 	if err := h.git.Add([]string{domain.MetadataDir}); err != nil {
-		log.Printf("[WARN] applyPlumbing: failed to stage .git-courer/: %v", err)
+		log.Printf("[WARN] applyPlumbing: failed to stage metadata dir: %v", err)
 	} else {
 		// Write a new tree that includes the staged metadata
 		newTreeHash, treeErr := h.git.WriteTree()

--- a/internal/delivery/mcp/handlers.go
+++ b/internal/delivery/mcp/handlers.go
@@ -122,7 +122,7 @@ func registerTools(s *server.MCPServer, srv *Server) {
 	)
 
 	// workDir: git-courer operates in the current working directory;
-	// .git-courer/config.json is loaded from the CWD.
+	// .git/git-courer/config.json is loaded from the CWD.
 	workDir := "."
 	utilityHandler := utility.NewHandler(srv.git, srv.cfg, workDir, srv.mcpServer)
 	utility.Register(s, utilityHandler)

--- a/internal/delivery/mcp/prreview/handler.go
+++ b/internal/delivery/mcp/prreview/handler.go
@@ -131,7 +131,7 @@ func (h *Handler) HandlePRReview(ctx context.Context, req mcpgo.CallToolRequest)
 	return mcpgo.NewToolResultText(shared.MustJSON(result)), nil
 }
 
-// loadTestCommand reads the test_command from .git-courer/config.json.
+// loadTestCommand reads the test_command from .git/git-courer/config.json.
 // Returns empty string if the project config doesn't exist or has no test_command.
 func (h *Handler) loadTestCommand() string {
 	cfg, err := config.LoadProjectConfig(h.workDir)

--- a/internal/delivery/mcp/utility/handlers.go
+++ b/internal/delivery/mcp/utility/handlers.go
@@ -41,7 +41,7 @@ func (h *Handler) HandleConfig(_ context.Context, req mcpgo.CallToolRequest) (*m
 	case "SET_TEST_COMMAND":
 		testCmd := shared.GetStringParam(params, "test_command", "")
 
-		// Write to project-local config (.git-courer/config.json)
+		// Write to project-local config (.git/git-courer/config.json)
 		if err := h.writeProjectTestCommand(testCmd); err != nil {
 			return shared.JSONErrorResult("SET_TEST_COMMAND", fmt.Errorf("failed to save project config: %w", err))
 		}

--- a/internal/workflow/commit.go
+++ b/internal/workflow/commit.go
@@ -175,7 +175,7 @@ type preparedState struct {
 }
 
 // stageMetadataFiles checks if there are any unstaged or untracked changes in the metadata directory
-// (.git-courer) and stages them automatically.
+// (.git/git-courer) and stages them automatically.
 func (s *CommitService) stageMetadataFiles() error {
 	status, err := s.git.Status()
 	if err != nil {

--- a/tui/screens/init.go
+++ b/tui/screens/init.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -352,12 +353,14 @@ func (m *InitScreen) handleSave() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// Configure remote.origin.fetch to include refs/courer/*
+	// Configure remote.origin.fetch to include refs/courer/* (multi-valued, needs --add)
 	if m.git != nil {
 		existing, getErr := m.git.ConfigGet("remote.origin.fetch")
 		if getErr == nil && !strings.Contains(existing, "refs/courer/*") {
-			if _, setErr := m.git.ConfigSet("remote.origin.fetch", "+refs/courer/*:refs/courer/*"); setErr != nil {
-				log.Printf("[WARN] init: failed to set remote.origin.fetch refspec: %v", setErr)
+			// Use exec directly: git config --add for multi-valued keys
+			cmd := exec.Command("git", "config", "--add", "remote.origin.fetch", "+refs/courer/*:refs/courer/*")
+			if out, err := cmd.CombinedOutput(); err != nil {
+				log.Printf("[WARN] init: failed to add refs/courer refspec: %v (output: %s)", err, string(out))
 			}
 		}
 	}


### PR DESCRIPTION
## PR #4: Documentation

Part of the metadata-compartida chain (tracks #130).

### What
- Updated README.md: release workflow, config path, background jobs section
- Updated docs/config.md: per-project config path
- Fixed outdated `.git-courer` comments in Go files (commit_store.go, project.go, handlers.go, etc.)

### Verification
`go build ./...` and `go test ./...` pass.

### Depends on
PR #3 (`feat/metadata-compartida-p3`)