### PR TITLE
fix: remove 10 IDE/obsolete MCP client entries from MCPClients()

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 | **[Roadmap](ROADMAP.md)** | What's coming next and the strategic vision |
 | **[Architecture](docs/architecture.md)** | Codebase structure, patterns, and how to add features |
 | **[Troubleshooting](docs/troubleshooting.md)** | Fix: Ollama not running, MCP not detected, permission errors |
-| **[MCP Clients](docs/mcp-clients.md)** | All 14 supported clients, config formats, manual setup |
+| **[MCP Clients](docs/mcp-clients.md)** | All 5 supported CLI agents, config formats, manual setup |
 | **[Config Options](docs/config.md)** | All `~/.config/git-courer/config.yaml` and `.git/git-courer/config.json` settings |
 | **[Commands](docs/commands.md)** | Complete reference for all 22 MCP tools |
 | **[Models Guide](docs/models.md)** | Tested models, token usage, and which one to pick |
@@ -159,21 +159,12 @@ For workflow details: [docs/workflows.md](docs/workflows.md)
 
 | Tool | Auto-configured |
 |------|----------------|
-| Claude Code | ✓ |
-| Cursor | ✓ |
-| Windsurf | ✓ |
 | OpenCode | ✓ |
-| Cline | ✓ |
-| Roo Code | ✓ |
-| VS Code | ✓ |
-| Claude Desktop | ✓ macOS/Win only |
-| Continue | ✓ |
-| Zed | ✓ |
+| Claude Code | ✓ |
 | Codex | ✓ |
-| Gemini CLI | ✓ |
 | pi | ✓ |
 | Antigravity | ✓ |
- 
+  
 Run `git-courer mcp setup` to configure all detected tools at once, or `git-courer mcp setup <client>` for a specific one.
 
 ## Interactive TUI
@@ -200,7 +191,7 @@ git-courer runs as an interactive TUI when launched without arguments. It also p
 | `git-courer` | Launch interactive TUI (requires terminal) |
 | `git-courer mcp` | Run MCP server |
 | `git-courer mcp setup` | Configure all detected AI tools |
-| `git-courer mcp setup <client>` | Configure a specific tool (e.g. `cursor`) |
+| `git-courer mcp setup <client>` | Configure a specific tool (e.g. `opencode`) |
 | `git-courer release` | Automated semver releases and changelogs (CLI only) |
 | `git-courer remove` | Remove git-courer from the current project |
 | `git-courer uninstall` | Uninstall the binary globally |

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -1,6 +1,6 @@
 # MCP Clients
 
-git-courer supports **14 MCP clients** and auto-configures all detected tools with a single command.
+git-courer supports **5 MCP clients** and auto-configures all detected tools with a single command.
 
 ## Supported Clients
 
@@ -8,15 +8,6 @@ git-courer supports **14 MCP clients** and auto-configures all detected tools wi
 |--------|--------|----------|---------------|
 | OpenCode | ✓ | Linux, macOS, Windows | Object (`mcp`) |
 | Claude Code | ✓ | Linux, macOS, Windows | Object (`mcpServers`) |
-| Cursor | ✓ | Linux, macOS, Windows | Object (`mcpServers`) |
-| Windsurf | ✓ | Linux, macOS, Windows | Object (`mcpServers`) |
-| Cline | ✓ | Linux, macOS, Windows | Object (`mcpServers`) |
-| Roo Code | ✓ | Linux, macOS, Windows | Object (`mcpServers`) |
-| Continue | ✓ | Linux, macOS, Windows | **Array** (`mcpServers`) |
-| VS Code | ✓ | Linux, macOS, Windows | Object (`servers`) |
-| Zed | ✓ | Linux, macOS, Windows | Object (`mcpServers`) |
-| Gemini CLI | ✓ | Linux, macOS, Windows | Object (`mcpServers`) |
-| Claude Desktop | ✓ | macOS, Windows only | Object (`mcpServers`) |
 | Codex | ✓ | Linux, macOS, Windows | Object (`mcpServers`) |
 | pi | ✓ | Linux, macOS, Windows | Object (`mcpServers`) |
 | Antigravity | ✓ | Linux, macOS, Windows | Object (`mcpServers`) |
