### PR TITLE
feat: SDD 2 — Codex CLI PreToolUse hook infra + restore CLI + TUI restore

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -64,6 +64,9 @@ func main() {
 	case "uninstall":
 		runUninstall()
 		return
+	case "restore":
+		runRestore()
+		return
 	case "update":
 		runUpdate()
 		return
@@ -118,6 +121,7 @@ func showHelp() {
 	fmt.Println("  git-courer doctor           # Diagnose MCP client health")
 	fmt.Println("  git-courer update           # Check for binary updates")
 	fmt.Println("  git-courer uninstall        # Remove git-courer")
+	fmt.Println("  git-courer restore          # Restore MCP configs from backups")
 	fmt.Println("  git-courer version          # Show version")
 }
 
@@ -155,6 +159,17 @@ func runRemove() {
 func runUninstall() {
 	if err := installer.RunUninstall(); err != nil {
 		fmt.Fprintf(os.Stderr, "Uninstall failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// runRestore handles the restore subcommand for CLI usage.
+// It restores MCP client config backups and removes hooks/GIT_COURER.md
+// without removing the binary or global config.
+func runRestore() {
+	cmd := cli.RestoreCommand{}
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
 }

--- a/internal/delivery/cli/doctor.go
+++ b/internal/delivery/cli/doctor.go
@@ -49,9 +49,19 @@ func statusLabel(ok bool) string {
 	return "no"
 }
 
+// hooksLabel maps the installer's real HooksStatus value to a
+// human-readable label for the doctor report.
+//
+//   - "installed"     → "yes"
+//   - "not_installed" → "no"
+//   - anything else   → the status string as-is (defensive passthrough)
 func hooksLabel(status string) string {
-	if status == "not_implemented" {
-		return "pending (SDDs 2-5)"
+	switch status {
+	case "installed":
+		return "yes"
+	case "not_installed":
+		return "no"
+	default:
+		return status
 	}
-	return status
 }

--- a/internal/delivery/cli/doctor_test.go
+++ b/internal/delivery/cli/doctor_test.go
@@ -25,7 +25,8 @@ func TestDoctorRun_PrintsDiagnostics(t *testing.T) {
 				ConfigPath:         "/tmp/config.json",
 				MCPConfigured:      true,
 				GitCourerMdPresent: true,
-				HooksStatus:        "not_implemented",
+				// Use a real HooksStatus value that the installer now reports.
+				HooksStatus: "installed",
 			},
 		}
 	}
@@ -61,8 +62,29 @@ func TestDoctorRun_PrintsDiagnostics(t *testing.T) {
 	if !strings.Contains(output, "yes") {
 		t.Errorf("output missing 'yes' status markers\noutput: %s", output)
 	}
-	if !strings.Contains(output, "pending (SDDs 2-5)") {
-		t.Errorf("output missing hooks status\noutput: %s", output)
+}
+
+// TestHooksLabel_Installed verifies hooksLabel maps the "installed" status
+// reported by the installer to the human-readable "yes" label.
+func TestHooksLabel_Installed(t *testing.T) {
+	if got := hooksLabel("installed"); got != "yes" {
+		t.Errorf("hooksLabel(%q): got %q, want %q", "installed", got, "yes")
+	}
+}
+
+// TestHooksLabel_NotInstalled verifies hooksLabel maps the "not_installed"
+// status to the human-readable "no" label.
+func TestHooksLabel_NotInstalled(t *testing.T) {
+	if got := hooksLabel("not_installed"); got != "no" {
+		t.Errorf("hooksLabel(%q): got %q, want %q", "not_installed", got, "no")
+	}
+}
+
+// TestHooksLabel_UnknownStatusPassthrough verifies hooksLabel returns an
+// unrecognized status string as-is (defensive passthrough).
+func TestHooksLabel_UnknownStatusPassthrough(t *testing.T) {
+	if got := hooksLabel("something-else"); got != "something-else" {
+		t.Errorf("hooksLabel(%q): got %q, want passthrough %q", "something-else", got, "something-else")
 	}
 }
 

--- a/internal/delivery/cli/hook_check.go
+++ b/internal/delivery/cli/hook_check.go
@@ -8,35 +8,127 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/blak0p/git-courer/internal/classifier/gitcmd"
 )
 
+// CodexHookInput is the JSON that Codex CLI sends via stdin to a PreToolUse hook.
+type CodexHookInput struct {
+	ToolInput struct {
+		Command string `json:"command"`
+	} `json:"tool_input"`
+}
+
+// CodexHookOutput is the JSON the hook must emit on stdout for Codex CLI.
+type CodexHookOutput struct {
+	HookSpecificOutput struct {
+		HookEventName             string `json:"hookEventName"`
+		PermissionDecision        string `json:"permissionDecision"`
+		PermissionDecisionReason  string `json:"permissionDecisionReason"`
+	} `json:"hookSpecificOutput"`
+}
+
 // HookCheckCommand implements the hook-check CLI subcommand.
 //
-// It receives the shell command the agent is about to run, classifies it via
-// gitcmd.Classify, and prints the classification Result as JSON to stdout.
-// This is a thin adapter — all classification logic lives in the gitcmd
-// package so it can be unit-tested independently.
-type HookCheckCommand struct{}
+// It supports two modes:
+//   - CLI mode (args provided): classifies the command and emits Result JSON.
+//   - Stdin mode (no args): reads a Codex hook payload from stdin, classifies
+//     the command, and emits CodexHookOutput JSON with permissionDecision.
+//
+// All classification logic lives in the gitcmd package so it can be
+// unit-tested independently.
+type HookCheckCommand struct {
+	Stdin  io.Reader // defaults to os.Stdin; mockable in tests
+	Stdout io.Writer // defaults to os.Stdout; mockable in tests
+}
 
-// Run classifies args[0] and emits the Result as JSON on stdout.
-// It returns an error if no command argument was provided.
+// Run classifies a shell command and emits the result as JSON.
+//
+// When args are provided, it uses CLI mode (existing behavior) and emits the
+// gitcmd.Result struct. When no args are provided, it reads a Codex hook
+// payload from Stdin, classifies the command, and emits CodexHookOutput.
 func (c HookCheckCommand) Run(args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("usage: git-courer hook-check <command>")
+	stdin := c.Stdin
+	if stdin == nil {
+		stdin = os.Stdin
 	}
-	command := args[0]
-	if command == "" {
+	stdout := c.Stdout
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+
+	// CLI mode: args provided
+	if len(args) > 0 {
+		command := args[0]
+		if command == "" {
+			return fmt.Errorf("usage: git-courer hook-check <command>")
+		}
+
+		result := gitcmd.Classify(command)
+		if err := json.NewEncoder(stdout).Encode(result); err != nil {
+			return fmt.Errorf("hook-check: failed to encode result: %w", err)
+		}
+		return nil
+	}
+
+	// No args and no Stdin set — programmer error, not stdin mode.
+	if c.Stdin == nil {
 		return fmt.Errorf("usage: git-courer hook-check <command>")
 	}
 
-	result := gitcmd.Classify(command)
+	// Stdin mode: no args, read Codex hook payload from stdin
+	return c.runStdinMode(stdin, stdout)
+}
 
-	// Emit as JSON — consistent with existing delivery patterns.
-	if err := json.NewEncoder(os.Stdout).Encode(result); err != nil {
-		return fmt.Errorf("hook-check: failed to encode result: %w", err)
+// runStdinMode reads a Codex hook payload from stdin, classifies the command,
+// and emits CodexHookOutput JSON. On parse errors, it falls back to allow
+// (safe fallback per spec).
+func (c HookCheckCommand) runStdinMode(stdin io.Reader, stdout io.Writer) error {
+	data, err := io.ReadAll(stdin)
+	if err != nil {
+		// Can't read stdin — safe fallback to allow
+		return emitCodexAllow(stdout, "failed to read stdin")
 	}
-	return nil
+
+	if len(data) == 0 {
+		return emitCodexAllow(stdout, "empty stdin")
+	}
+
+	var input CodexHookInput
+	if err := json.Unmarshal(data, &input); err != nil {
+		// Malformed JSON — safe fallback to allow
+		return emitCodexAllow(stdout, "failed to parse stdin JSON")
+	}
+
+	if input.ToolInput.Command == "" {
+		return emitCodexAllow(stdout, "empty command")
+	}
+
+	result := gitcmd.Classify(input.ToolInput.Command)
+
+	output := CodexHookOutput{}
+	output.HookSpecificOutput.HookEventName = "PreToolUse"
+
+	switch result.Decision {
+	case "ask":
+		output.HookSpecificOutput.PermissionDecision = "deny"
+		output.HookSpecificOutput.PermissionDecisionReason = result.Reason
+	default:
+		output.HookSpecificOutput.PermissionDecision = "allow"
+		output.HookSpecificOutput.PermissionDecisionReason = result.Reason
+	}
+
+	return json.NewEncoder(stdout).Encode(output)
+}
+
+// emitCodexAllow writes a CodexHookOutput with permissionDecision=allow and
+// the given reason. Used as safe fallback on parse errors.
+func emitCodexAllow(stdout io.Writer, reason string) error {
+	output := CodexHookOutput{}
+	output.HookSpecificOutput.HookEventName = "PreToolUse"
+	output.HookSpecificOutput.PermissionDecision = "allow"
+	output.HookSpecificOutput.PermissionDecisionReason = reason
+	return json.NewEncoder(stdout).Encode(output)
 }

--- a/internal/delivery/cli/hook_check_test.go
+++ b/internal/delivery/cli/hook_check_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -95,13 +96,15 @@ func TestHookCheckRun_NonGitCommand(t *testing.T) {
 	}
 }
 
-// TestHookCheckRun_NoArgs verifies Run returns an error when no args provided.
-func TestHookCheckRun_NoArgs(t *testing.T) {
-	cmd := HookCheckCommand{}
+// TestHookCheckRun_NoArgs_NoStdin verifies Run returns an error when no args
+// are provided AND Stdin is nil (no stream to read from — programmer error).
+// With a real Stdin set, no-args means stdin mode (see TestHookCheck_Stdin_*).
+func TestHookCheckRun_NoArgs_NoStdin(t *testing.T) {
+	cmd := HookCheckCommand{Stdout: &bytes.Buffer{}}
 
 	err := cmd.Run([]string{})
 	if err == nil {
-		t.Fatal("expected error when no args provided, got nil")
+		t.Fatal("expected error when no args and no Stdin provided, got nil")
 	}
 }
 
@@ -113,5 +116,110 @@ func TestHookCheckRun_EmptyArg(t *testing.T) {
 	err := cmd.Run([]string{""})
 	if err == nil {
 		t.Fatal("expected error when arg is empty, got nil")
+	}
+}
+
+// --- stdin mode (Codex hook protocol) ---
+
+// runStdin invokes HookCheckCommand.Run in stdin mode (no CLI args) with the
+// given stdin payload and returns the captured stdout bytes. It uses the
+// mockable Stdin/Stdout fields so the test never touches real OS streams.
+func runStdin(t *testing.T, stdin string) []byte {
+	t.Helper()
+	cmd := HookCheckCommand{
+		Stdin:  strings.NewReader(stdin),
+		Stdout: &bytes.Buffer{},
+	}
+	if err := cmd.Run(nil); err != nil {
+		t.Fatalf("Run(stdin) returned error: %v", err)
+	}
+	if buf, ok := cmd.Stdout.(*bytes.Buffer); ok {
+		return buf.Bytes()
+	}
+	t.Fatal("Stdout was not a *bytes.Buffer")
+	return nil
+}
+
+// TestHookCheck_Stdin_GitCommand verifies stdin mode emits a Codex
+// permissionDecision deny for a git command, with the MCP tool in the reason.
+func TestHookCheck_Stdin_GitCommand(t *testing.T) {
+	out := runStdin(t, `{"tool_input":{"command":"git status"}}`)
+
+	var parsed CodexHookOutput
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		t.Fatalf("stdout not valid CodexHookOutput: %v\noutput: %q", err, out)
+	}
+	if parsed.HookSpecificOutput.HookEventName != "PreToolUse" {
+		t.Errorf("hookEventName: got %q, want %q", parsed.HookSpecificOutput.HookEventName, "PreToolUse")
+	}
+	if parsed.HookSpecificOutput.PermissionDecision != "deny" {
+		t.Errorf("permissionDecision: got %q, want %q", parsed.HookSpecificOutput.PermissionDecision, "deny")
+	}
+	if !strings.Contains(parsed.HookSpecificOutput.PermissionDecisionReason, "status") {
+		t.Errorf("permissionDecisionReason should mention the MCP tool 'status': got %q", parsed.HookSpecificOutput.PermissionDecisionReason)
+	}
+}
+
+// TestHookCheck_Stdin_NonGitCommand verifies stdin mode emits allow for a
+// non-git command.
+func TestHookCheck_Stdin_NonGitCommand(t *testing.T) {
+	out := runStdin(t, `{"tool_input":{"command":"ls -la"}}`)
+
+	var parsed CodexHookOutput
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		t.Fatalf("stdout not valid CodexHookOutput: %v\noutput: %q", err, out)
+	}
+	if parsed.HookSpecificOutput.PermissionDecision != "allow" {
+		t.Errorf("permissionDecision: got %q, want %q", parsed.HookSpecificOutput.PermissionDecision, "allow")
+	}
+}
+
+// TestHookCheck_Stdin_MalformedJSON verifies stdin mode falls back to allow
+// when the JSON cannot be parsed (safe fallback per spec).
+func TestHookCheck_Stdin_MalformedJSON(t *testing.T) {
+	out := runStdin(t, "garbage-not-json")
+
+	var parsed CodexHookOutput
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		t.Fatalf("malformed stdin should still emit valid CodexHookOutput: %v\noutput: %q", err, out)
+	}
+	if parsed.HookSpecificOutput.PermissionDecision != "allow" {
+		t.Errorf("permissionDecision on parse error: got %q, want %q (safe fallback)", parsed.HookSpecificOutput.PermissionDecision, "allow")
+	}
+}
+
+// TestHookCheck_Stdin_Empty verifies stdin mode emits allow when stdin is
+// empty (nothing to classify → safe fallback).
+func TestHookCheck_Stdin_Empty(t *testing.T) {
+	out := runStdin(t, "")
+
+	var parsed CodexHookOutput
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		t.Fatalf("empty stdin should still emit valid CodexHookOutput: %v\noutput: %q", err, out)
+	}
+	if parsed.HookSpecificOutput.PermissionDecision != "allow" {
+		t.Errorf("permissionDecision on empty stdin: got %q, want %q", parsed.HookSpecificOutput.PermissionDecision, "allow")
+	}
+}
+
+// TestHookCheck_CLIArgs_Unchanged verifies that when args are provided, Run
+// still emits the existing Result JSON (CLI mode preserved).
+func TestHookCheck_CLIArgs_Unchanged(t *testing.T) {
+	var buf bytes.Buffer
+	cmd := HookCheckCommand{
+		Stdout: &buf,
+	}
+	if err := cmd.Run([]string{"git status"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	var result map[string]string
+	if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
+		t.Fatalf("CLI mode stdout not valid JSON: %v\noutput: %q", err, buf.String())
+	}
+	if result["Decision"] != "ask" {
+		t.Errorf("CLI mode Decision: got %q, want %q", result["Decision"], "ask")
+	}
+	if result["MCPTool"] != "status" {
+		t.Errorf("CLI mode MCPTool: got %q, want %q", result["MCPTool"], "status")
 	}
 }

--- a/internal/delivery/cli/restore.go
+++ b/internal/delivery/cli/restore.go
@@ -1,0 +1,42 @@
+// Package cli provides CLI delivery adapters for git-courer subcommands.
+//
+// This file implements the restore subcommand: a thin adapter that runs the
+// installer's RunRestore to restore MCP client config backups, remove hooks,
+// and remove GIT_COURER.md files. It follows the same pattern as DoctorCommand
+// — all domain logic lives in the installer package; this adapter only wires
+// the CLI boundary and prints the result.
+package cli
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/blak0p/git-courer/internal/installer"
+)
+
+// restoreFn is the function RestoreCommand.Run calls to perform the restore.
+// It is a package-level variable so tests can stub it without depending on
+// real client detection or filesystem state.
+var restoreFn = installer.RunRestore
+
+// errSentinel is a stable error used by tests to verify RestoreCommand.Run
+// propagates errors from restoreFn.
+var errSentinel = errors.New("restore failed: sentinel")
+
+// RestoreCommand implements the restore CLI subcommand.
+//
+// It restores .bak config backups for all detected MCP clients and removes
+// the git-courer hook and GIT_COURER.md from each client. Unlike uninstall, it
+// does NOT remove the binary or the global config — it is a config-only
+// restore. All restore logic lives in the installer package.
+type RestoreCommand struct{}
+
+// Run executes the restore and prints a completion message on stdout. It
+// returns the error from the installer if the restore fails.
+func (c RestoreCommand) Run() error {
+	if err := restoreFn(); err != nil {
+		return err
+	}
+	fmt.Println("✓ Restore complete!")
+	return nil
+}

--- a/internal/delivery/cli/restore_test.go
+++ b/internal/delivery/cli/restore_test.go
@@ -1,0 +1,76 @@
+// Package cli_test verifies the restore CLI adapter.
+package cli
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestRestoreRun_PrintsCompletion verifies RestoreCommand.Run invokes the
+// restore function and prints a completion message on stdout.
+func TestRestoreRun_PrintsCompletion(t *testing.T) {
+	cmd := RestoreCommand{}
+
+	// Stub restoreFn so we don't touch real MCP client configs.
+	originalRestoreFn := restoreFn
+	defer func() { restoreFn = originalRestoreFn }()
+	called := false
+	restoreFn = func() error {
+		called = true
+		return nil
+	}
+
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	err = cmd.Run()
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if !called {
+		t.Error("restoreFn was not called by RestoreCommand.Run")
+	}
+
+	var buf bytes.Buffer
+	if _, copyErr := buf.ReadFrom(r); copyErr != nil {
+		t.Fatalf("read pipe: %v", copyErr)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "Restore complete") {
+		t.Errorf("output missing 'Restore complete' marker\noutput: %s", output)
+	}
+}
+
+// TestRestoreRun_PropagatesError verifies RestoreCommand.Run surfaces the
+// error returned by restoreFn to the caller.
+func TestRestoreRun_PropagatesError(t *testing.T) {
+	cmd := RestoreCommand{}
+
+	originalRestoreFn := restoreFn
+	defer func() { restoreFn = originalRestoreFn }()
+	restoreFn = func() error {
+		return errSentinel
+	}
+
+	oldStdout := os.Stdout
+	_, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := cmd.Run()
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != errSentinel {
+		t.Errorf("Run error: got %v, want %v", err, errSentinel)
+	}
+}

--- a/internal/installer/hooks.go
+++ b/internal/installer/hooks.go
@@ -2,11 +2,188 @@
 package installer
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 )
+
+// gitCourerHookCommand is the command written into a client's hooks.json
+// PreToolUse matcher so the agent runs git-courer hook-check before every
+// Bash tool call.
+const gitCourerHookCommand = "git-courer hook-check"
+
+// hooksFilePayload is the JSON shape of a Codex-style hooks.json file.
+type hooksFilePayload struct {
+	Hooks map[string][]map[string]interface{} `json:"hooks"`
+}
+
+// hookEntryMatchesGitCourer reports whether a single hook entry map is the
+// git-courer PreToolUse hook (by command).
+func hookEntryMatchesGitCourer(entry map[string]interface{}) bool {
+	cmd, _ := entry["command"].(string)
+	return cmd == gitCourerHookCommand
+}
+
+// installHook writes (or merges into) the client's hooks.json a PreToolUse
+// hook with matcher "Bash" that runs `git-courer hook-check`.
+//
+// Behavior:
+//   - If hooks.json does not exist, it is created with the git-courer entry.
+//   - If hooks.json exists and already contains the git-courer entry, it is
+//     left unchanged (idempotent).
+//   - If hooks.json exists without the git-courer entry, a .bak backup is
+//     created first and the git-courer entry is merged in, preserving any
+//     other existing hooks.
+//
+// The client's HooksConfig must be non-nil; otherwise installHook returns an
+// error.
+func installHook(client *MCPClient) error {
+	if client == nil || client.HooksConfig == nil {
+		return fmt.Errorf("installHook: client has no HooksConfig")
+	}
+	hooksPath := client.HooksConfig.Path
+
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0755); err != nil {
+		return fmt.Errorf("installHook: create hooks dir: %w", err)
+	}
+
+	payload := hooksFilePayload{Hooks: map[string][]map[string]interface{}{}}
+
+	// If the file already exists, load it and check for the git-courer entry.
+	if data, err := os.ReadFile(hooksPath); err == nil {
+		if jsonErr := json.Unmarshal(data, &payload); jsonErr == nil {
+			for _, entry := range payload.Hooks["PreToolUse"] {
+				if hookEntryMatchesGitCourer(entry) {
+					// Already installed — idempotent no-op.
+					return nil
+				}
+			}
+		}
+		// File exists but does not contain git-courer hook → backup before merge.
+		if backupErr := backupConfig(hooksPath); backupErr != nil {
+			return fmt.Errorf("installHook: backup hooks.json: %w", backupErr)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("installHook: read hooks.json: %w", err)
+	}
+
+	// Append the git-courer PreToolUse hook.
+	payload.Hooks["PreToolUse"] = append(payload.Hooks["PreToolUse"], map[string]interface{}{
+		"matcher": "Bash",
+		"command": gitCourerHookCommand,
+	})
+
+	out, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("installHook: marshal hooks.json: %w", err)
+	}
+	if err := os.WriteFile(hooksPath, out, 0644); err != nil {
+		return fmt.Errorf("installHook: write hooks.json: %w", err)
+	}
+	return nil
+}
+
+// removeHook strips the git-courer PreToolUse entry from the client's
+// hooks.json. If no hooks remain after removal, the file is deleted. If the
+// file does not exist or does not contain the git-courer entry, removeHook is
+// a no-op. The client's HooksConfig must be non-nil.
+func removeHook(client *MCPClient) error {
+	if client == nil || client.HooksConfig == nil {
+		return fmt.Errorf("removeHook: client has no HooksConfig")
+	}
+	hooksPath := client.HooksConfig.Path
+
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // nothing to remove
+		}
+		return fmt.Errorf("removeHook: read hooks.json: %w", err)
+	}
+
+	var payload hooksFilePayload
+	if jsonErr := json.Unmarshal(data, &payload); jsonErr != nil {
+		return fmt.Errorf("removeHook: parse hooks.json: %w", jsonErr)
+	}
+
+	pre, ok := payload.Hooks["PreToolUse"]
+	if !ok {
+		return nil // no PreToolUse hooks at all
+	}
+
+	filtered := pre[:0]
+	removed := false
+	for _, entry := range pre {
+		if hookEntryMatchesGitCourer(entry) {
+			removed = true
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	if !removed {
+		return nil // git-courer hook was not present
+	}
+
+	// Rebuild payload without empty slices.
+	cleanPayload := hooksFilePayload{Hooks: map[string][]map[string]interface{}{}}
+	for event, entries := range payload.Hooks {
+		if event == "PreToolUse" {
+			entries = filtered
+		}
+		if len(entries) > 0 {
+			cleanPayload.Hooks[event] = entries
+		}
+	}
+
+	if len(cleanPayload.Hooks) == 0 {
+		// No hooks remain → delete the file.
+		if err := os.Remove(hooksPath); err != nil {
+			return fmt.Errorf("removeHook: delete empty hooks.json: %w", err)
+		}
+		return nil
+	}
+
+	out, err := json.MarshalIndent(cleanPayload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("removeHook: marshal hooks.json: %w", err)
+	}
+	if err := os.WriteFile(hooksPath, out, 0644); err != nil {
+		return fmt.Errorf("removeHook: write hooks.json: %w", err)
+	}
+	return nil
+}
+
+// hooksStatus reports the real installation state of the git-courer hook for
+// the given client.
+//
+// Returns:
+//   - "installed"     if hooks.json exists and contains the git-courer
+//                      PreToolUse entry.
+//   - "not_installed" otherwise (file missing, unreadable, or lacks the
+//                      git-courer entry).
+func hooksStatus(client *MCPClient) string {
+	if client == nil || client.HooksConfig == nil {
+		return "not_installed"
+	}
+	hooksPath := client.HooksConfig.Path
+
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		return "not_installed"
+	}
+	var payload hooksFilePayload
+	if jsonErr := json.Unmarshal(data, &payload); jsonErr != nil {
+		return "not_installed"
+	}
+	for _, entry := range payload.Hooks["PreToolUse"] {
+		if hookEntryMatchesGitCourer(entry) {
+			return "installed"
+		}
+	}
+	return "not_installed"
+}
 
 // FindBinaryPath tries to find the git-courer binary path.
 // Supports Linux, macOS, and Windows.

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -73,7 +73,8 @@ func RunPostInstall() error {
 func RunUninstall() error {
 	fmt.Println("Uninstalling git-courer...")
 
-	// Restore .bak backups for each detected agent's config before removing.
+	// Remove hooks and GIT_COURER.md for each detected client, then restore
+	// .bak backups.
 	for _, client := range DetectClients() {
 		configPath := client.Paths[0]
 		for _, path := range client.Paths {
@@ -82,6 +83,23 @@ func RunUninstall() error {
 				break
 			}
 		}
+
+		// Remove PreToolUse hook if the client supports hooks.
+		if client.HooksConfig != nil {
+			if err := removeHook(client); err != nil {
+				fmt.Printf("  ⚠ Failed to remove hook for %s: %v\n", client.Name, err)
+			} else {
+				fmt.Printf("  ✓ Removed hook: %s\n", client.Name)
+			}
+		}
+
+		// Remove GIT_COURER.md if it exists.
+		rulesPath := filepath.Join(filepath.Dir(configPath), gitCourerMdFilename)
+		if err := os.Remove(rulesPath); err == nil {
+			fmt.Printf("  ✓ Removed GIT_COURER.md: %s\n", client.Name)
+		}
+
+		// Restore .bak backup of the config.
 		restoreBackup(configPath)
 	}
 
@@ -103,8 +121,53 @@ func RunUninstall() error {
 		fmt.Printf("  ✓ Removed config: %s\n", globalConfig)
 	}
 
-	// Remove MCP configs - TODO: ask user or remove all
 	fmt.Println("\n✓ git-courer uninstalled!")
+	return nil
+}
+
+// RunRestore restores .bak config backups for all detected MCP clients.
+// It also removes hooks and GIT_COURER.md for each client, but does NOT
+// remove the binary or global config — it's a config-only restore.
+func RunRestore() error {
+	fmt.Println("Restoring MCP client configs...")
+
+	var restored int
+	for _, client := range DetectClients() {
+		configPath := client.Paths[0]
+		for _, path := range client.Paths {
+			if _, err := os.Stat(path); err == nil {
+				configPath = path
+				break
+			}
+		}
+
+		// Remove PreToolUse hook if the client supports hooks.
+		if client.HooksConfig != nil {
+			if err := removeHook(client); err != nil {
+				fmt.Printf("  ⚠ Failed to remove hook for %s: %v\n", client.Name, err)
+			} else {
+				fmt.Printf("  ✓ Removed hook: %s\n", client.Name)
+			}
+		}
+
+		// Remove GIT_COURER.md if it exists.
+		rulesPath := filepath.Join(filepath.Dir(configPath), gitCourerMdFilename)
+		if err := os.Remove(rulesPath); err == nil {
+			fmt.Printf("  ✓ Removed GIT_COURER.md: %s\n", client.Name)
+		}
+
+		// Restore .bak backup of the config.
+		restoreBackup(configPath)
+		restored++
+	}
+
+	if restored == 0 {
+		fmt.Println("  No MCP clients detected.")
+	} else {
+		fmt.Printf("  ✓ %d client(s) restored\n", restored)
+	}
+
+	fmt.Println("\n✓ Restore complete!")
 	return nil
 }
 

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -22,10 +22,6 @@ const (
 	PostInstallEnv = "GIT_COURER_POSTINSTALL"
 )
 
-// statusNotImplemented is the HooksStatus value used while the hook
-// installation is still a stub (SDDs 2-5 fill in the real implementation).
-const statusNotImplemented = "not_implemented"
-
 // ClientDiagnostic is the per-client diagnostic returned by RunDoctor.
 //
 // Fields:
@@ -33,8 +29,10 @@ const statusNotImplemented = "not_implemented"
 //   - ConfigPath: the resolved config file path.
 //   - MCPConfigured: true if the config file exists and contains git-courer.
 //   - GitCourerMdPresent: true if GIT_COURER.md exists in the config directory.
-//   - HooksStatus: the hook installation status — "not_implemented" until
-//     SDDs 2-5 land the real hook installation logic.
+//   - HooksStatus: the real hook installation status reported by hooksStatus
+//     — "installed" if the client's hooks.json contains the git-courer
+//     PreToolUse entry, "not_installed" otherwise (including clients without
+//     HooksConfig).
 type ClientDiagnostic struct {
 	ClientName         string
 	ConfigPath         string
@@ -126,7 +124,8 @@ func restoreBackup(configPath string) {
 
 // RunDoctor inspects each detected MCP client and reports diagnostic state:
 // whether the MCP config exists and contains git-courer, whether
-// GIT_COURER.md exists, and the hook installation status (stub until SDDs 2-5).
+// GIT_COURER.md exists, and the real hook installation status reported by
+// hooksStatus ("installed" or "not_installed").
 //
 // It returns one ClientDiagnostic per detected client.
 func RunDoctor() []ClientDiagnostic {
@@ -145,7 +144,7 @@ func RunDoctor() []ClientDiagnostic {
 		d := ClientDiagnostic{
 			ClientName:  client.Name,
 			ConfigPath:  configPath,
-			HooksStatus: statusNotImplemented,
+			HooksStatus: hooksStatus(client),
 		}
 
 		if data, err := os.ReadFile(configPath); err == nil {

--- a/internal/installer/mcp_config.go
+++ b/internal/installer/mcp_config.go
@@ -250,6 +250,14 @@ func ConfigureMCP(client *MCPClient, binPath string) error {
 		if containsGitCourer(string(data)) {
 			// Already configured — still ensure GIT_COURER.md exists (idempotent).
 			ensureGitCourerMd(configPath)
+			// Install hooks if the client supports them (idempotent no-op if
+			// already installed). Even on the early-return path we must keep
+			// hooks in sync with the configured client.
+			if client.HooksConfig != nil {
+				if err := installHook(client); err != nil {
+					return fmt.Errorf("install hook for %s: %w", client.Name, err)
+				}
+			}
 			return nil // Already configured
 		}
 	}
@@ -276,6 +284,15 @@ func ConfigureMCP(client *MCPClient, binPath string) error {
 
 	// Write GIT_COURER.md golden rules alongside the config (idempotent).
 	ensureGitCourerMd(configPath)
+
+	// Install hooks if the client supports them (idempotent no-op if already
+	// installed). Done AFTER the config is written so a failing hook install
+	// does not leave a half-configured MCP entry without a rollback path.
+	if client.HooksConfig != nil {
+		if err := installHook(client); err != nil {
+			return fmt.Errorf("install hook for %s: %w", client.Name, err)
+		}
+	}
 
 	if client.PostInstallNotice != nil {
 		if msg := client.PostInstallNotice(binPath); msg != "" {

--- a/internal/installer/mcp_config.go
+++ b/internal/installer/mcp_config.go
@@ -59,6 +59,7 @@ type MCPClient struct {
 	PostInstallNotice func(binPath string) string // optional post-install warning check
 	Paths             []string                    // possible config file paths for this platform
 	Detect            func() bool
+	HooksConfig       *HooksConfig // optional; non-nil for clients that support hooks (e.g. Codex)
 }
 
 // MCPServerConfig represents an MCP server entry.
@@ -66,6 +67,14 @@ type MCPServerConfig struct {
 	Command string   `json:"command,omitempty"`
 	Args    []string `json:"args,omitempty"`
 	Type    string   `json:"type,omitempty"`
+}
+
+// HooksConfig describes where a client's hooks file lives and what format it
+// uses. When non-nil on an MCPClient, ConfigureMCP installs the git-courer
+// PreToolUse hook there (and RunDoctor reports its real status).
+type HooksConfig struct {
+	Path   string // e.g. "/home/u/.codex/hooks.json"
+	Format string // "json"
 }
 
 var getMCPClients = MCPClients
@@ -146,6 +155,10 @@ func MCPClients() []*MCPClient {
 			Detect: func() bool {
 				_, err := exec.LookPath("codex")
 				return err == nil
+			},
+			HooksConfig: &HooksConfig{
+				Path:   filepath.Join(home, ".codex/hooks.json"),
+				Format: "json",
 			},
 		},
 		{

--- a/internal/installer/mcp_config_test.go
+++ b/internal/installer/mcp_config_test.go
@@ -1,0 +1,153 @@
+// Package installer_test verifies ConfigureMCP installs PreToolUse hooks
+// for clients that support them (SDD 2, Phase 3).
+package installer
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// codexTestClient builds a Codex-like MCPClient whose config and hooks paths
+// live inside the provided temp dir, so tests never touch the real home.
+func codexTestClient(t *testing.T, dir string) *MCPClient {
+	t.Helper()
+	configPath := filepath.Join(dir, "config.toml")
+	hooksPath := filepath.Join(dir, "hooks.json")
+	return &MCPClient{
+		Name:     "codex",
+		Filename: "config.toml",
+		RootKey:  "mcpServers",
+		ConfigFn: func(binPath string) map[string]interface{} {
+			return map[string]interface{}{"command": binPath, "args": []string{"mcp"}}
+		},
+		Paths:  []string{configPath},
+		Detect: func() bool { return true },
+		HooksConfig: &HooksConfig{
+			Path:   hooksPath,
+			Format: "json",
+		},
+	}
+}
+
+// noHooksTestClient builds a client WITHOUT HooksConfig (e.g. opencode) so
+// we can assert ConfigureMCP does not create any hooks.json for it.
+func noHooksTestClient(t *testing.T, dir string) *MCPClient {
+	t.Helper()
+	configPath := filepath.Join(dir, "opencode.json")
+	return &MCPClient{
+		Name:     "opencode",
+		Filename: "opencode.json",
+		RootKey:  "mcp",
+		ConfigFn: func(binPath string) map[string]interface{} {
+			return map[string]interface{}{"command": []string{binPath, "mcp"}}
+		},
+		Paths:  []string{configPath},
+		Detect: func() bool { return true },
+		// HooksConfig intentionally nil
+	}
+}
+
+// assertHooksJsonHasGitCourer reads hooksPath and verifies it contains
+// exactly one git-courer PreToolUse entry.
+func assertHooksJsonHasGitCourer(t *testing.T, hooksPath string, wantCount int) {
+	t.Helper()
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("hooks.json not created at %s: %v", hooksPath, err)
+	}
+	content := string(data)
+	for _, want := range []string{"PreToolUse", "Bash", "git-courer", "hook-check"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("hooks.json missing %q in:\n%s", want, content)
+		}
+	}
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("hooks.json not valid JSON: %v", err)
+	}
+	hooks, _ := parsed["hooks"].(map[string]interface{})
+	pre, _ := hooks["PreToolUse"].([]interface{})
+	count := 0
+	for _, e := range pre {
+		em, _ := e.(map[string]interface{})
+		if cmd, _ := em["command"].(string); cmd == "git-courer hook-check" {
+			count++
+		}
+	}
+	if count != wantCount {
+		t.Errorf("git-courer hook entries: got %d, want %d\ncontent:\n%s", count, wantCount, content)
+	}
+}
+
+// TestConfigureMCP_InstallsHook verifies ConfigureMCP creates hooks.json
+// with the git-courer PreToolUse entry for a client that has HooksConfig.
+func TestConfigureMCP_InstallsHook(t *testing.T) {
+	dir := t.TempDir()
+	client := codexTestClient(t, dir)
+
+	if err := ConfigureMCP(client, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("ConfigureMCP: %v", err)
+	}
+
+	assertHooksJsonHasGitCourer(t, client.HooksConfig.Path, 1)
+}
+
+// TestConfigureMCP_NoHooksConfig verifies ConfigureMCP does NOT create any
+// hooks.json for a client without HooksConfig (e.g. opencode).
+func TestConfigureMCP_NoHooksConfig(t *testing.T) {
+	dir := t.TempDir()
+	client := noHooksTestClient(t, dir)
+
+	if err := ConfigureMCP(client, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("ConfigureMCP: %v", err)
+	}
+
+	// No hooks file should exist anywhere in the temp dir.
+	matches, _ := filepath.Glob(filepath.Join(dir, "*hooks*"))
+	if len(matches) != 0 {
+		t.Errorf("no hooks.json expected for client without HooksConfig, found: %v", matches)
+	}
+}
+
+// TestConfigureMCP_HooksIdempotent verifies calling ConfigureMCP twice
+// produces exactly one git-courer entry (not duplicated).
+func TestConfigureMCP_HooksIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	client := codexTestClient(t, dir)
+
+	if err := ConfigureMCP(client, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("ConfigureMCP first call: %v", err)
+	}
+	if err := ConfigureMCP(client, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("ConfigureMCP second call: %v", err)
+	}
+
+	assertHooksJsonHasGitCourer(t, client.HooksConfig.Path, 1)
+}
+
+// TestConfigureMCP_InstallsHookOnEarlyReturn verifies ConfigureMCP installs
+// the hook even on the early-return path (when the config already contains
+// git-courer). This guards the "already configured" branch.
+func TestConfigureMCP_InstallsHookOnEarlyReturn(t *testing.T) {
+	dir := t.TempDir()
+	client := codexTestClient(t, dir)
+
+	// First call: writes config + hooks.
+	if err := ConfigureMCP(client, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("ConfigureMCP first call: %v", err)
+	}
+	// Remove hooks.json to prove the second (early-return) call reinstalls it.
+	if err := os.Remove(client.HooksConfig.Path); err != nil {
+		t.Fatalf("remove hooks.json: %v", err)
+	}
+
+	// Second call hits the containsGitCourer early-return branch.
+	if err := ConfigureMCP(client, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("ConfigureMCP second call: %v", err)
+	}
+
+	assertHooksJsonHasGitCourer(t, client.HooksConfig.Path, 1)
+}

--- a/internal/installer/v26_test.go
+++ b/internal/installer/v26_test.go
@@ -3,6 +3,7 @@
 package installer
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -292,6 +293,227 @@ func TestMCPClients_CodexHasHooksConfig(t *testing.T) {
 	}
 	if codex.HooksConfig.Format != "json" {
 		t.Errorf("codex HooksConfig.Format: got %q, want %q", codex.HooksConfig.Format, "json")
+	}
+}
+
+// TestInstallHook_CreatesHooksJson verifies installHook writes a hooks.json
+// with a PreToolUse Bash matcher pointing at git-courer hook-check when no
+// hooks file exists yet.
+func TestInstallHook_CreatesHooksJson(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+
+	client := &MCPClient{
+		Name: "codex",
+		HooksConfig: &HooksConfig{
+			Path:   hooksPath,
+			Format: "json",
+		},
+	}
+
+	if err := installHook(client); err != nil {
+		t.Fatalf("installHook: %v", err)
+	}
+
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("hooks.json not created: %v", err)
+	}
+	content := string(data)
+	for _, want := range []string{"PreToolUse", "Bash", "git-courer", "hook-check"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("hooks.json missing %q in:\n%s", want, content)
+		}
+	}
+}
+
+// TestInstallHook_Idempotent verifies installHook does NOT duplicate the
+// git-courer entry when hooks.json already contains it.
+func TestInstallHook_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+	existing := `{"hooks":{"PreToolUse":[{"matcher":"Bash","command":"git-courer hook-check"}]}}`
+	if err := os.WriteFile(hooksPath, []byte(existing), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	client := &MCPClient{
+		Name: "codex",
+		HooksConfig: &HooksConfig{Path: hooksPath, Format: "json"},
+	}
+	if err := installHook(client); err != nil {
+		t.Fatalf("installHook: %v", err)
+	}
+
+	data, _ := os.ReadFile(hooksPath)
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("hooks.json not valid JSON after idempotent install: %v", err)
+	}
+	hooks, _ := parsed["hooks"].(map[string]interface{})
+	pre, _ := hooks["PreToolUse"].([]interface{})
+	count := 0
+	for _, e := range pre {
+		em, _ := e.(map[string]interface{})
+		if cmd, _ := em["command"].(string); cmd == "git-courer hook-check" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("git-courer hook entries after idempotent install: got %d, want 1", count)
+	}
+}
+
+// TestInstallHook_MergesPreservesExisting verifies installHook merges the
+// git-courer hook into an existing hooks.json that already has other hooks,
+// preserving those other entries and creating a .bak backup.
+func TestInstallHook_MergesPreservesExisting(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+	existing := `{"hooks":{"PreToolUse":[{"matcher":"Bash","command":"some-other-hook"}]}}`
+	if err := os.WriteFile(hooksPath, []byte(existing), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	client := &MCPClient{
+		Name: "codex",
+		HooksConfig: &HooksConfig{Path: hooksPath, Format: "json"},
+	}
+	if err := installHook(client); err != nil {
+		t.Fatalf("installHook: %v", err)
+	}
+
+	// backup created
+	if _, err := os.Stat(hooksPath + ".bak"); err != nil {
+		t.Errorf("backup .bak not created: %v", err)
+	}
+
+	data, _ := os.ReadFile(hooksPath)
+	content := string(data)
+	if !strings.Contains(content, "some-other-hook") {
+		t.Errorf("existing hook was lost during merge:\n%s", content)
+	}
+	if !strings.Contains(content, "git-courer hook-check") {
+		t.Errorf("git-courer hook was not added during merge:\n%s", content)
+	}
+}
+
+// TestRemoveHook_RemovesGitCourerEntry verifies removeHook strips the
+// git-courer entry and leaves other hooks intact.
+func TestRemoveHook_RemovesGitCourerEntry(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+	existing := `{"hooks":{"PreToolUse":[{"matcher":"Bash","command":"some-other-hook"},{"matcher":"Bash","command":"git-courer hook-check"}]}}`
+	if err := os.WriteFile(hooksPath, []byte(existing), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	client := &MCPClient{
+		Name: "codex",
+		HooksConfig: &HooksConfig{Path: hooksPath, Format: "json"},
+	}
+	if err := removeHook(client); err != nil {
+		t.Fatalf("removeHook: %v", err)
+	}
+
+	data, _ := os.ReadFile(hooksPath)
+	content := string(data)
+	if strings.Contains(content, "git-courer hook-check") {
+		t.Errorf("git-courer entry still present after remove:\n%s", content)
+	}
+	if !strings.Contains(content, "some-other-hook") {
+		t.Errorf("other hook was removed too:\n%s", content)
+	}
+}
+
+// TestRemoveHook_DeletesFileWhenEmpty verifies removeHook deletes hooks.json
+// when no hooks remain after removing the git-courer entry.
+func TestRemoveHook_DeletesFileWhenEmpty(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+	existing := `{"hooks":{"PreToolUse":[{"matcher":"Bash","command":"git-courer hook-check"}]}}`
+	if err := os.WriteFile(hooksPath, []byte(existing), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	client := &MCPClient{
+		Name: "codex",
+		HooksConfig: &HooksConfig{Path: hooksPath, Format: "json"},
+	}
+	if err := removeHook(client); err != nil {
+		t.Fatalf("removeHook: %v", err)
+	}
+
+	if _, err := os.Stat(hooksPath); err == nil {
+		t.Error("hooks.json should have been deleted when empty, still exists")
+	}
+}
+
+// TestRemoveHook_NoFileIsNoop verifies removeHook is a no-op (no error) when
+// hooks.json does not exist.
+func TestRemoveHook_NoFileIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+
+	client := &MCPClient{
+		Name: "codex",
+		HooksConfig: &HooksConfig{Path: hooksPath, Format: "json"},
+	}
+	if err := removeHook(client); err != nil {
+		t.Errorf("removeHook on missing file returned error: %v", err)
+	}
+}
+
+// TestHooksStatus_Installed verifies hooksStatus returns "installed" when
+// hooks.json exists and contains the git-courer PreToolUse entry.
+func TestHooksStatus_Installed(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+	existing := `{"hooks":{"PreToolUse":[{"matcher":"Bash","command":"git-courer hook-check"}]}}`
+	if err := os.WriteFile(hooksPath, []byte(existing), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	client := &MCPClient{
+		Name: "codex",
+		HooksConfig: &HooksConfig{Path: hooksPath, Format: "json"},
+	}
+	if got := hooksStatus(client); got != "installed" {
+		t.Errorf("hooksStatus: got %q, want %q", got, "installed")
+	}
+}
+
+// TestHooksStatus_NotInstalled_NoFile verifies hooksStatus returns
+// "not_installed" when hooks.json does not exist.
+func TestHooksStatus_NotInstalled_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+
+	client := &MCPClient{
+		Name: "codex",
+		HooksConfig: &HooksConfig{Path: hooksPath, Format: "json"},
+	}
+	if got := hooksStatus(client); got != "not_installed" {
+		t.Errorf("hooksStatus: got %q, want %q", got, "not_installed")
+	}
+}
+
+// TestHooksStatus_NotInstalled_NoGitCourerEntry verifies hooksStatus returns
+// "not_installed" when hooks.json exists but lacks the git-courer entry.
+func TestHooksStatus_NotInstalled_NoGitCourerEntry(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+	existing := `{"hooks":{"PreToolUse":[{"matcher":"Bash","command":"some-other-hook"}]}}`
+	if err := os.WriteFile(hooksPath, []byte(existing), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	client := &MCPClient{
+		Name: "codex",
+		HooksConfig: &HooksConfig{Path: hooksPath, Format: "json"},
+	}
+	if got := hooksStatus(client); got != "not_installed" {
+		t.Errorf("hooksStatus: got %q, want %q", got, "not_installed")
 	}
 }
 

--- a/internal/installer/v26_test.go
+++ b/internal/installer/v26_test.go
@@ -600,6 +600,265 @@ func TestRunDoctor_HooksNotInstalled(t *testing.T) {
 	}
 }
 
+// -----------------------------------------------------------------------------
+// Phase 5: RunUninstall hook + GIT_COURER.md cleanup
+// -----------------------------------------------------------------------------
+
+// TestRunUninstall_RemovesHook verifies RunUninstall calls removeHook for a
+// detected client that carries a HooksConfig, stripping the git-courer
+// PreToolUse entry from its hooks.json.
+func TestRunUninstall_RemovesHook(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	hooksPath := filepath.Join(dir, "hooks.json")
+
+	// Pre-install the git-courer hook so removeHook has something to remove.
+	hooksContent := `{"hooks":{"PreToolUse":[{"matcher":"Bash","command":"git-courer hook-check"}]}}`
+	if err := os.WriteFile(hooksPath, []byte(hooksContent), 0644); err != nil {
+		t.Fatalf("write hooks: %v", err)
+	}
+
+	// Redirect HOME so RunUninstall's global-config removal (os.UserHomeDir)
+	// touches a temp dir, never the developer's real config.
+	oldHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", oldHome)
+	os.Setenv("HOME", t.TempDir())
+
+	oldGetClients := getMCPClients
+	defer func() { getMCPClients = oldGetClients }()
+	getMCPClients = func() []*MCPClient {
+		return []*MCPClient{
+			{
+				Name:     "codex",
+				Filename: "config.toml",
+				RootKey:  "mcpServers",
+				ConfigFn: func(binPath string) map[string]interface{} {
+					return map[string]interface{}{"command": binPath}
+				},
+				Paths:  []string{configPath},
+				Detect: func() bool { return true },
+				HooksConfig: &HooksConfig{
+					Path:   hooksPath,
+					Format: "json",
+				},
+			},
+		}
+	}
+
+	if err := RunUninstall(); err != nil {
+		// RunUninstall may fail to remove the real binary in the test env;
+		// the hook cleanup happens BEFORE the binary removal, so a hook-side
+		// assertion is still valid. Only hard-fail on errors unrelated to
+		// the binary removal.
+		if !strings.Contains(err.Error(), "binary") {
+			t.Fatalf("RunUninstall: %v", err)
+		}
+	}
+
+	// The hook entry must be gone — hooks.json was deleted when it became
+	// empty (only contained the git-courer entry).
+	if _, err := os.Stat(hooksPath); err == nil {
+		data, _ := os.ReadFile(hooksPath)
+		if strings.Contains(string(data), "git-courer hook-check") {
+			t.Errorf("git-courer hook still present after uninstall:\n%s", data)
+		}
+	}
+}
+
+// TestRunUninstall_RemovesGitCourerMd verifies RunUninstall removes the
+// GIT_COURER.md file from each detected client's config directory.
+func TestRunUninstall_RemovesGitCourerMd(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	// Pre-create GIT_COURER.md alongside the config.
+	rulesPath := filepath.Join(dir, gitCourerMdFilename)
+	if err := os.WriteFile(rulesPath, []byte("# rules\n"), 0644); err != nil {
+		t.Fatalf("write rules: %v", err)
+	}
+
+	// Redirect HOME so RunUninstall never touches the real global config.
+	oldHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", oldHome)
+	os.Setenv("HOME", t.TempDir())
+
+	oldGetClients := getMCPClients
+	defer func() { getMCPClients = oldGetClients }()
+	getMCPClients = func() []*MCPClient {
+		return []*MCPClient{
+			{
+				Name:     "codex",
+				Filename: "config.toml",
+				RootKey:  "mcpServers",
+				ConfigFn: func(binPath string) map[string]interface{} {
+					return map[string]interface{}{"command": binPath}
+				},
+				Paths:  []string{configPath},
+				Detect: func() bool { return true },
+			},
+		}
+	}
+
+	if err := RunUninstall(); err != nil {
+		if !strings.Contains(err.Error(), "binary") {
+			t.Fatalf("RunUninstall: %v", err)
+		}
+	}
+
+	if _, err := os.Stat(rulesPath); err == nil {
+		t.Error("GIT_COURER.md should have been removed by RunUninstall")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Phase 6: RunRestore
+// -----------------------------------------------------------------------------
+
+// TestRunRestore_RestoresBackup verifies RunRestore copies the .bak backup
+// over the config file and removes the .bak.
+func TestRunRestore_RestoresBackup(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	original := `{"mcpServers":{"other":{"command":"other"}}}`
+	if err := os.WriteFile(configPath, []byte(original), 0644); err != nil {
+		t.Fatalf("write original: %v", err)
+	}
+	if err := os.WriteFile(configPath+".bak", []byte(original), 0644); err != nil {
+		t.Fatalf("write backup: %v", err)
+	}
+	modified := `{"mcpServers":{"git-courer":{"command":"git-courer"}}}`
+	if err := os.WriteFile(configPath, []byte(modified), 0644); err != nil {
+		t.Fatalf("write modified: %v", err)
+	}
+
+	oldGetClients := getMCPClients
+	defer func() { getMCPClients = oldGetClients }()
+	getMCPClients = func() []*MCPClient {
+		return []*MCPClient{
+			{
+				Name:     "codex",
+				Filename: "config.toml",
+				RootKey:  "mcpServers",
+				ConfigFn: func(binPath string) map[string]interface{} {
+					return map[string]interface{}{"command": binPath}
+				},
+				Paths:  []string{configPath},
+				Detect: func() bool { return true },
+			},
+		}
+	}
+
+	if err := RunRestore(); err != nil {
+		t.Fatalf("RunRestore: %v", err)
+	}
+
+	restored, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("config missing after restore: %v", err)
+	}
+	if string(restored) != original {
+		t.Errorf("config not restored from backup:\ngot:  %q\nwant: %q", restored, original)
+	}
+	if _, err := os.Stat(configPath + ".bak"); err == nil {
+		t.Error(".bak should have been removed after restore")
+	}
+}
+
+// TestRunRestore_RemovesHook verifies RunRestore strips the git-courer
+// PreToolUse entry from a detected client's hooks.json.
+func TestRunRestore_RemovesHook(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	hooksPath := filepath.Join(dir, "hooks.json")
+
+	hooksContent := `{"hooks":{"PreToolUse":[{"matcher":"Bash","command":"git-courer hook-check"}]}}`
+	if err := os.WriteFile(hooksPath, []byte(hooksContent), 0644); err != nil {
+		t.Fatalf("write hooks: %v", err)
+	}
+
+	oldGetClients := getMCPClients
+	defer func() { getMCPClients = oldGetClients }()
+	getMCPClients = func() []*MCPClient {
+		return []*MCPClient{
+			{
+				Name:     "codex",
+				Filename: "config.toml",
+				RootKey:  "mcpServers",
+				ConfigFn: func(binPath string) map[string]interface{} {
+					return map[string]interface{}{"command": binPath}
+				},
+				Paths:  []string{configPath},
+				Detect: func() bool { return true },
+				HooksConfig: &HooksConfig{
+					Path:   hooksPath,
+					Format: "json",
+				},
+			},
+		}
+	}
+
+	if err := RunRestore(); err != nil {
+		t.Fatalf("RunRestore: %v", err)
+	}
+
+	// hooks.json contained only the git-courer entry → file deleted when empty.
+	if _, err := os.Stat(hooksPath); err == nil {
+		data, _ := os.ReadFile(hooksPath)
+		if strings.Contains(string(data), "git-courer hook-check") {
+			t.Errorf("git-courer hook still present after restore:\n%s", data)
+		}
+	}
+}
+
+// TestRunRestore_RemovesGitCourerMd verifies RunRestore removes the
+// GIT_COURER.md file from each detected client's config directory.
+func TestRunRestore_RemovesGitCourerMd(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	rulesPath := filepath.Join(dir, gitCourerMdFilename)
+	if err := os.WriteFile(rulesPath, []byte("# rules\n"), 0644); err != nil {
+		t.Fatalf("write rules: %v", err)
+	}
+
+	oldGetClients := getMCPClients
+	defer func() { getMCPClients = oldGetClients }()
+	getMCPClients = func() []*MCPClient {
+		return []*MCPClient{
+			{
+				Name:     "codex",
+				Filename: "config.toml",
+				RootKey:  "mcpServers",
+				ConfigFn: func(binPath string) map[string]interface{} {
+					return map[string]interface{}{"command": binPath}
+				},
+				Paths:  []string{configPath},
+				Detect: func() bool { return true },
+			},
+		}
+	}
+
+	if err := RunRestore(); err != nil {
+		t.Fatalf("RunRestore: %v", err)
+	}
+
+	if _, err := os.Stat(rulesPath); err == nil {
+		t.Error("GIT_COURER.md should have been removed by RunRestore")
+	}
+}
+
+// TestRunRestore_NoClientsIsNoop verifies RunRestore returns no error and
+// performs no restore when no MCP clients are detected.
+func TestRunRestore_NoClientsIsNoop(t *testing.T) {
+	oldGetClients := getMCPClients
+	defer func() { getMCPClients = oldGetClients }()
+	getMCPClients = func() []*MCPClient { return nil }
+
+	if err := RunRestore(); err != nil {
+		t.Fatalf("RunRestore with no clients should not error: %v", err)
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && indexOf(s, substr) >= 0
 }

--- a/internal/installer/v26_test.go
+++ b/internal/installer/v26_test.go
@@ -5,6 +5,7 @@ package installer
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -255,6 +256,42 @@ func TestRestoreBackup_NoBackupIsNoop(t *testing.T) {
 	data, _ := os.ReadFile(configPath)
 	if string(data) != current {
 		t.Errorf("config changed when no backup existed:\ngot:  %q\nwant: %q", data, current)
+	}
+}
+
+// TestHooksConfig_Fields verifies the HooksConfig struct exposes Path and
+// Format fields so MCPClient can carry a hooks descriptor per client.
+func TestHooksConfig_Fields(t *testing.T) {
+	hc := HooksConfig{Path: "/home/u/.codex/hooks.json", Format: "json"}
+	if hc.Path != "/home/u/.codex/hooks.json" {
+		t.Errorf("Path: got %q", hc.Path)
+	}
+	if hc.Format != "json" {
+		t.Errorf("Format: got %q", hc.Format)
+	}
+}
+
+// TestMCPClients_CodexHasHooksConfig verifies the Codex entry in MCPClients
+// carries a HooksConfig pointing at ~/.codex/hooks.json with format "json".
+func TestMCPClients_CodexHasHooksConfig(t *testing.T) {
+	var codex *MCPClient
+	for _, c := range MCPClients() {
+		if c.Name == "codex" {
+			codex = c
+			break
+		}
+	}
+	if codex == nil {
+		t.Fatal("codex client not found in MCPClients()")
+	}
+	if codex.HooksConfig == nil {
+		t.Fatal("codex HooksConfig is nil — expected non-nil")
+	}
+	if !strings.HasSuffix(codex.HooksConfig.Path, ".codex/hooks.json") {
+		t.Errorf("codex HooksConfig.Path: got %q, want suffix .codex/hooks.json", codex.HooksConfig.Path)
+	}
+	if codex.HooksConfig.Format != "json" {
+		t.Errorf("codex HooksConfig.Format: got %q, want %q", codex.HooksConfig.Format, "json")
 	}
 }
 

--- a/internal/installer/v26_test.go
+++ b/internal/installer/v26_test.go
@@ -188,8 +188,10 @@ func TestRunDoctor_ReportsDiagnostics(t *testing.T) {
 	if !d.GitCourerMdPresent {
 		t.Error("GitCourerMdPresent: got false, want true (GIT_COURER.md was written)")
 	}
-	if d.HooksStatus != statusNotImplemented {
-		t.Errorf("HooksStatus: got %q, want %q", d.HooksStatus, statusNotImplemented)
+	// The test client has no HooksConfig, so hooksStatus reports
+	// "not_installed" (the real status, not the old stub).
+	if d.HooksStatus != "not_installed" {
+		t.Errorf("HooksStatus: got %q, want %q", d.HooksStatus, "not_installed")
 	}
 }
 
@@ -338,7 +340,7 @@ func TestInstallHook_Idempotent(t *testing.T) {
 	}
 
 	client := &MCPClient{
-		Name: "codex",
+		Name:        "codex",
 		HooksConfig: &HooksConfig{Path: hooksPath, Format: "json"},
 	}
 	if err := installHook(client); err != nil {
@@ -376,7 +378,7 @@ func TestInstallHook_MergesPreservesExisting(t *testing.T) {
 	}
 
 	client := &MCPClient{
-		Name: "codex",
+		Name:        "codex",
 		HooksConfig: &HooksConfig{Path: hooksPath, Format: "json"},
 	}
 	if err := installHook(client); err != nil {
@@ -409,7 +411,7 @@ func TestRemoveHook_RemovesGitCourerEntry(t *testing.T) {
 	}
 
 	client := &MCPClient{
-		Name: "codex",
+		Name:        "codex",
 		HooksConfig: &HooksConfig{Path: hooksPath, Format: "json"},
 	}
 	if err := removeHook(client); err != nil {
@@ -437,7 +439,7 @@ func TestRemoveHook_DeletesFileWhenEmpty(t *testing.T) {
 	}
 
 	client := &MCPClient{
-		Name: "codex",
+		Name:        "codex",
 		HooksConfig: &HooksConfig{Path: hooksPath, Format: "json"},
 	}
 	if err := removeHook(client); err != nil {
@@ -456,7 +458,7 @@ func TestRemoveHook_NoFileIsNoop(t *testing.T) {
 	hooksPath := filepath.Join(dir, "hooks.json")
 
 	client := &MCPClient{
-		Name: "codex",
+		Name:        "codex",
 		HooksConfig: &HooksConfig{Path: hooksPath, Format: "json"},
 	}
 	if err := removeHook(client); err != nil {
@@ -475,7 +477,7 @@ func TestHooksStatus_Installed(t *testing.T) {
 	}
 
 	client := &MCPClient{
-		Name: "codex",
+		Name:        "codex",
 		HooksConfig: &HooksConfig{Path: hooksPath, Format: "json"},
 	}
 	if got := hooksStatus(client); got != "installed" {
@@ -490,7 +492,7 @@ func TestHooksStatus_NotInstalled_NoFile(t *testing.T) {
 	hooksPath := filepath.Join(dir, "hooks.json")
 
 	client := &MCPClient{
-		Name: "codex",
+		Name:        "codex",
 		HooksConfig: &HooksConfig{Path: hooksPath, Format: "json"},
 	}
 	if got := hooksStatus(client); got != "not_installed" {
@@ -509,11 +511,92 @@ func TestHooksStatus_NotInstalled_NoGitCourerEntry(t *testing.T) {
 	}
 
 	client := &MCPClient{
-		Name: "codex",
+		Name:        "codex",
 		HooksConfig: &HooksConfig{Path: hooksPath, Format: "json"},
 	}
 	if got := hooksStatus(client); got != "not_installed" {
 		t.Errorf("hooksStatus: got %q, want %q", got, "not_installed")
+	}
+}
+
+// TestRunDoctor_HooksInstalled verifies RunDoctor reports HooksStatus
+// "installed" when the client's hooks.json contains the git-courer
+// PreToolUse entry.
+func TestRunDoctor_HooksInstalled(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	hooksPath := filepath.Join(dir, "hooks.json")
+
+	// Pre-create hooks.json with the git-courer entry.
+	hooksContent := `{"hooks":{"PreToolUse":[{"matcher":"Bash","command":"git-courer hook-check"}]}}`
+	if err := os.WriteFile(hooksPath, []byte(hooksContent), 0644); err != nil {
+		t.Fatalf("write hooks: %v", err)
+	}
+
+	oldGetClients := getMCPClients
+	defer func() { getMCPClients = oldGetClients }()
+	getMCPClients = func() []*MCPClient {
+		return []*MCPClient{
+			{
+				Name:     "codex",
+				Filename: "config.toml",
+				RootKey:  "mcpServers",
+				ConfigFn: func(binPath string) map[string]interface{} {
+					return map[string]interface{}{"command": binPath}
+				},
+				Paths:  []string{configPath},
+				Detect: func() bool { return true },
+				HooksConfig: &HooksConfig{
+					Path:   hooksPath,
+					Format: "json",
+				},
+			},
+		}
+	}
+
+	diagnostics := RunDoctor()
+	if len(diagnostics) != 1 {
+		t.Fatalf("RunDoctor returned %d diagnostics, want 1", len(diagnostics))
+	}
+	if got := diagnostics[0].HooksStatus; got != "installed" {
+		t.Errorf("HooksStatus: got %q, want %q", got, "installed")
+	}
+}
+
+// TestRunDoctor_HooksNotInstalled verifies RunDoctor reports HooksStatus
+// "not_installed" when the client's hooks.json does not exist.
+func TestRunDoctor_HooksNotInstalled(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	hooksPath := filepath.Join(dir, "hooks.json") // intentionally not created
+
+	oldGetClients := getMCPClients
+	defer func() { getMCPClients = oldGetClients }()
+	getMCPClients = func() []*MCPClient {
+		return []*MCPClient{
+			{
+				Name:     "codex",
+				Filename: "config.toml",
+				RootKey:  "mcpServers",
+				ConfigFn: func(binPath string) map[string]interface{} {
+					return map[string]interface{}{"command": binPath}
+				},
+				Paths:  []string{configPath},
+				Detect: func() bool { return true },
+				HooksConfig: &HooksConfig{
+					Path:   hooksPath,
+					Format: "json",
+				},
+			},
+		}
+	}
+
+	diagnostics := RunDoctor()
+	if len(diagnostics) != 1 {
+		t.Fatalf("RunDoctor returned %d diagnostics, want 1", len(diagnostics))
+	}
+	if got := diagnostics[0].HooksStatus; got != "not_installed" {
+		t.Errorf("HooksStatus: got %q, want %q", got, "not_installed")
 	}
 }
 

--- a/tui/model.go
+++ b/tui/model.go
@@ -24,6 +24,7 @@ const (
 	stateLLMCfg // Merged: General Settings + LLM Context Window → LLM Configuration
 	stateFinish
 	stateUninstall
+	stateRestore
 	stateMCPSetup
 	stateUpdate
 )
@@ -45,6 +46,7 @@ const (
 	menuInstall MenuOption = iota
 	menuUpdateBinary
 	menuUninstall
+	menuRestore
 	menuQuit
 )
 
@@ -57,6 +59,7 @@ type AppModel struct {
 	height        int
 	install       screens.InstallScreen
 	uninstall     screens.UninstallScreen
+	restore       screens.RestoreScreen
 	mcpSetup      screens.MCPSetupScreen
 	form          components.FormModel
 	cfg           *config.Config
@@ -89,6 +92,7 @@ func NewAppModel(width, height int) AppModel {
 		cfg:       cfg,
 		install:   screens.NewInstallScreen(width, cfg),
 		uninstall: screens.NewUninstallScreen(width),
+		restore:   screens.NewRestoreScreen(width),
 		mcpSetup:  screens.NewMCPSetupScreen(width),
 		form:      components.NewFormModel(cfg, width),
 		spin:      s,
@@ -182,6 +186,18 @@ func (m *AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			newModel, cmd := m.uninstall.Update(msg)
 			m.uninstall = *(newModel.(*screens.UninstallScreen))
 			if m.uninstall.Done() {
+				m.popState()
+			}
+			return m, cmd
+		case stateRestore:
+			if msg.String() == "esc" {
+				m.popState()
+				return m, nil
+			}
+			var cmd tea.Cmd
+			newModel, cmd := m.restore.Update(msg)
+			m.restore = *(newModel.(*screens.RestoreScreen))
+			if m.restore.Done() {
 				m.popState()
 			}
 			return m, cmd
@@ -284,6 +300,8 @@ func (m *AppModel) handleEnter() (tea.Model, tea.Cmd) {
 			}
 		case menuUninstall:
 			m.pushState(stateUninstall)
+		case menuRestore:
+			m.pushState(stateRestore)
 		case menuQuit:
 			return m, tea.Quit
 		}
@@ -365,6 +383,8 @@ func (m AppModel) View() string {
 		content = m.renderFinish()
 	case stateUninstall:
 		content = m.uninstall.View()
+	case stateRestore:
+		content = m.restore.View()
 	case stateMCPSetup:
 		content = m.mcpSetup.View()
 	case stateUpdate:
@@ -426,6 +446,7 @@ func (m AppModel) renderWelcome() string {
 		{menuInstall, "Install / Update Config"},
 		{menuUpdateBinary, "Update Binary"},
 		{menuUninstall, "Uninstall"},
+		{menuRestore, "Restore Config"},
 		{menuQuit, "Quit"},
 	}
 

--- a/tui/screens/restore.go
+++ b/tui/screens/restore.go
@@ -1,0 +1,156 @@
+// Package screens provides the TUI wizard screens for git-courer.
+//
+// This file implements the RestoreScreen: a three-step wizard (confirmation →
+// progress → done) that restores MCP client config backups and removes the
+// git-courer hook + GIT_COURER.md for each detected client. It mirrors
+// UninstallScreen's structure exactly, but delegates the destructive work to
+// installer.RunRestore (config-only; it never removes the binary or global
+// config).
+package screens
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/blak0p/git-courer/internal/installer"
+	"github.com/blak0p/git-courer/tui/styles"
+	"github.com/charmbracelet/bubbletea"
+)
+
+// RestoreScreen represents the restore flow model.
+type RestoreScreen struct {
+	width         int
+	step          int // 0=confirmation, 1=progress, 2=done
+	restoredItems []string
+	err           error
+}
+
+// NewRestoreScreen creates a new restore screen.
+func NewRestoreScreen(width int) RestoreScreen {
+	return RestoreScreen{
+		width: width,
+		step:  0,
+	}
+}
+
+// Init initializes the restore screen.
+func (m RestoreScreen) Init() tea.Cmd {
+	return nil
+}
+
+// Update handles messages for the restore screen.
+func (m *RestoreScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		return m, nil
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c":
+			return m, tea.Quit
+
+		case "enter":
+			return m.handleEnter()
+		}
+	}
+
+	return m, nil
+}
+
+// handleEnter handles the enter key based on current step.
+func (m *RestoreScreen) handleEnter() (tea.Model, tea.Cmd) {
+	switch m.step {
+	case 0: // Confirmation
+		m.step = 1
+		m.performRestore()
+
+	case 1: // Progress
+		m.step = 2
+
+	case 2: // Done
+		return m, nil
+	}
+	return m, nil
+}
+
+// Done returns true if the restore process is complete.
+func (m RestoreScreen) Done() bool {
+	return m.step == 2
+}
+
+// performRestore executes a config-only restore via installer.RunRestore.
+// The installer reports per-client actions on stdout; we capture a summary
+// list for the progress view. Unlike uninstall, the binary and global config
+// are left untouched.
+func (m *RestoreScreen) performRestore() {
+	m.restoredItems = []string{}
+	if err := installer.RunRestore(); err != nil {
+		m.err = err
+		return
+	}
+	// Report a single summary entry derived from the clients the installer
+	// iterated over. installer.RunRestore already prints per-client detail;
+	// the screen records a high-level confirmation for the progress view.
+	for _, client := range installer.DetectClients() {
+		m.restoredItems = append(m.restoredItems, fmt.Sprintf("Config restored: %s", client.Name))
+	}
+}
+
+// View renders the restore screen.
+func (m RestoreScreen) View() string {
+	var s strings.Builder
+
+	header := styles.BoxHeaderStyle.Render("RESTORE") + "\n\n"
+
+	if m.err != nil {
+		s.WriteString(styles.ErrorStyle.Render(fmt.Sprintf("Error: %v\n\n", m.err)))
+	}
+
+	var content string
+	switch m.step {
+	case 0:
+		content = m.renderConfirmation()
+	case 1:
+		content = m.renderProgress()
+	case 2:
+		content = m.renderDone()
+	}
+
+	s.WriteString(content)
+
+	return styles.BoxStyle.Render(header + s.String())
+}
+
+func (m RestoreScreen) renderConfirmation() string {
+	var s strings.Builder
+	s.WriteString(styles.SelectedStyle.Render("Confirm Restore\n\n"))
+	s.WriteString("This will restore MCP configs from backups and remove hooks\n")
+
+	s.WriteString(styles.HelpStyle.Render("Press ENTER to restore configs"))
+	return s.String()
+}
+
+func (m RestoreScreen) renderProgress() string {
+	var s strings.Builder
+	s.WriteString(styles.SelectedStyle.Render("Restoring...\n\n"))
+
+	for _, item := range m.restoredItems {
+		s.WriteString(styles.SuccessStyle.Render("✓ ") + item + "\n")
+	}
+
+	if len(m.restoredItems) == 0 {
+		s.WriteString(styles.SubtextStyle.Render("Nothing to restore.\n"))
+	}
+
+	return s.String()
+}
+
+func (m RestoreScreen) renderDone() string {
+	var s strings.Builder
+	s.WriteString(styles.SuccessStyle.Render("✓ Restore complete!\n\n"))
+	s.WriteString("MCP configs have been restored from backups.\n")
+	s.WriteString("\n")
+	s.WriteString(styles.SubtextStyle.Render("Press ENTER to exit\n"))
+	return s.String()
+}

--- a/tui/screens/restore_test.go
+++ b/tui/screens/restore_test.go
@@ -1,0 +1,58 @@
+// Package screens provides the TUI wizard screens for git-courer.
+package screens
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRestoreScreen_Init verifies a freshly created RestoreScreen starts at
+// step 0 (confirmation), not yet done.
+func TestRestoreScreen_Init(t *testing.T) {
+	m := NewRestoreScreen(80)
+
+	if m.step != 0 {
+		t.Errorf("initial step: got %d, want 0", m.step)
+	}
+	if m.Done() {
+		t.Error("fresh RestoreScreen should not be Done()")
+	}
+	if m.Init() != nil {
+		t.Error("Init should return nil cmd")
+	}
+}
+
+// TestRestoreScreen_Done verifies Done returns true only after the screen
+// reaches step 2 (done).
+func TestRestoreScreen_Done(t *testing.T) {
+	m := NewRestoreScreen(80)
+
+	if m.Done() {
+		t.Error("step 0 should not be Done()")
+	}
+
+	m.step = 1
+	if m.Done() {
+		t.Error("step 1 should not be Done()")
+	}
+
+	m.step = 2
+	if !m.Done() {
+		t.Error("step 2 should be Done()")
+	}
+}
+
+// TestRestoreScreen_View renders confirmation text at step 0.
+func TestRestoreScreen_View(t *testing.T) {
+	m := NewRestoreScreen(80)
+	view := m.View()
+
+	// Per the spec, the confirmation text must mention restoring configs and
+	// removing hooks.
+	if !strings.Contains(view, "restore") {
+		t.Errorf("confirmation view missing 'restore'\nview:\n%s", view)
+	}
+	if !strings.Contains(view, "hooks") {
+		t.Errorf("confirmation view missing 'hooks'\nview:\n%s", view)
+	}
+}


### PR DESCRIPTION
Closes #158, #160

## PR Type

- [x] New feature

## Summary

SDD 2 completo — Codex CLI PreToolUse Hook + Permissions:

### PR 1 (phases 1-4)
- hooks.go: installHook, removeHook, hooksStatus
- hook-check stdin mode for Codex CLI hook protocol
- ConfigureMCP installs hooks for Codex clients
- Doctor reports real hooks status

### PR 2 (phases 5-7)
- RunUninstall removes hooks + GIT_COURER.md before restoring backups
- New `git-courer restore` CLI subcommand for config-only restore
- New TUI restore screen with 3-step wizard

## Changes

| File | Change |
|------|--------|
| `internal/installer/hooks.go` | New: installHook, removeHook, hooksStatus |
| `internal/installer/installer.go` | RunUninstall hooks cleanup + new RunRestore |
| `internal/installer/mcp_config.go` | installHook on both code paths |
| `internal/installer/mcp_config_test.go` | 4 ConfigureMCP hook tests |
| `internal/installer/v26_test.go` | Updated + 8 new tests |
| `internal/delivery/cli/hook_check.go` | stdin mode + CodexHookOutput |
| `internal/delivery/cli/hook_check_test.go` | 5 stdin mode tests |
| `internal/delivery/cli/doctor.go` | real hooks status |
| `internal/delivery/cli/doctor_test.go` | 3 hooksLabel tests |
| `internal/delivery/cli/restore.go` | NEW: RestoreCommand |
| `internal/delivery/cli/restore_test.go` | NEW: 2 tests |
| `cmd/main.go` | restore subcommand |
| `tui/screens/restore.go` | NEW: RestoreScreen |
| `tui/screens/restore_test.go` | NEW: 3 tests |
| `tui/model.go` | stateRestore + menuRestore wired |

## Test Plan

- [x] `go test ./...` passes
- [x] 20+ new tests
- [x] Strict TDD mode