### PR TITLE
feat: add shared infrastructure for v2.6.0 Global Agent Policy (SDD 1)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -73,6 +73,12 @@ func main() {
 	case "release":
 		runRelease(os.Args[2:])
 		return
+	case "hook-check":
+		runHookCheck(os.Args[2:])
+		return
+	case "doctor":
+		runDoctor()
+		return
 	case "--version", "-v":
 		fmt.Printf("git-courer v%s\n", config.ServerVersion)
 		return
@@ -108,6 +114,8 @@ func showHelp() {
 	fmt.Println("    apply                     # Create and push release tag")
 	fmt.Println("    abort                     # Discard pending release")
 	fmt.Println("    regenerate [--feedback]   # Revise changelog with feedback")
+	fmt.Println("  git-courer hook-check <cmd> # Classify a command (agent hook)")
+	fmt.Println("  git-courer doctor           # Diagnose MCP client health")
 	fmt.Println("  git-courer update           # Check for binary updates")
 	fmt.Println("  git-courer uninstall        # Remove git-courer")
 	fmt.Println("  git-courer version          # Show version")
@@ -308,6 +316,26 @@ func runRelease(args []string) {
 
 	cmd := cli.NewReleaseCommand(gitAdapter, llmAdapter, cfg, commitStore, ".")
 	if err := cmd.Run(args); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+// runHookCheck handles the hook-check subcommand for CLI usage.
+// It classifies a shell command and emits the result as JSON on stdout.
+func runHookCheck(args []string) {
+	cmd := cli.HookCheckCommand{}
+	if err := cmd.Run(args); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+// runDoctor handles the doctor subcommand for CLI usage.
+// It runs installer diagnostics and emits them as JSON on stdout.
+func runDoctor() {
+	cmd := cli.DoctorCommand{}
+	if err := cmd.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}

--- a/internal/classifier/gitcmd/classifier.go
+++ b/internal/classifier/gitcmd/classifier.go
@@ -1,0 +1,129 @@
+// Package gitcmd classifies shell commands to determine whether a git
+// subcommand should be redirected to the corresponding git-courer MCP tool.
+//
+// Classify is a pure function: it inspects the command string only and does
+// not touch the filesystem or execute anything. The returned Result tells
+// the hook-check adapter what to emit to the agent so it uses the safer,
+// structured MCP tool instead of raw git.
+package gitcmd
+
+import "strings"
+
+// Result is the outcome of classifying a command.
+//
+// Decision is one of:
+//   - "allow" — the command is safe to run as-is (non-git, maintenance, etc.)
+//   - "ask"   — the command is a git mutation/read the agent should run via
+//               the suggested MCP tool instead.
+//
+// MCPTool is the git-courer MCP tool name that should be used in place of the
+// raw git subcommand. It is empty when Decision is "allow".
+//
+// Reason is a human-readable explanation shown to the agent. For "ask"
+// decisions it follows the format "Use git-courer/{tool} instead of bash
+// git {subcommand}".
+type Result struct {
+	Command  string
+	Decision string
+	MCPTool  string
+	Reason   string
+}
+
+// mcpTools maps a git subcommand to the git-courer MCP tool that should be
+// used instead. Maintenance and informational commands are intentionally
+// absent — they are allowed directly by Classify.
+var mcpTools = map[string]string{
+	"status":       "status",
+	"diff":         "diff",
+	"commit":       "commit",
+	"log":          "history",
+	"branch":       "branch",
+	"merge":        "integrate",
+	"rebase":       "integrate",
+	"cherry-pick":  "integrate",
+	"revert":       "rewrite",
+	"reset":        "rewrite",
+	"stash":        "stash",
+	"push":         "sync",
+	"pull":         "sync",
+	"fetch":        "sync",
+	"show":         "history",
+	"blame":        "history",
+	"remote":       "sync",
+	"config":       "config",
+	"add":          "stage",
+	"restore":      "stage",
+	"clean":        "stage",
+	"rm":           "stage",
+	"mv":           "stage",
+	"switch":       "branch",
+	"checkout":     "branch",
+	"worktree":     "branch",
+	"shortlog":     "history",
+	"describe":     "history",
+	"reflog":       "history",
+	"notes":        "history",
+	"archive":      "history",
+}
+
+// allowedSubcommands are git subcommands with no MCP equivalent that are safe
+// to run directly (maintenance, informational, one-time setup).
+var allowedSubcommands = map[string]bool{
+	"gc":           true,
+	"fsck":         true,
+	"prune":        true,
+	"repack":       true,
+	"maintenance":  true,
+	"help":         true,
+	"version":      true,
+	"init":         true,
+	"clone":        true,
+}
+
+// Classify inspects a command string and returns a Result indicating whether
+// the agent should run it directly ("allow") or use the corresponding
+// git-courer MCP tool instead ("ask").
+//
+// Classify is a pure function — it has no side effects and is deterministic
+// for a given input.
+func Classify(command string) Result {
+	r := Result{Command: command, Decision: "allow"}
+
+	trimmed := strings.TrimSpace(command)
+	if trimmed == "" {
+		// Empty input — nothing to run, treat as allow.
+		return r
+	}
+
+	if !strings.HasPrefix(trimmed, "git") {
+		// Non-git command — allow.
+		return r
+	}
+
+	// Extract the subcommand token after "git".
+	fields := strings.Fields(trimmed)
+	if len(fields) <= 1 {
+		// Bare "git" (no subcommand) — prints help, allow.
+		return r
+	}
+
+	sub := fields[1]
+
+	if allowedSubcommands[sub] {
+		// Maintenance/informational — no MCP equivalent, allow.
+		return r
+	}
+
+	if tool, ok := mcpTools[sub]; ok {
+		r.Decision = "ask"
+		r.MCPTool = tool
+		r.Reason = "Use git-courer/" + tool + " instead of bash git " + sub
+		return r
+	}
+
+	// Unknown git subcommand — safe default is ask with a generic reason.
+	r.Decision = "ask"
+	r.MCPTool = ""
+	r.Reason = "Unknown git subcommand '" + sub + "' — check for a git-courer MCP tool before running raw git"
+	return r
+}

--- a/internal/classifier/gitcmd/classifier_test.go
+++ b/internal/classifier/gitcmd/classifier_test.go
@@ -1,0 +1,203 @@
+// Package gitcmd_test verifies the git command classifier behavior.
+package gitcmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestClassify_KnownGitSubcommands verifies each known git subcommand maps
+// to the expected MCP tool with decision "ask" and a reason that references
+// the suggested tool.
+func TestClassify_KnownGitSubcommands(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		command    string
+		wantTool   string
+		wantReason string
+	}{
+		{"status", "git status", "status", "git-courer/status"},
+		{"diff", "git diff", "diff", "git-courer/diff"},
+		{"commit", "git commit", "commit", "git-courer/commit"},
+		{"log", "git log", "history", "git-courer/history"},
+		{"branch", "git branch", "branch", "git-courer/branch"},
+		{"merge", "git merge", "integrate", "git-courer/integrate"},
+		{"rebase", "git rebase", "integrate", "git-courer/integrate"},
+		{"cherry-pick", "git cherry-pick", "integrate", "git-courer/integrate"},
+		{"revert", "git revert", "rewrite", "git-courer/rewrite"},
+		{"reset", "git reset", "rewrite", "git-courer/rewrite"},
+		{"stash", "git stash", "stash", "git-courer/stash"},
+		{"push", "git push", "sync", "git-courer/sync"},
+		{"pull", "git pull", "sync", "git-courer/sync"},
+		{"fetch", "git fetch", "sync", "git-courer/sync"},
+		{"show", "git show", "history", "git-courer/history"},
+		{"blame", "git blame", "history", "git-courer/history"},
+		{"remote", "git remote", "sync", "git-courer/sync"},
+		{"config", "git config", "config", "git-courer/config"},
+		{"add", "git add", "stage", "git-courer/stage"},
+		{"restore", "git restore", "stage", "git-courer/stage"},
+		{"clean", "git clean", "stage", "git-courer/stage"},
+		{"rm", "git rm", "stage", "git-courer/stage"},
+		{"mv", "git mv", "stage", "git-courer/stage"},
+		{"switch", "git switch", "branch", "git-courer/branch"},
+		{"checkout", "git checkout", "branch", "git-courer/branch"},
+		{"worktree", "git worktree", "branch", "git-courer/branch"},
+		{"shortlog", "git shortlog", "history", "git-courer/history"},
+		{"describe", "git describe", "history", "git-courer/history"},
+		{"reflog", "git reflog", "history", "git-courer/history"},
+		{"notes", "git notes", "history", "git-courer/history"},
+		{"archive", "git archive", "history", "git-courer/history"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := Classify(tt.command)
+			if r.Command != tt.command {
+				t.Errorf("Command: got %q, want %q", r.Command, tt.command)
+			}
+			if r.Decision != "ask" {
+				t.Errorf("Decision: got %q, want %q", r.Decision, "ask")
+			}
+			if r.MCPTool != tt.wantTool {
+				t.Errorf("MCPTool: got %q, want %q", r.MCPTool, tt.wantTool)
+			}
+			if r.Reason == "" {
+				t.Error("Reason is empty — expected a non-empty reason")
+			}
+			if !strings.Contains(r.Reason, tt.wantReason) {
+				t.Errorf("Reason: got %q, want it to contain %q", r.Reason, tt.wantReason)
+			}
+		})
+	}
+}
+
+// TestClassify_MaintenanceCommands verifies maintenance/info commands that
+// have no MCP equivalent are allowed directly.
+func TestClassify_MaintenanceCommands(t *testing.T) {
+	t.Parallel()
+
+	commands := []string{
+		"git gc",
+		"git fsck",
+		"git prune",
+		"git repack",
+		"git maintenance",
+		"git help",
+		"git version",
+		"git init",
+		"git clone",
+	}
+
+	for _, cmd := range commands {
+		t.Run(cmd, func(t *testing.T) {
+			r := Classify(cmd)
+			if r.Decision != "allow" {
+				t.Errorf("Decision: got %q, want allow", r.Decision)
+			}
+			if r.MCPTool != "" {
+				t.Errorf("MCPTool: got %q, want empty (no MCP equivalent)", r.MCPTool)
+			}
+			if r.Reason != "" {
+				t.Errorf("Reason: got %q, want empty for allow", r.Reason)
+			}
+		})
+	}
+}
+
+// TestClassify_NonGitCommands verifies non-git commands are allowed.
+func TestClassify_NonGitCommands(t *testing.T) {
+	t.Parallel()
+
+	commands := []string{
+		"ls -la",
+		"echo hello",
+		"npm install",
+		"go test ./...",
+		"cat file.txt",
+		"grep pattern file",
+	}
+
+	for _, cmd := range commands {
+		t.Run(cmd, func(t *testing.T) {
+			r := Classify(cmd)
+			if r.Command != cmd {
+				t.Errorf("Command: got %q, want %q", r.Command, cmd)
+			}
+			if r.Decision != "allow" {
+				t.Errorf("Decision: got %q, want allow", r.Decision)
+			}
+			if r.MCPTool != "" {
+				t.Errorf("MCPTool: got %q, want empty", r.MCPTool)
+			}
+			if r.Reason != "" {
+				t.Errorf("Reason: got %q, want empty for non-git allow", r.Reason)
+			}
+		})
+	}
+}
+
+// TestClassify_UnknownGitSubcommand verifies an unknown git subcommand
+// falls back to ask with a generic reason.
+func TestClassify_UnknownGitSubcommand(t *testing.T) {
+	t.Parallel()
+
+	r := Classify("git totally-made-up")
+	if r.Command != "git totally-made-up" {
+		t.Errorf("Command: got %q, want %q", r.Command, "git totally-made-up")
+	}
+	if r.Decision != "ask" {
+		t.Errorf("Decision: got %q, want ask", r.Decision)
+	}
+	if r.MCPTool != "" {
+		t.Errorf("MCPTool: got %q, want empty for unknown subcommand", r.MCPTool)
+	}
+	if r.Reason == "" {
+		t.Error("Reason is empty — expected a generic reason for unknown git subcommand")
+	}
+}
+
+// TestClassify_EmptyInput verifies empty input is treated as non-git (allow).
+func TestClassify_EmptyInput(t *testing.T) {
+	t.Parallel()
+
+	r := Classify("")
+	if r.Command != "" {
+		t.Errorf("Command: got %q, want empty", r.Command)
+	}
+	if r.Decision != "allow" {
+		t.Errorf("Decision: got %q, want allow", r.Decision)
+	}
+	if r.MCPTool != "" {
+		t.Errorf("MCPTool: got %q, want empty", r.MCPTool)
+	}
+	if r.Reason != "" {
+		t.Errorf("Reason: got %q, want empty", r.Reason)
+	}
+}
+
+// TestClassify_GitWithSubcommandArgs verifies the classifier extracts the
+// subcommand correctly even when extra arguments follow.
+func TestClassify_GitWithSubcommandArgs(t *testing.T) {
+	t.Parallel()
+
+	r := Classify("git status --short --branch")
+	if r.Decision != "ask" {
+		t.Errorf("Decision: got %q, want ask", r.Decision)
+	}
+	if r.MCPTool != "status" {
+		t.Errorf("MCPTool: got %q, want status", r.MCPTool)
+	}
+}
+
+// TestClassify_BareGit verifies a bare "git" with no subcommand is allowed
+// (no mutation risk — usually a help printout).
+func TestClassify_BareGit(t *testing.T) {
+	t.Parallel()
+
+	r := Classify("git")
+	if r.Decision != "allow" {
+		t.Errorf("Decision: got %q, want allow (bare git prints help)", r.Decision)
+	}
+}

--- a/internal/delivery/cli/doctor.go
+++ b/internal/delivery/cli/doctor.go
@@ -1,0 +1,57 @@
+// Package cli provides CLI delivery adapters for git-courer subcommands.
+//
+// This file implements the doctor subcommand: a thin adapter that runs the
+// installer's RunDoctor diagnostics and prints a human-readable report so the
+// user can see the health of every detected MCP client at a glance.
+package cli
+
+import (
+	"fmt"
+
+	"github.com/blak0p/git-courer/internal/installer"
+)
+
+// doctorFn is the function DoctorCommand.Run calls to obtain diagnostics.
+// It is a package-level variable so tests can stub it without depending on
+// real client detection.
+var doctorFn = installer.RunDoctor
+
+// DoctorCommand implements the doctor CLI subcommand.
+//
+// It runs the installer diagnostics and prints a human-readable report to
+// stdout. All diagnostic logic lives in the installer package.
+type DoctorCommand struct{}
+
+// Run prints a human-readable doctor report on stdout.
+func (c DoctorCommand) Run() error {
+	diagnostics := doctorFn()
+
+	if len(diagnostics) == 0 {
+		fmt.Println("No MCP clients detected.")
+		return nil
+	}
+
+	for _, d := range diagnostics {
+		fmt.Printf("=== %s ===\n", d.ClientName)
+		fmt.Printf("  Config: %s\n", d.ConfigPath)
+		fmt.Printf("  MCP configured:       %s\n", statusLabel(d.MCPConfigured))
+		fmt.Printf("  GIT_COURER.md present: %s\n", statusLabel(d.GitCourerMdPresent))
+		fmt.Printf("  Hooks installed:       %s\n", hooksLabel(d.HooksStatus))
+		fmt.Println()
+	}
+	return nil
+}
+
+func statusLabel(ok bool) string {
+	if ok {
+		return "yes"
+	}
+	return "no"
+}
+
+func hooksLabel(status string) string {
+	if status == "not_implemented" {
+		return "pending (SDDs 2-5)"
+	}
+	return status
+}

--- a/internal/delivery/cli/doctor_test.go
+++ b/internal/delivery/cli/doctor_test.go
@@ -1,0 +1,105 @@
+// Package cli_test verifies the doctor CLI adapter.
+package cli
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/blak0p/git-courer/internal/installer"
+)
+
+// TestDoctorRun_PrintsDiagnostics verifies DoctorCommand.Run prints a
+// human-readable report with client name, config path, and status fields.
+func TestDoctorRun_PrintsDiagnostics(t *testing.T) {
+	cmd := DoctorCommand{}
+
+	// Mock the doctorFn so we don't depend on real client detection.
+	originalDoctorFn := doctorFn
+	defer func() { doctorFn = originalDoctorFn }()
+	doctorFn = func() []installer.ClientDiagnostic {
+		return []installer.ClientDiagnostic{
+			{
+				ClientName:         "test-client",
+				ConfigPath:         "/tmp/config.json",
+				MCPConfigured:      true,
+				GitCourerMdPresent: true,
+				HooksStatus:        "not_implemented",
+			},
+		}
+	}
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	err = cmd.Run()
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, copyErr := buf.ReadFrom(r); copyErr != nil {
+		t.Fatalf("read pipe: %v", copyErr)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "test-client") {
+		t.Errorf("output missing client name %q\noutput: %s", "test-client", output)
+	}
+	if !strings.Contains(output, "/tmp/config.json") {
+		t.Errorf("output missing config path %q\noutput: %s", "/tmp/config.json", output)
+	}
+	if !strings.Contains(output, "yes") {
+		t.Errorf("output missing 'yes' status markers\noutput: %s", output)
+	}
+	if !strings.Contains(output, "pending (SDDs 2-5)") {
+		t.Errorf("output missing hooks status\noutput: %s", output)
+	}
+}
+
+// TestDoctorRun_NoClients verifies DoctorCommand.Run prints a friendly message
+// when no clients are detected (not an error).
+func TestDoctorRun_NoClients(t *testing.T) {
+	cmd := DoctorCommand{}
+
+	originalDoctorFn := doctorFn
+	defer func() { doctorFn = originalDoctorFn }()
+	doctorFn = func() []installer.ClientDiagnostic {
+		return nil
+	}
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	err = cmd.Run()
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, copyErr := buf.ReadFrom(r); copyErr != nil {
+		t.Fatalf("read pipe: %v", copyErr)
+	}
+
+	output := strings.TrimSpace(buf.String())
+	if !strings.Contains(output, "No MCP clients detected") {
+		t.Errorf("expected friendly message, got: %q", output)
+	}
+}

--- a/internal/delivery/cli/hook_check.go
+++ b/internal/delivery/cli/hook_check.go
@@ -1,0 +1,42 @@
+// Package cli provides CLI delivery adapters for git-courer subcommands.
+//
+// This file implements the hook-check subcommand: a thin adapter that
+// classifies a shell command via the gitcmd classifier and emits the Result
+// as JSON on stdout so the calling agent can decide which tool to use.
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/blak0p/git-courer/internal/classifier/gitcmd"
+)
+
+// HookCheckCommand implements the hook-check CLI subcommand.
+//
+// It receives the shell command the agent is about to run, classifies it via
+// gitcmd.Classify, and prints the classification Result as JSON to stdout.
+// This is a thin adapter — all classification logic lives in the gitcmd
+// package so it can be unit-tested independently.
+type HookCheckCommand struct{}
+
+// Run classifies args[0] and emits the Result as JSON on stdout.
+// It returns an error if no command argument was provided.
+func (c HookCheckCommand) Run(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("usage: git-courer hook-check <command>")
+	}
+	command := args[0]
+	if command == "" {
+		return fmt.Errorf("usage: git-courer hook-check <command>")
+	}
+
+	result := gitcmd.Classify(command)
+
+	// Emit as JSON — consistent with existing delivery patterns.
+	if err := json.NewEncoder(os.Stdout).Encode(result); err != nil {
+		return fmt.Errorf("hook-check: failed to encode result: %w", err)
+	}
+	return nil
+}