@@ -26,7 +17,7 @@ git-courer supports **14 MCP clients** and auto-configures all detected tools wi
 ```bash
 git-courer mcp setup
 # ✓ OpenCode configured
-# ✓ Cursor configured
+# ✓ Codex configured
 # ...
 ```
 
@@ -34,7 +25,7 @@ git-courer mcp setup
 
 ```bash
 git-courer mcp setup opencode
-git-courer mcp setup cursor
+git-courer mcp setup codex
 git-courer mcp setup claude-code
 ```
 
@@ -65,31 +56,6 @@ git-courer mcp setup claude-code
 }
 ```
 
-### Continue Format (Array)
-```json
-{
-  "mcpServers": [
-    {
-      "name": "git-courer",
-      "command": "/usr/.local/bin/git-courer",
-      "args": ["mcp"]
-    }
-  ]
-}
-```
-
-### VS Code Format
-```json
-{
-  "servers": {
-    "git-courer": {
-      "command": "/usr/.local/bin/git-courer",
-      "args": ["mcp"]
-    }
-  }
-}
-```
-
 ## Detection Rules
 
 git-courer detects a client if:
@@ -105,8 +71,6 @@ git-courer mcp setup <client>
 
 If your AI tool supports MCP and isn't listed, open an issue. Adding a new client is usually **5 lines of code** — just define the config format and paths.
 
-## Client not detecting on Linux?
-
-Some clients (like Claude Desktop) are **macOS/Windows only** and don't have Linux support yet.
+## Client not detecting?
 
 For desktop apps installed via Flatpak/Snap, the config paths may differ. Check the client's documentation for the MCP config location.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -25,8 +25,8 @@ cat ~/.config/opencode/opencode.json
 # For Claude Code
 cat ~/.claude.json
 
-# For Cursor
-cat ~/.cursor/mcp.json
+# For Codex
+cat ~/.codex/config.toml
 ```
 
 You should see a `"git-courer"` entry. If not, run:
@@ -37,10 +37,9 @@ git-courer mcp setup
 **Check 3: Does the tool support MCP?**
 - OpenCode: ✓ Native support
 - Claude Code: ✓ Native support
-- Cursor: ✓ Native support
-- Windsurf: ✓ Native support
-- VS Code (Cline): ✓ Via extension
-- Claude Desktop: ✓ Only on macOS/Windows
+- Codex: ✓ Native support
+- pi: ✓ Native support
+- Antigravity: ✓ Native support
 
 ## Ollama is not running / commit messages fail
 
@@ -142,16 +141,9 @@ What git-courer saves: the 500–2,000 tokens × every automatic git operation y
 |------|-------------|
 | OpenCode | `~/.config/opencode/opencode.json` |
 | Claude Code | `~/.claude.json` or `./.claude.json` |
-| Cursor | `~/.cursor/mcp.json` |
-| Windsurf | `~/.codeium/windsurf/mcp_config.json` |
-| Cline | `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` |
-| Roo Code | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/cline_mcp_settings.json` |
-| Continue | `~/.continue/config.json` |
-| VS Code | `~/.config/Code/User/mcp.json` |
-| Zed | `~/.config/zed/settings.json` |
 | Codex | `~/.codex/config.toml` |
-| Claude Desktop | `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) |
-| Gemini CLI | `~/.gemini/settings.json` |
+| pi | `~/.pi/agent/mcp.json` |
+| Antigravity | `~/.gemini/antigravity-cli/mcp_config.json` |
 
 ## Still having issues?
 

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -76,12 +76,8 @@ func TestMCPClients_AllHaveRequiredFields(t *testing.T) {
 		if c.Detect == nil {
 			t.Errorf("client %q has nil Detect", c.Name)
 		}
-		// claude-desktop and some clients only support specific OSes (darwin/windows),
-		// so paths may be nil on Linux — that's expected behavior.
-		if len(c.Paths) == 0 && runtime.GOOS == "linux" && c.Name != "claude-desktop" {
-			t.Errorf("client %q has no config paths on linux", c.Name)
-		}
-		if len(c.Paths) == 0 && runtime.GOOS != "linux" {
+		// All remaining clients support Linux, so paths must be non-empty on every OS.
+		if len(c.Paths) == 0 {
 			t.Errorf("client %q has no config paths on %s", c.Name, runtime.GOOS)
 		}
 	}
@@ -114,17 +110,6 @@ func TestMCPClients_ConfigFn_OpenCode(t *testing.T) {
 	}
 	if entry["enabled"] != true {
 		t.Errorf("enabled: got %v, want true", entry["enabled"])
-	}
-}
-
-func TestMCPClients_ConfigFn_Continue_ArrayFormat(t *testing.T) {
-	client := findClient(t, "continue")
-	if !client.IsArray {
-		t.Error("continue client should have IsArray=true")
-	}
-	entry := client.ConfigFn("/usr/local/bin/git-courer")
-	if entry["name"] != "git-courer" {
-		t.Errorf("name: got %v, want 'git-courer'", entry["name"])
 	}
 }
 
@@ -653,54 +638,6 @@ func TestPiPostInstallNotice(t *testing.T) {
 	}
 }
 
-func TestMCPClients_ConfigFn_Antigravity(t *testing.T) {
-	binPath := "/usr/local/bin/git-courer"
-
-	var cliClient, ideClient *MCPClient
-	for _, c := range MCPClients() {
-		if c.Name == "antigravity" {
-			if len(c.Paths) > 0 && strings.Contains(c.Paths[0], "antigravity-cli") {
-				cliClient = c
-			} else if len(c.Paths) > 0 && strings.Contains(c.Paths[0], "antigravity-ide") {
-				ideClient = c
-			}
-		}
-	}
-
-	if cliClient == nil {
-		t.Fatal("Antigravity CLI client not found")
-	}
-	if ideClient == nil {
-		t.Fatal("Antigravity IDE client not found")
-	}
-
-	// CLI
-	entryCLI := cliClient.ConfigFn(binPath)
-	if entryCLI["command"] != binPath {
-		t.Errorf("CLI command: got %v, want %q", entryCLI["command"], binPath)
-	}
-	argsCLI, ok := entryCLI["args"].([]string)
-	if !ok {
-		t.Fatalf("CLI args is not []string: %T", entryCLI["args"])
-	}
-	if len(argsCLI) != 1 || argsCLI[0] != "mcp" {
-		t.Errorf("CLI args: got %v, want [mcp]", argsCLI)
-	}
-
-	// IDE
-	entryIDE := ideClient.ConfigFn(binPath)
-	if entryIDE["command"] != binPath {
-		t.Errorf("IDE command: got %v, want %q", entryIDE["command"], binPath)
-	}
-	argsIDE, ok := entryIDE["args"].([]string)
-	if !ok {
-		t.Fatalf("IDE args is not []string: %T", entryIDE["args"])
-	}
-	if len(argsIDE) != 1 || argsIDE[0] != "mcp" {
-		t.Errorf("IDE args: got %v, want [mcp]", argsIDE)
-	}
-}
-
 func TestDetect_AntigravityCLI(t *testing.T) {
 	oldLookPath := lookPath
 	defer func() {
@@ -733,146 +670,11 @@ func TestDetect_AntigravityCLI(t *testing.T) {
 				return "", os.ErrNotExist
 			}
 
-			var cliClient *MCPClient
-			for _, c := range MCPClients() {
-				if c.Name == "antigravity" && len(c.Paths) > 0 && strings.Contains(c.Paths[0], "antigravity-cli") {
-					cliClient = c
-					break
-				}
-			}
-			if cliClient == nil {
-				t.Fatal("Antigravity CLI client not found in MCPClients()")
-			}
-
-			got := cliClient.Detect()
+			client := findClient(t, "antigravity")
+			got := client.Detect()
 			if got != tc.wantDetect {
 				t.Errorf("Detect() = %v, want %v", got, tc.wantDetect)
 			}
 		})