--- a/internal/delivery/cli/hook_check_test.go
+++ b/internal/delivery/cli/hook_check_test.go
@@ -1,0 +1,117 @@
+// Package cli_test verifies the hook-check CLI adapter.
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+// TestHookCheckRun_GitCommand verifies a git command is classified and the
+// Result is emitted as JSON on stdout.
+func TestHookCheckRun_GitCommand(t *testing.T) {
+	cmd := HookCheckCommand{}
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	err = cmd.Run([]string{"git status"})
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, copyErr := buf.ReadFrom(r); copyErr != nil {
+		t.Fatalf("read pipe: %v", copyErr)
+	}
+
+	var result map[string]string
+	if jsonErr := json.Unmarshal(buf.Bytes(), &result); jsonErr != nil {
+		t.Fatalf("stdout is not valid JSON: %v\noutput: %q", jsonErr, buf.String())
+	}
+
+	if result["Command"] != "git status" {
+		t.Errorf("Command: got %q, want %q", result["Command"], "git status")
+	}
+	if result["Decision"] != "ask" {
+		t.Errorf("Decision: got %q, want %q", result["Decision"], "ask")
+	}
+	if result["MCPTool"] != "status" {
+		t.Errorf("MCPTool: got %q, want %q", result["MCPTool"], "status")
+	}
+	if result["Reason"] == "" {
+		t.Error("Reason is empty — expected non-empty reason")
+	}
+}
+
+// TestHookCheckRun_NonGitCommand verifies a non-git command is classified as
+// allow and emitted as JSON on stdout.
+func TestHookCheckRun_NonGitCommand(t *testing.T) {
+	cmd := HookCheckCommand{}
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	err = cmd.Run([]string{"ls -la"})
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, copyErr := buf.ReadFrom(r); copyErr != nil {
+		t.Fatalf("read pipe: %v", copyErr)
+	}
+
+	var result map[string]string
+	if jsonErr := json.Unmarshal(buf.Bytes(), &result); jsonErr != nil {
+		t.Fatalf("stdout is not valid JSON: %v\noutput: %q", jsonErr, buf.String())
+	}
+
+	if result["Command"] != "ls -la" {
+		t.Errorf("Command: got %q, want %q", result["Command"], "ls -la")
+	}
+	if result["Decision"] != "allow" {
+		t.Errorf("Decision: got %q, want %q", result["Decision"], "allow")
+	}
+	if result["MCPTool"] != "" {
+		t.Errorf("MCPTool: got %q, want empty", result["MCPTool"])
+	}
+}
+
+// TestHookCheckRun_NoArgs verifies Run returns an error when no args provided.
+func TestHookCheckRun_NoArgs(t *testing.T) {
+	cmd := HookCheckCommand{}
+
+	err := cmd.Run([]string{})
+	if err == nil {
+		t.Fatal("expected error when no args provided, got nil")
+	}
+}
+
+// TestHookCheckRun_EmptyArg verifies Run returns an error when the single
+// argument is empty (nothing to classify).
+func TestHookCheckRun_EmptyArg(t *testing.T) {
+	cmd := HookCheckCommand{}
+
+	err := cmd.Run([]string{""})
+	if err == nil {
+		t.Fatal("expected error when arg is empty, got nil")
+	}
+}

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 const (
@@ -20,6 +21,27 @@ const (
 	// PostInstallEnv is the env var that triggers post-install setup.
 	PostInstallEnv = "GIT_COURER_POSTINSTALL"
 )
+
+// statusNotImplemented is the HooksStatus value used while the hook
+// installation is still a stub (SDDs 2-5 fill in the real implementation).
+const statusNotImplemented = "not_implemented"
+
+// ClientDiagnostic is the per-client diagnostic returned by RunDoctor.
+//
+// Fields:
+//   - ClientName: the MCP client name (e.g. "claude-code").
+//   - ConfigPath: the resolved config file path.
+//   - MCPConfigured: true if the config file exists and contains git-courer.
+//   - GitCourerMdPresent: true if GIT_COURER.md exists in the config directory.
+//   - HooksStatus: the hook installation status — "not_implemented" until
+//     SDDs 2-5 land the real hook installation logic.
+type ClientDiagnostic struct {
+	ClientName         string
+	ConfigPath         string
+	MCPConfigured      bool
+	GitCourerMdPresent bool
+	HooksStatus        string
+}
 
 // RunPostInstall runs setup after go install.
 // Called when GIT_COURER_POSTINSTALL=1 is set.
@@ -53,6 +75,18 @@ func RunPostInstall() error {
 func RunUninstall() error {
 	fmt.Println("Uninstalling git-courer...")
 
+	// Restore .bak backups for each detected agent's config before removing.
+	for _, client := range DetectClients() {
+		configPath := client.Paths[0]
+		for _, path := range client.Paths {
+			if _, err := os.Stat(path); err == nil {
+				configPath = path
+				break
+			}
+		}
+		restoreBackup(configPath)
+	}
+
 	// Remove binary
 	binPath, err := FindBinaryPath()
 	if err != nil {
@@ -74,6 +108,59 @@ func RunUninstall() error {
 	// Remove MCP configs - TODO: ask user or remove all
 	fmt.Println("\n✓ git-courer uninstalled!")
 	return nil
+}
+
+// restoreBackup restores configPath + ".bak" over configPath if a backup
+// exists, then removes the backup. Silently no-ops if no backup exists.
+func restoreBackup(configPath string) {
+	bakPath := configPath + ".bak"
+	data, err := os.ReadFile(bakPath)
+	if err != nil {
+		return // no backup — nothing to restore
+	}
+	if err := os.WriteFile(configPath, data, 0644); err == nil {
+		fmt.Printf("  ✓ Restored backup: %s\n", configPath)
+		_ = os.Remove(bakPath)
+	}
+}
+
+// RunDoctor inspects each detected MCP client and reports diagnostic state:
+// whether the MCP config exists and contains git-courer, whether
+// GIT_COURER.md exists, and the hook installation status (stub until SDDs 2-5).
+//
+// It returns one ClientDiagnostic per detected client.
+func RunDoctor() []ClientDiagnostic {
+	clients := DetectClients()
+	diagnostics := make([]ClientDiagnostic, 0, len(clients))
+
+	for _, client := range clients {
+		configPath := client.Paths[0]
+		for _, path := range client.Paths {
+			if _, err := os.Stat(path); err == nil {
+				configPath = path
+				break
+			}
+		}
+
+		d := ClientDiagnostic{
+			ClientName:  client.Name,
+			ConfigPath:  configPath,
+			HooksStatus: statusNotImplemented,
+		}
+
+		if data, err := os.ReadFile(configPath); err == nil {
+			d.MCPConfigured = strings.Contains(string(data), "git-courer")
+		}
+
+		rulesPath := filepath.Join(filepath.Dir(configPath), gitCourerMdFilename)
+		if _, err := os.Stat(rulesPath); err == nil {
+			d.GitCourerMdPresent = true
+		}
+
+		diagnostics = append(diagnostics, d)
+	}
+
+	return diagnostics
 }
 
 // RunUpdate checks for and applies updates.

--- a/internal/installer/mcp_config.go
+++ b/internal/installer/mcp_config.go
@@ -9,7 +9,45 @@ import (
 	"os/user"
 	"path/filepath"
 	"strings"
+
+	"github.com/blak0p/git-courer/internal/delivery/mcp/descriptions"
 )
+
+// gitCourerMdFilename is the golden-rules file written alongside each MCP
+// client config so agents always see the status/diff/pr-review workflow.
+const gitCourerMdFilename = "GIT_COURER.md"
+
+// gitCourerMdContent is the content written to GIT_COURER.md during MCP
+// configuration. It distills the golden rules from the MCP server summary so
+// agents loading the config directory see them without an MCP initialize.
+const gitCourerMdContent = `# git-courer — Golden Rules
+
+git-courer is NOT a wrapper around git. Some tools do things raw git CANNOT.
+Others are structured replacements that return JSON instead of human text.
+
+## Golden Rules — save tokens and prevent mistakes
+
+1. BEFORE any mutation → status (know the repo state)
+2. BEFORE push → diff + review
+3. BEFORE PR → pr-review (all checks in one call)
+
+## Tool map (use these instead of raw bash git)
+
+| git command       | git-courer MCP tool | why |
+|-------------------|---------------------|-----|
+| git status        | status              | complete repo state in one call |
+| git diff          | diff                | AST-labeled diffs — know WHAT changed |
+| git commit        | commit              | LLM pipeline — atomic commits by dependency graph |
+| git log/show/blame| history             | structured JSON, no pager hangs |
+| git branch/switch | branch              | structured, auto-stash, safety gates |
+| git merge/rebase  | integrate           | structured conflict detection |
+| git revert/reset  | rewrite             | auto-backup before mutation |
+| git stash         | stash               | structured JSON |
+| git push/pull/fetch| sync               | PUSH is irreversible — safety gates |
+| git add/restore   | stage               | structured, binary-file interception |
+
+Source of truth: ` + descriptions.GitCourerSummary + `
+`
 
 // MCPClient represents an MCP client configuration.
 type MCPClient struct {
@@ -197,7 +235,16 @@ func ConfigureMCP(client *MCPClient, binPath string) error {
 	// Check if already configured
 	if data, err := os.ReadFile(configPath); err == nil {
 		if containsGitCourer(string(data)) {
+			// Already configured — still ensure GIT_COURER.md exists (idempotent).
+			ensureGitCourerMd(configPath)
 			return nil // Already configured
+		}
+	}
+
+	// Backup existing config before mutation (only if it exists).
+	if _, err := os.Stat(configPath); err == nil {
+		if backupErr := backupConfig(configPath); backupErr != nil {
+			return fmt.Errorf("failed to backup config: %w", backupErr)
 		}
 	}
 
@@ -214,6 +261,9 @@ func ConfigureMCP(client *MCPClient, binPath string) error {
 		return err
 	}
 
+	// Write GIT_COURER.md golden rules alongside the config (idempotent).
+	ensureGitCourerMd(configPath)
+
 	if client.PostInstallNotice != nil {
 		if msg := client.PostInstallNotice(binPath); msg != "" {
 			fmt.Fprintln(os.Stderr, msg)
@@ -221,6 +271,27 @@ func ConfigureMCP(client *MCPClient, binPath string) error {
 	}
 
 	return nil
+}
+
+// ensureGitCourerMd writes GIT_COURER.md in the same directory as configPath
+// if it does not already exist. Idempotent — an existing file is preserved.
+func ensureGitCourerMd(configPath string) {
+	rulesPath := filepath.Join(filepath.Dir(configPath), gitCourerMdFilename)
+	if _, err := os.Stat(rulesPath); err == nil {
+		return // already exists — do not overwrite user content
+	}
+	_ = os.WriteFile(rulesPath, []byte(gitCourerMdContent), 0644)
+}
+
+// backupConfig copies configPath to configPath + ".bak" so RunUninstall can
+// restore it. This is a simple read→write copy — atomicity is not required
+// because the file is small and local.
+func backupConfig(configPath string) error {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(configPath+".bak", data, 0644)
 }
 
 func containsGitCourer(data string) bool {

--- a/internal/installer/v26_test.go
+++ b/internal/installer/v26_test.go
@@ -1,0 +1,272 @@
+// Package installer_test verifies GIT_COURER.md creation, config backup, and
+// the doctor diagnostics added in v2.6.0.
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestConfigureMCP_CreatesGitCourerMd verifies ConfigureMCP creates a
+// GIT_COURER.md golden-rules file in the config directory alongside the
+// MCP config.
+func TestConfigureMCP_CreatesGitCourerMd(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "settings.json")
+
+	client := &MCPClient{
+		Name:     "claude-code",
+		Filename: "settings.json",
+		RootKey:  "mcpServers",
+		ConfigFn: func(binPath string) map[string]interface{} {
+			return map[string]interface{}{"command": binPath, "args": []string{"mcp"}}
+		},
+		Paths:  []string{configPath},
+		Detect: func() bool { return true },
+	}
+
+	if err := ConfigureMCP(client, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("ConfigureMCP: %v", err)
+	}
+
+	rulesPath := filepath.Join(dir, gitCourerMdFilename)
+	data, err := os.ReadFile(rulesPath)
+	if err != nil {
+		t.Fatalf("GIT_COURER.md not created: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("GIT_COURER.md is empty")
+	}
+	// Golden rules must be present.
+	content := string(data)
+	for _, want := range []string{"status", "diff", "pr-review"} {
+		if !contains(content, want) {
+			t.Errorf("GIT_COURER.md missing %q in:\n%s", want, content)
+		}
+	}
+}
+
+// TestConfigureMCP_DoesNotOverwriteGitCourerMd verifies GIT_COURER.md creation
+// is idempotent — an existing file is NOT overwritten.
+func TestConfigureMCP_DoesNotOverwriteGitCourerMd(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "settings.json")
+
+	// Pre-create a custom GIT_COURER.md with user content.
+	custom := "# custom rules\n"
+	rulesPath := filepath.Join(dir, gitCourerMdFilename)
+	if err := os.WriteFile(rulesPath, []byte(custom), 0644); err != nil {
+		t.Fatalf("write custom rules: %v", err)
+	}
+
+	client := &MCPClient{
+		Name:     "claude-code",
+		Filename: "settings.json",
+		RootKey:  "mcpServers",
+		ConfigFn: func(binPath string) map[string]interface{} {
+			return map[string]interface{}{"command": binPath}
+		},
+		Paths:  []string{configPath},
+		Detect: func() bool { return true },
+	}
+
+	if err := ConfigureMCP(client, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("ConfigureMCP: %v", err)
+	}
+
+	data, _ := os.ReadFile(rulesPath)
+	if string(data) != custom {
+		t.Errorf("existing GIT_COURER.md was overwritten:\ngot:  %q\nwant: %q", data, custom)
+	}
+}
+
+// TestConfigureMCP_CreatesBackup verifies a .bak backup of the existing config
+// is created before the config is modified.
+func TestConfigureMCP_CreatesBackup(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "settings.json")
+
+	original := `{"mcpServers":{"other":{"command":"other"}}}`
+	if err := os.WriteFile(configPath, []byte(original), 0644); err != nil {
+		t.Fatalf("write original: %v", err)
+	}
+
+	client := &MCPClient{
+		Name:     "claude-code",
+		Filename: "settings.json",
+		RootKey:  "mcpServers",
+		ConfigFn: func(binPath string) map[string]interface{} {
+			return map[string]interface{}{"command": binPath}
+		},
+		Paths:  []string{configPath},
+		Detect: func() bool { return true },
+	}
+
+	if err := ConfigureMCP(client, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("ConfigureMCP: %v", err)
+	}
+
+	backup, err := os.ReadFile(configPath + ".bak")
+	if err != nil {
+		t.Fatalf("backup file not created: %v", err)
+	}
+	if string(backup) != original {
+		t.Errorf("backup content does not match original:\ngot:  %q\nwant: %q", backup, original)
+	}
+}
+
+// TestConfigureMCP_NoBackupWhenNoExistingConfig verifies no backup is created
+// when the config file does not exist yet (nothing to back up).
+func TestConfigureMCP_NoBackupWhenNoExistingConfig(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "settings.json")
+
+	client := &MCPClient{
+		Name:     "claude-code",
+		Filename: "settings.json",
+		RootKey:  "mcpServers",
+		ConfigFn: func(binPath string) map[string]interface{} {
+			return map[string]interface{}{"command": binPath}
+		},
+		Paths:  []string{configPath},
+		Detect: func() bool { return true },
+	}
+
+	if err := ConfigureMCP(client, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("ConfigureMCP: %v", err)
+	}
+
+	if _, err := os.Stat(configPath + ".bak"); err == nil {
+		t.Error("backup file should NOT exist when there was no original config")
+	}
+}
+
+// TestRunDoctor_ReportsDiagnostics verifies RunDoctor returns diagnostics for
+// each detected client.
+func TestRunDoctor_ReportsDiagnostics(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "settings.json")
+
+	// Mock getMCPClients to return a single detected client.
+	oldGetClients := getMCPClients
+	defer func() { getMCPClients = oldGetClients }()
+	getMCPClients = func() []*MCPClient {
+		return []*MCPClient{
+			{
+				Name:     "test-client",
+				Filename: "settings.json",
+				RootKey:  "mcpServers",
+				ConfigFn: func(binPath string) map[string]interface{} {
+					return map[string]interface{}{"command": binPath}
+				},
+				Paths:  []string{configPath},
+				Detect: func() bool { return true },
+			},
+		}
+	}
+
+	// Run ConfigureMCP first so the config and GIT_COURER.md exist.
+	if err := ConfigureMCP(getMCPClients()[0], "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("ConfigureMCP: %v", err)
+	}
+
+	diagnostics := RunDoctor()
+	if len(diagnostics) == 0 {
+		t.Fatal("RunDoctor returned no diagnostics")
+	}
+
+	d := diagnostics[0]
+	if d.ClientName != "test-client" {
+		t.Errorf("ClientName: got %q, want %q", d.ClientName, "test-client")
+	}
+	if !d.MCPConfigured {
+		t.Error("MCPConfigured: got false, want true (config was written)")
+	}
+	if !d.GitCourerMdPresent {
+		t.Error("GitCourerMdPresent: got false, want true (GIT_COURER.md was written)")
+	}
+	if d.HooksStatus != statusNotImplemented {
+		t.Errorf("HooksStatus: got %q, want %q", d.HooksStatus, statusNotImplemented)
+	}
+}
+
+// TestRunDoctor_NoClients verifies RunDoctor returns empty diagnostics when
+// no clients are detected.
+func TestRunDoctor_NoClients(t *testing.T) {
+	oldGetClients := getMCPClients
+	defer func() { getMCPClients = oldGetClients }()
+	getMCPClients = func() []*MCPClient { return nil }
+
+	diagnostics := RunDoctor()
+	if len(diagnostics) != 0 {
+		t.Errorf("RunDoctor returned %d diagnostics, want 0", len(diagnostics))
+	}
+}
+
+// TestRestoreBackup_RestoresConfig verifies restoreBackup copies the .bak
+// file over the config and removes the .bak. This is the unit test for the
+// backup-restore logic added in RunUninstall; RunUninstall itself is tested
+// as an integration in sdd-verify because it touches the real binary path
+// and global config.
+func TestRestoreBackup_RestoresConfig(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "settings.json")
+
+	original := `{"mcpServers":{"other":{"command":"other"}}}`
+	if err := os.WriteFile(configPath, []byte(original), 0644); err != nil {
+		t.Fatalf("write original: %v", err)
+	}
+	if err := os.WriteFile(configPath+".bak", []byte(original), 0644); err != nil {
+		t.Fatalf("write backup: %v", err)
+	}
+	modified := `{"mcpServers":{"git-courer":{"command":"git-courer"}}}`
+	if err := os.WriteFile(configPath, []byte(modified), 0644); err != nil {
+		t.Fatalf("write modified: %v", err)
+	}
+
+	restoreBackup(configPath)
+
+	restored, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("config file missing after restore: %v", err)
+	}
+	if string(restored) != original {
+		t.Errorf("config was not restored from backup:\ngot:  %q\nwant: %q", restored, original)
+	}
+
+	if _, err := os.Stat(configPath + ".bak"); err == nil {
+		t.Error("backup file should have been removed after restore")
+	}
+}
+
+// TestRestoreBackup_NoBackupIsNoop verifies restoreBackup is a no-op when no
+// .bak file exists.
+func TestRestoreBackup_NoBackupIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "settings.json")
+	current := `{"mcpServers":{"git-courer":{"command":"x"}}}`
+	if err := os.WriteFile(configPath, []byte(current), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	restoreBackup(configPath) // no .bak — should do nothing
+
+	data, _ := os.ReadFile(configPath)
+	if string(data) != current {
+		t.Errorf("config changed when no backup existed:\ngot:  %q\nwant: %q", data, current)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && indexOf(s, substr) >= 0
+}
+
+func indexOf(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
## Summary

SDD 1 of the v2.6.0 Global Agent Policy — shared infrastructure that SDDs 2-5 will use to enforce MCP tool preference over raw bash git.

### Changes

**hook-check** (`git-courer hook-check <command>`):
- Classifies shell commands: `git *` → `ask` + suggest MCP tool, non-git → `allow`
- Pure function in `internal/classifier/gitcmd/` — 31 git subcommands mapped to MCP tools
- JSON output for agent hooks

**doctor** (`git-courer doctor`):
- Diagnoses each detected MCP client: MCP configured, GIT_COURER.md present, hooks status
- Human-readable output (not JSON — for users, not agents)

**GIT_COURER.md**:
- Golden rules file created alongside MCP config during `mcp setup`
- Idempotent — existing files are never overwritten

**Config backup/rollback**:
- `.bak` copy before any config write
- `git-courer uninstall` restores `.bak` files

### Files changed
| File | Action |
|------|--------|
| `internal/classifier/gitcmd/classifier.go` | Created |
| `internal/classifier/gitcmd/classifier_test.go` | Created |
| `internal/delivery/cli/hook_check.go` | Created |
| `internal/delivery/cli/hook_check_test.go` | Created |
| `internal/delivery/cli/doctor.go` | Created |
| `internal/delivery/cli/doctor_test.go` | Created |
| `internal/installer/mcp_config.go` | Modified |
| `internal/installer/installer.go` | Modified |
| `internal/installer/v26_test.go` | Created |
| `cmd/main.go` | Modified |

### Verification
- ✅ `go test ./...` — all green
- ✅ `go vet ./...` — clean
- ✅ `go build ./...` — clean

### Notes
- Hooks status in doctor is `not_implemented` — filled by SDDs 2-5
- This is a `size:exception` PR (~560 lines)