-	}
-}
-
-func TestDetect_AntigravityIDE(t *testing.T) {
-	oldLookPath := lookPath
-	oldOSStat := osStat
-	defer func() {
-		lookPath = oldLookPath
-		osStat = oldOSStat
-	}()
-
-	tests := []struct {
-		name        string
-		lookPathErr error
-		osStatErr   error
-		wantDetect  bool
-	}{
-		{
-			name:        "antigravity in PATH",
-			lookPathErr: nil,
-			osStatErr:   os.ErrNotExist,
-			wantDetect:  true,
-		},
-		{
-			name:        "antigravity ide dir exists",
-			lookPathErr: os.ErrNotExist,
-			osStatErr:   nil,
-			wantDetect:  true,
-		},
-		{
-			name:        "both exist",
-			lookPathErr: nil,
-			osStatErr:   nil,
-			wantDetect:  true,
-		},
-		{
-			name:        "neither exists",
-			lookPathErr: os.ErrNotExist,
-			osStatErr:   os.ErrNotExist,
-			wantDetect:  false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			lookPath = func(file string) (string, error) {
-				if file == "antigravity" {
-					return "/bin/antigravity", tc.lookPathErr
-				}
-				return "", os.ErrNotExist
-			}
-			osStat = func(name string) (os.FileInfo, error) {
-				if strings.Contains(name, filepath.Join(".gemini", "antigravity-ide")) {
-					return nil, tc.osStatErr
-				}
-				return nil, os.ErrNotExist
-			}
-
-			var ideClient *MCPClient
-			for _, c := range MCPClients() {
-				if c.Name == "antigravity" && len(c.Paths) > 0 && strings.Contains(c.Paths[0], "antigravity-ide") {
-					ideClient = c
-					break
-				}
-			}
-			if ideClient == nil {
-				t.Fatal("Antigravity IDE client not found in MCPClients()")
-			}
-
-			got := ideClient.Detect()
-			if got != tc.wantDetect {
-				t.Errorf("Detect() = %v, want %v", got, tc.wantDetect)
-			}
-		})
-	}
-}
-
-func TestSetupClient_Antigravity_DuplicateName(t *testing.T) {
-	oldHomeDirFn := homeDirFn
-	oldLookPath := lookPath
-	oldOSStat := osStat
-	defer func() {
-		homeDirFn = oldHomeDirFn
-		lookPath = oldLookPath
-		osStat = oldOSStat
-	}()
-
-	tempHome := t.TempDir()
-	homeDirFn = func() string { return tempHome }
-
-	// Mock so both CLI (agy) and IDE (antigravity) are detected
-	lookPath = func(file string) (string, error) {
-		if file == "agy" || file == "antigravity" {
-			return "/bin/" + file, nil
-		}
-		return "", os.ErrNotExist
-	}
-	osStat = func(name string) (os.FileInfo, error) {
-		return nil, nil // succeed for any stat call
-	}
-
-	binPath := "/usr/local/bin/git-courer"
-	err := SetupClient("antigravity", binPath)
-	if err != nil {
-		t.Fatalf("SetupClient(\"antigravity\") failed: %v", err)
-	}
-
-	// Verify both configs were created and contain git-courer
-	cliConfigPath := filepath.Join(tempHome, ".gemini/antigravity-cli/mcp_config.json")
-	ideConfigPath := filepath.Join(tempHome, ".gemini/antigravity-ide/mcp_config.json")
-
-	cliData, err := os.ReadFile(cliConfigPath)
-	if err != nil {
-		t.Fatalf("Failed to read CLI config: %v", err)
-	}
-	if !containsGitCourer(string(cliData)) {
-		t.Errorf("CLI config does not contain git-courer: %s", cliData)
-	}
-
-	ideData, err := os.ReadFile(ideConfigPath)
-	if err != nil {
-		t.Fatalf("Failed to read IDE config: %v", err)
-	}
-	if !containsGitCourer(string(ideData)) {
-		t.Errorf("IDE config does not contain git-courer: %s", ideData)
 	}
 }

--- a/internal/installer/mcp_config.go
+++ b/internal/installer/mcp_config.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
-	"runtime"
 	"strings"
 )
 
@@ -50,7 +49,6 @@ func DetectClients() []*MCPClient {
 // MCPClients returns all supported MCP clients.
 func MCPClients() []*MCPClient {
 	home := homeDirFn()
-	osName := runtime.GOOS
 
 	return []*MCPClient{
 		{
@@ -95,119 +93,6 @@ func MCPClients() []*MCPClient {
 			},
 		},
 		{
-			Name:     "cursor",
-			Filename: "mcp.json",
-			RootKey:  "mcpServers",
-			ConfigFn: func(binPath string) map[string]interface{} {
-				return map[string]interface{}{
-					"command": binPath,
-					"args":    []string{"mcp"},
-				}
-			},
-			Paths: []string{
-				filepath.Join(home, ".cursor/mcp.json"),
-			},
-			Detect: func() bool {
-				if _, err := exec.LookPath("cursor"); err == nil {
-					return true
-				}
-				_, err := os.Stat(filepath.Join(home, ".cursor"))
-				return err == nil
-			},
-		},
-		{
-			Name:     "windsurf",
-			Filename: "mcp_config.json",
-			RootKey:  "mcpServers",
-			ConfigFn: func(binPath string) map[string]interface{} {
-				return map[string]interface{}{
-					"command": binPath,
-					"args":    []string{"mcp"},
-				}
-			},
-			Paths: []string{
-				filepath.Join(home, ".codeium/windsurf/mcp_config.json"),
-			},
-			Detect: func() bool {
-				// Check for windsurf directory
-				_, err := os.Stat(filepath.Join(home, ".codeium/windsurf"))
-				return err == nil
-			},
-		},
-		{
-			Name:     "cline",
-			Filename: "cline_mcp_settings.json",
-			RootKey:  "mcpServers",
-			ConfigFn: func(binPath string) map[string]interface{} {
-				return map[string]interface{}{
-					"command": binPath,
-					"args":    []string{"mcp"},
-				}
-			},
-			Paths: clinePaths(),
-			Detect: func() bool {
-				switch osName {
-				case "darwin":
-					_, err := os.Stat(filepath.Join(home, "Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev"))
-					return err == nil
-				case "windows":
-					_, err := os.Stat(filepath.Join(os.Getenv("APPDATA"), "Code/User/globalStorage/saoudrizwan.claude-dev"))
-					return err == nil
-				default:
-					_, err := os.Stat(filepath.Join(home, ".config/Code/User/globalStorage/saoudrizwan.claude-dev"))
-					return err == nil
-				}
-			},
-		},
-		{
-			Name:     "continue",
-			Filename: "config.json",
-			RootKey:  "mcpServers",
-			IsArray:  true,
-			ConfigFn: func(binPath string) map[string]interface{} {
-				return map[string]interface{}{
-					"name":    "git-courer",
-					"command": binPath,
-					"args":    []string{"mcp"},
-				}
-			},
-			Paths: []string{
-				filepath.Join(home, ".continue/config.json"),
-			},
-			Detect: func() bool {
-				_, err := os.Stat(filepath.Join(home, ".continue"))
-				return err == nil
-			},
-		},
-		{
-			Name:     "vscode",
-			Filename: "mcp.json",
-			RootKey:  "servers",
-			ConfigFn: func(binPath string) map[string]interface{} {
-				return map[string]interface{}{
-					"command": binPath,
-					"args":    []string{"mcp"},
-				}
-			},
-			Paths: func() []string {
-				switch osName {
-				case "darwin":
-					return []string{filepath.Join(home, "Library/Application Support/Code/User/mcp.json")}
-				case "windows":
-					return []string{filepath.Join(os.Getenv("APPDATA"), "Code/User/mcp.json")}
-				default:
-					return []string{filepath.Join(home, ".config/Code/User/mcp.json")}
-				}
-			}(),
-			Detect: func() bool {
-				if _, err := exec.LookPath("code"); err == nil {
-					return true
-				}
-				_, err := exec.LookPath("code-insiders")
-				return err == nil
-			},
-		},
-		{
 			Name:     "codex",
 			Filename: "config.toml",
 			RootKey:  "mcpServers",
@@ -222,114 +107,6 @@ func MCPClients() []*MCPClient {
 			},
 			Detect: func() bool {
 				_, err := exec.LookPath("codex")
-				return err == nil
-			},
-		},
-		{
-			Name:     "zed",
-			Filename: "settings.json",
-			RootKey:  "mcpServers",
-			ConfigFn: func(binPath string) map[string]interface{} {
-				return map[string]interface{}{
-					"command": binPath,
-					"args":    []string{"mcp"},
-				}
-			},
-			Paths: func() []string {
-				switch osName {
-				case "darwin":
-					return []string{filepath.Join(home, "Library/Application Support/Zed/settings.json")}
-				case "windows":
-					return []string{filepath.Join(os.Getenv("APPDATA"), "Zed/settings.json")}
-				default:
-					return []string{filepath.Join(home, ".config/zed/settings.json")}
-				}
-			}(),
-			Detect: func() bool {
-				if _, err := exec.LookPath("zed"); err == nil {
-					return true
-				}
-				_, err := os.Stat(filepath.Join(home, ".config/zed"))
-				return err == nil
-			},
-		},
-		{
-			Name:     "claude-desktop",
-			Filename: "claude_desktop_config.json",
-			RootKey:  "mcpServers",
-			ConfigFn: func(binPath string) map[string]interface{} {
-				return map[string]interface{}{
-					"command": binPath,
-					"args":    []string{"mcp"},
-				}
-			},
-			Paths: func() []string {
-				switch osName {
-				case "darwin":
-					return []string{filepath.Join(home, "Library/Application Support/Claude/claude_desktop_config.json")}
-				case "windows":
-					return []string{filepath.Join(os.Getenv("APPDATA"), "Claude/claude_desktop_config.json")}
-				default:
-					return []string{}
-				}
-			}(),
-			Detect: func() bool {
-				switch osName {
-				case "darwin":
-					_, err := os.Stat(filepath.Join(home, "Library/Application Support/Claude"))
-					return err == nil
-				case "windows":
-					_, err := os.Stat(filepath.Join(os.Getenv("APPDATA"), "Claude"))
-					return err == nil
-				default:
-					return false
-				}
-			},
-		},
-		{
-			Name:     "roo-code",
-			Filename: "cline_mcp_settings.json",
-			RootKey:  "mcpServers",
-			ConfigFn: func(binPath string) map[string]interface{} {
-				return map[string]interface{}{
-					"command": binPath,
-					"args":    []string{"mcp"},
-				}
-			},
-			Paths: rooCodePaths(),
-			Detect: func() bool {
-				switch osName {
-				case "darwin":
-					_, err := os.Stat(filepath.Join(home, "Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline"))
-					return err == nil
-				case "windows":
-					_, err := os.Stat(filepath.Join(os.Getenv("APPDATA"), "Code/User/globalStorage/rooveterinaryinc.roo-cline"))
-					return err == nil
-				default:
-					_, err := os.Stat(filepath.Join(home, ".config/Code/User/globalStorage/rooveterinaryinc.roo-cline"))
-					return err == nil
-				}
-			},
-		},
-		// Gemini CLI support
-		{
-			Name:     "gemini",
-			Filename: "settings.json",
-			RootKey:  "mcpServers",
-			ConfigFn: func(binPath string) map[string]interface{} {
-				return map[string]interface{}{
-					"command": binPath,
-					"args":    []string{"mcp"},
-				}
-			},
-			Paths: []string{
-				filepath.Join(home, ".gemini/settings.json"),
-			},
-			Detect: func() bool {
-				if _, err := exec.LookPath("gemini"); err == nil {
-					return true
-				}
-				_, err := os.Stat(filepath.Join(home, ".gemini"))
 				return err == nil
 			},
 		},
@@ -391,57 +168,12 @@ func MCPClients() []*MCPClient {
 				return err == nil
 			},
 		},
-		{
-			Name:     "antigravity",
-			Filename: "mcp_config.json",
-			RootKey:  "mcpServers",
-			ConfigFn: func(binPath string) map[string]interface{} {
-				return map[string]interface{}{
-					"command": binPath,
-					"args":    []string{"mcp"},
-				}
-			},
-			Paths: []string{
-				filepath.Join(home, ".gemini/antigravity-ide/mcp_config.json"),
-			},
-			Detect: func() bool {
-				if _, err := lookPath("antigravity"); err == nil {
-					return true
-				}
-				_, err := osStat(filepath.Join(home, ".gemini/antigravity-ide"))
-				return err == nil
-			},
-		},
 	}
 }
 
 func homeDir() string {
 	u, _ := user.Current()
 	return u.HomeDir
-}
-
-func clinePaths() []string {
-	home := homeDirFn()
-	switch runtime.GOOS {
-	case "darwin":
-		return []string{filepath.Join(home, "Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json")}
-	case "windows":
-		return []string{filepath.Join(os.Getenv("APPDATA"), "Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json")}
-	default:
-		return []string{filepath.Join(home, ".config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json")}
-	}
-}
-
-func rooCodePaths() []string {
-	home := homeDirFn()
-	switch runtime.GOOS {
-	case "darwin":
-		return []string{filepath.Join(home, "Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/cline_mcp_settings.json")}
-	case "windows":
-		return []string{filepath.Join(os.Getenv("APPDATA"), "Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/cline_mcp_settings.json")}
-	default:
-		return []string{filepath.Join(home, ".config/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/cline_mcp_settings.json")}
-	}
 }
 
 // ConfigureMCP configures git-courer for the given MCP client.

--- a/tui/screens/mcp_setup_test.go
+++ b/tui/screens/mcp_setup_test.go
@@ -32,8 +32,8 @@ func TestMCPSetupScreen_Dedup(t *testing.T) {
 			Detect: func() bool { return false }, // undetected pi
 		},
 		{
-			Name:   "cursor",
-			Detect: func() bool { return true }, // detected cursor
+			Name:   "codex",
+			Detect: func() bool { return true }, // detected codex
 		},
 	}
 
@@ -46,7 +46,7 @@ func TestMCPSetupScreen_Dedup(t *testing.T) {
 
 	// 3. Verify deduplication in items
 	items := screen.Items()
-	// Expected: unique names: "antigravity", "pi", "cursor"
+	// Expected: unique names: "antigravity", "pi", "codex"
 	if len(items) != 3 {
 		t.Fatalf("expected 3 items after deduplication, got %d: %+v", len(items), items)
 	}
@@ -71,12 +71,12 @@ func TestMCPSetupScreen_Dedup(t *testing.T) {
 		t.Error("pi should not be detected")
 	}
 
-	// Item 2: "cursor" (detected=true)
-	if items[2].Name != "cursor" {
-		t.Errorf("item 2 name: got %q, want %q", items[2].Name, "cursor")
+	// Item 2: "codex" (detected=true)
+	if items[2].Name != "codex" {
+		t.Errorf("item 2 name: got %q, want %q", items[2].Name, "codex")
 	}
 	if !items[2].Detected {
-		t.Error("cursor should be detected")
+		t.Error("codex should be detected")
 	}
 }
 
@@ -113,8 +113,8 @@ func TestMCPSetupScreen_ConfigureClients(t *testing.T) {
 			Detect: func() bool { return false }, // pi, not detected
 		},
 		{
-			Name:   "cursor",
-			Detect: func() bool { return true }, // cursor, detected
+			Name:   "codex",
+			Detect: func() bool { return true }, // codex, detected
 		},
 	}
 	getMCPClients = func() []*installer.MCPClient {
@@ -138,17 +138,17 @@ func TestMCPSetupScreen_ConfigureClients(t *testing.T) {
 
 	// We expect:
 	// - only the detected antigravity entry to be configured (since it was selected and detected)
-	// - cursor to be configured (since it was selected and detected)
+	// - codex to be configured (since it was selected and detected)
 	// - undetected antigravity IDE NOT to be configured
 	// - pi NOT to be configured (not selected, not detected)
 	if len(configured) != 2 {
 		t.Fatalf("expected 2 client configurations, got %d", len(configured))
 	}
 
-	// Verify the clients configured are CLI and cursor
+	// Verify the clients configured are CLI and codex
 	hasCli := false
 	hasIde := false
-	hasCursor := false
+	hasCodex := false
 	for _, c := range configured {
 		if c.Name == "antigravity" {
 			if c == mockClients[0] {
@@ -156,8 +156,8 @@ func TestMCPSetupScreen_ConfigureClients(t *testing.T) {
 			} else if c == mockClients[1] {
 				hasIde = true
 			}
-		} else if c.Name == "cursor" {
-			hasCursor = true
+		} else if c.Name == "codex" {
+			hasCodex = true
 		}
 	}
 
@@ -167,7 +167,7 @@ func TestMCPSetupScreen_ConfigureClients(t *testing.T) {
 	if hasIde {
 		t.Error("expected antigravity IDE not to be configured")
 	}
-	if !hasCursor {
-		t.Error("expected cursor to be configured")
+	if !hasCodex {
+		t.Error("expected codex to be configured")
 	}
 }


### PR DESCRIPTION
## Summary

Remove 10 IDE/obsolete client entries from `MCPClients()` as SDD 0 prerequisite for v2.6.0 Global Agent Policy. Only 5 CLI agents remain.

### Removed clients
cursor, windsurf, cline, continue, vscode, zed, claude-desktop, roo-code, gemini, antigravity-ide

### Kept CLI agents
opencode, claude-code, codex, pi, antigravity-cli

### Changes
- **`internal/installer/mcp_config.go`**: Removed 10 entries + dead `clinePaths()`/`rooCodePaths()` helpers
- **`internal/installer/installer_test.go`**: Removed 4 obsolete tests, simplified `TestDetect_AntigravityCLI`
- **`tui/screens/mcp_setup_test.go`**: Replaced `cursor` mock with `codex`
- **`README.md`**: Updated Supported Tools table (14→5), quick links, and examples
- **`docs/mcp-clients.md`**: Updated client count, table, and removed IDE format sections
- **`docs/troubleshooting.md`**: Updated Check 2/3 examples and config paths table

### Verification
- ✅ `go test ./internal/installer/...` — PASS
- ✅ `go test ./tui/screens/...` — PASS
- ✅ `go vet` — clean
- ✅ `MCPClients()` returns exactly 5 clients
- ✅ `SetupClient("cursor")` returns `"unknown client: cursor"`

Closes #155 (SDD 0)