### PR TITLE
feat: SDD 2 — Codex CLI hooks (PreToolUse, SessionStart, SubagentStart)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -120,11 +120,13 @@ func showHelp() {
 	fmt.Println("    apply                     # Create and push release tag")
 	fmt.Println("    abort                     # Discard pending release")
 	fmt.Println("    regenerate [--feedback]   # Revise changelog with feedback")
-	fmt.Println("  git-courer hook-check <cmd> # Classify a command (agent hook)")
-	fmt.Println("  git-courer doctor           # Diagnose MCP client health")
-	fmt.Println("  git-courer update           # Check for binary updates")
-	fmt.Println("  git-courer uninstall        # Remove git-courer")
-	fmt.Println("  git-courer version          # Show version")
+	fmt.Println("  git-courer hook-check <cmd>     # Classify a command (agent hook)")
+	fmt.Println("  git-courer session-start-hook   # Codex SessionStart hook (agent)")
+	fmt.Println("  git-courer subagent-start-hook  # Codex SubagentStart hook (agent)")
+	fmt.Println("  git-courer doctor             # Diagnose MCP client health")
+	fmt.Println("  git-courer update             # Check for binary updates")
+	fmt.Println("  git-courer uninstall          # Remove git-courer")
+	fmt.Println("  git-courer version            # Show version")
 }
 
 func runVersionPredict() {
@@ -262,11 +264,13 @@ func runTUI() {
 		fmt.Println("")
 		fmt.Println("Usage:")
 		fmt.Println("  git-courer           # Launch TUI (requires terminal)")
-		fmt.Println("  git-courer mcp      # Run MCP server")
-		fmt.Println("  git-courer mcp setup # Configure MCP clients")
-		fmt.Println("  git-courer update    # Check for updates")
-		fmt.Println("  git-courer uninstall # Remove git-courer")
-		fmt.Println("  git-courer version  # Show version")
+		fmt.Println("  git-courer mcp              # Run MCP server")
+		fmt.Println("  git-courer mcp setup         # Configure MCP clients")
+		fmt.Println("  git-courer hook-check <cmd>  # Classify a command (agent hook)")
+		fmt.Println("  git-courer doctor            # Diagnose MCP client health")
+		fmt.Println("  git-courer update            # Check for updates")
+		fmt.Println("  git-courer uninstall         # Remove git-courer")
+		fmt.Println("  git-courer version           # Show version")
 		return
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -76,6 +76,12 @@ func main() {
 	case "hook-check":
 		runHookCheck(os.Args[2:])
 		return
+	case "session-start-hook":
+		runSessionStartHook()
+		return
+	case "subagent-start-hook":
+		runSubagentStartHook()
+		return
 	case "doctor":
 		runDoctor()
 		return
@@ -326,6 +332,26 @@ func runRelease(args []string) {
 func runHookCheck(args []string) {
 	cmd := cli.HookCheckCommand{}
 	if err := cmd.Run(args); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+// runSessionStartHook handles the session-start-hook subcommand.
+// It reads stdin (ignored) and returns golden rules as additionalContext.
+func runSessionStartHook() {
+	cmd := cli.SessionStartHookCommand{}
+	if err := cmd.Run(nil); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+// runSubagentStartHook handles the subagent-start-hook subcommand.
+// It reads stdin (ignored) and returns golden rules as additionalContext.
+func runSubagentStartHook() {
+	cmd := cli.SubagentStartHookCommand{}
+	if err := cmd.Run(nil); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/blak0p/git-courer
 go 1.26
 
 require (
+	github.com/BurntSushi/toml v1.4.0
 	github.com/bluekeyes/go-gitdiff v0.8.1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
+github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=

--- a/internal/delivery/cli/doctor.go
+++ b/internal/delivery/cli/doctor.go
@@ -50,8 +50,12 @@ func statusLabel(ok bool) string {
 }
 
 func hooksLabel(status string) string {
-	if status == "not_implemented" {
-		return "pending (SDDs 2-5)"
+	switch status {
+	case "installed":
+		return "yes"
+	case "not_installed":
+		return "no"
+	default:
+		return status
 	}
-	return status
 }

--- a/internal/delivery/cli/doctor_test.go
+++ b/internal/delivery/cli/doctor_test.go
@@ -25,7 +25,7 @@ func TestDoctorRun_PrintsDiagnostics(t *testing.T) {
 				ConfigPath:         "/tmp/config.json",
 				MCPConfigured:      true,
 				GitCourerMdPresent: true,
-				HooksStatus:        "not_implemented",
+				HooksStatus:        "not_installed",
 			},
 		}
 	}
@@ -61,8 +61,8 @@ func TestDoctorRun_PrintsDiagnostics(t *testing.T) {
 	if !strings.Contains(output, "yes") {
 		t.Errorf("output missing 'yes' status markers\noutput: %s", output)
 	}
-	if !strings.Contains(output, "pending (SDDs 2-5)") {
-		t.Errorf("output missing hooks status\noutput: %s", output)
+	if !strings.Contains(output, "no") {
+		t.Errorf("output missing hooks status 'no'\noutput: %s", output)
 	}
 }
 

--- a/internal/delivery/cli/hook_check.go
+++ b/internal/delivery/cli/hook_check.go
@@ -8,10 +8,21 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/blak0p/git-courer/internal/classifier/gitcmd"
 )
+
+// isStdinPipe returns true when os.Stdin is connected to a pipe (not a
+// terminal). This is used to detect Codex hook stdin mode.
+var isStdinPipe = func() bool {
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (stat.Mode() & os.ModeCharDevice) == 0
+}
 
 // HookCheckCommand implements the hook-check CLI subcommand.
 //
@@ -19,14 +30,57 @@ import (
 // gitcmd.Classify, and prints the classification Result as JSON to stdout.
 // This is a thin adapter — all classification logic lives in the gitcmd
 // package so it can be unit-tested independently.
-type HookCheckCommand struct{}
+//
+// When no args are provided and stdin is a pipe, it reads Codex hook JSON
+// from stdin, extracts the command, and classifies it. For git commands it
+// emits additionalContext suggesting the git-courer MCP tool. Non-git
+// commands exit cleanly with no output.
+type HookCheckCommand struct {
+	Stdin  io.Reader // for testing; nil = os.Stdin
+	Stdout io.Writer // for testing; nil = os.Stdout
+}
+
+// codexHookInput represents the JSON structure Codex sends via stdin
+// for PreToolUse hooks.
+type codexHookInput struct {
+	Event struct {
+		Input struct {
+			Command string `json:"command"`
+		} `json:"input"`
+	} `json:"event"`
+}
+
+// codexHookOutput represents the JSON structure Codex expects as output
+// from a PreToolUse hook.
+type codexHookOutput struct {
+	HookSpecificOutput struct {
+		HookEventName     string `json:"hookEventName"`
+		AdditionalContext string `json:"additionalContext,omitempty"`
+	} `json:"hookSpecificOutput"`
+}
 
 // Run classifies args[0] and emits the Result as JSON on stdout.
-// It returns an error if no command argument was provided.
+// If no args are provided and stdin is a pipe, it reads Codex hook JSON
+// from stdin and classifies the embedded command.
 func (c HookCheckCommand) Run(args []string) error {
+	stdin := c.Stdin
+	if stdin == nil {
+		stdin = os.Stdin
+	}
+	stdout := c.Stdout
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+
+	// Stdin mode: no args, and either Stdin is explicitly set (testing) or
+	// os.Stdin is a pipe (Codex hook mode).
 	if len(args) == 0 {
+		if c.Stdin != nil || isStdinPipe() {
+			return c.runStdinMode(stdin, stdout)
+		}
 		return fmt.Errorf("usage: git-courer hook-check <command>")
 	}
+
 	command := args[0]
 	if command == "" {
 		return fmt.Errorf("usage: git-courer hook-check <command>")
@@ -35,8 +89,117 @@ func (c HookCheckCommand) Run(args []string) error {
 	result := gitcmd.Classify(command)
 
 	// Emit as JSON — consistent with existing delivery patterns.
-	if err := json.NewEncoder(os.Stdout).Encode(result); err != nil {
+	if err := json.NewEncoder(stdout).Encode(result); err != nil {
 		return fmt.Errorf("hook-check: failed to encode result: %w", err)
 	}
 	return nil
 }
+
+// runStdinMode reads Codex hook JSON from stdin, extracts the command,
+// and emits Codex hook output. For git commands it includes additionalContext
+// suggesting the MCP tool. Non-git commands exit cleanly with no output.
+func (c HookCheckCommand) runStdinMode(stdin io.Reader, stdout io.Writer) error {
+	data, err := io.ReadAll(stdin)
+	if err != nil {
+		return fmt.Errorf("hook-check: failed to read stdin: %w", err)
+	}
+
+	var input codexHookInput
+	if err := json.Unmarshal(data, &input); err != nil {
+		// If we can't parse the input, exit cleanly (safe fallback).
+		return nil
+	}
+
+	command := input.Event.Input.Command
+	if command == "" {
+		return nil
+	}
+
+	result := gitcmd.Classify(command)
+
+	// Only emit output for git commands (Decision == "ask").
+	if result.Decision != "ask" {
+		return nil
+	}
+
+	// Build the additionalContext suggesting the MCP tool.
+	additionalContext := fmt.Sprintf("Use git-courer/%s instead of bash %s", result.MCPTool, command)
+
+	output := codexHookOutput{}
+	output.HookSpecificOutput.HookEventName = "PreToolUse"
+	output.HookSpecificOutput.AdditionalContext = additionalContext
+
+	if err := json.NewEncoder(stdout).Encode(output); err != nil {
+		return fmt.Errorf("hook-check: failed to encode output: %w", err)
+	}
+	return nil
+}
+
+// SessionStartHookCommand implements the session-start-hook CLI subcommand.
+// It reads stdin (ignored) and returns golden rules as additionalContext.
+type SessionStartHookCommand struct {
+	Stdin  io.Reader // for testing; nil = os.Stdin
+	Stdout io.Writer // for testing; nil = os.Stdout
+}
+
+// Run reads stdin (ignored) and emits golden rules as Codex hook output.
+func (c SessionStartHookCommand) Run(args []string) error {
+	stdout := c.Stdout
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+
+	// Read and discard stdin (Codex sends event JSON but we don't need it).
+	stdin := c.Stdin
+	if stdin == nil {
+		stdin = os.Stdin
+	}
+	_, _ = io.ReadAll(stdin)
+
+	output := codexHookOutput{}
+	output.HookSpecificOutput.HookEventName = "SessionStart"
+	output.HookSpecificOutput.AdditionalContext = `## git-courer Golden Rules
+
+1. BEFORE any mutation → status
+2. BEFORE push → diff + review
+3. BEFORE PR → pr-review
+
+Use git-courer MCP tools instead of raw bash git.`
+
+	return json.NewEncoder(stdout).Encode(output)
+}
+
+// SubagentStartHookCommand implements the subagent-start-hook CLI subcommand.
+// It reads stdin (ignored) and returns golden rules as additionalContext.
+type SubagentStartHookCommand struct {
+	Stdin  io.Reader // for testing; nil = os.Stdin
+	Stdout io.Writer // for testing; nil = os.Stdout
+}
+
+// Run reads stdin (ignored) and emits golden rules as Codex hook output.
+func (c SubagentStartHookCommand) Run(args []string) error {
+	stdout := c.Stdout
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+
+	// Read and discard stdin (Codex sends event JSON but we don't need it).
+	stdin := c.Stdin
+	if stdin == nil {
+		stdin = os.Stdin
+	}
+	_, _ = io.ReadAll(stdin)
+
+	output := codexHookOutput{}
+	output.HookSpecificOutput.HookEventName = "SubagentStart"
+	output.HookSpecificOutput.AdditionalContext = `## git-courer Golden Rules
+
+1. BEFORE any mutation → status
+2. BEFORE push → diff + review
+3. BEFORE PR → pr-review
+
+Use git-courer MCP tools instead of raw bash git.`
+
+	return json.NewEncoder(stdout).Encode(output)
+}
+

--- a/internal/delivery/cli/hook_check.go
+++ b/internal/delivery/cli/hook_check.go
@@ -12,6 +12,7 @@ import (
 	"os"
 
 	"github.com/blak0p/git-courer/internal/classifier/gitcmd"
+	"github.com/blak0p/git-courer/internal/installer"
 )
 
 // isStdinPipe returns true when os.Stdin is connected to a pipe (not a
@@ -51,11 +52,14 @@ type codexHookInput struct {
 }
 
 // codexHookOutput represents the JSON structure Codex expects as output
-// from a PreToolUse hook.
+// from a hook. PreToolUse uses permissionDecision + permissionDecisionReason.
+// SessionStart/SubagentStart use additionalContext with golden rules.
 type codexHookOutput struct {
 	HookSpecificOutput struct {
-		HookEventName     string `json:"hookEventName"`
-		AdditionalContext string `json:"additionalContext,omitempty"`
+		HookEventName            string `json:"hookEventName"`
+		PermissionDecision       string `json:"permissionDecision,omitempty"`
+		PermissionDecisionReason string `json:"permissionDecisionReason,omitempty"`
+		AdditionalContext        string `json:"additionalContext,omitempty"`
 	} `json:"hookSpecificOutput"`
 }
 
@@ -97,7 +101,8 @@ func (c HookCheckCommand) Run(args []string) error {
 
 // runStdinMode reads Codex hook JSON from stdin, extracts the command,
 // and emits Codex hook output. For git commands it includes additionalContext
-// suggesting the MCP tool. Non-git commands exit cleanly with no output.
+// suggesting the MCP tool, so the agent knows to use git-courer instead.
+// Non-git commands exit cleanly with no output.
 func (c HookCheckCommand) runStdinMode(stdin io.Reader, stdout io.Writer) error {
 	data, err := io.ReadAll(stdin)
 	if err != nil {
@@ -122,7 +127,9 @@ func (c HookCheckCommand) runStdinMode(stdin io.Reader, stdout io.Writer) error 
 		return nil
 	}
 
-	// Build the additionalContext suggesting the MCP tool.
+	// Suggest the MCP tool via additionalContext — never deny.
+	// Codex always asks the user for permission on bash commands anyway.
+	// The agent sees the suggestion and the golden rules from SessionStart.
 	additionalContext := fmt.Sprintf("Use git-courer/%s instead of bash %s", result.MCPTool, command)
 
 	output := codexHookOutput{}
@@ -158,13 +165,7 @@ func (c SessionStartHookCommand) Run(args []string) error {
 
 	output := codexHookOutput{}
 	output.HookSpecificOutput.HookEventName = "SessionStart"
-	output.HookSpecificOutput.AdditionalContext = `## git-courer Golden Rules
-
-1. BEFORE any mutation → status
-2. BEFORE push → diff + review
-3. BEFORE PR → pr-review
-
-Use git-courer MCP tools instead of raw bash git.`
+	output.HookSpecificOutput.AdditionalContext = installer.GoldenRulesAdditionalContext
 
 	return json.NewEncoder(stdout).Encode(output)
 }
@@ -192,13 +193,7 @@ func (c SubagentStartHookCommand) Run(args []string) error {
 
 	output := codexHookOutput{}
 	output.HookSpecificOutput.HookEventName = "SubagentStart"
-	output.HookSpecificOutput.AdditionalContext = `## git-courer Golden Rules
-
-1. BEFORE any mutation → status
-2. BEFORE push → diff + review
-3. BEFORE PR → pr-review
-
-Use git-courer MCP tools instead of raw bash git.`
+	output.HookSpecificOutput.AdditionalContext = installer.GoldenRulesAdditionalContext
 
 	return json.NewEncoder(stdout).Encode(output)
 }

--- a/internal/delivery/cli/hook_check_test.go
+++ b/internal/delivery/cli/hook_check_test.go
@@ -100,7 +100,7 @@ func TestHookCheckRun_EmptyArg(t *testing.T) {
 }
 
 // TestHookCheckStdin_GitCommand verifies stdin mode emits additionalContext
-// for git commands.
+// suggesting the MCP tool for git commands.
 func TestHookCheckStdin_GitCommand(t *testing.T) {
 	input := `{"event":{"input":{"command":"git status"}}}`
 	var stdinBuf bytes.Buffer
@@ -131,6 +131,9 @@ func TestHookCheckStdin_GitCommand(t *testing.T) {
 	}
 	if !strings.Contains(output.HookSpecificOutput.AdditionalContext, "git-courer/status") {
 		t.Errorf("AdditionalContext missing MCP tool suggestion: %q", output.HookSpecificOutput.AdditionalContext)
+	}
+	if output.HookSpecificOutput.PermissionDecision != "" {
+		t.Errorf("PermissionDecision should be empty (suggest, not deny), got %q", output.HookSpecificOutput.PermissionDecision)
 	}
 }
 

--- a/internal/delivery/cli/hook_check_test.go
+++ b/internal/delivery/cli/hook_check_test.go
@@ -5,12 +5,243 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 )
 
 // TestHookCheckRun_GitCommand verifies a git command is classified and the
 // Result is emitted as JSON on stdout.
 func TestHookCheckRun_GitCommand(t *testing.T) {
+	cmd := HookCheckCommand{}
+
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+
+	err := cmd.Run([]string{"git status"})
+
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	var result map[string]string
+	if jsonErr := json.Unmarshal(buf.Bytes(), &result); jsonErr != nil {
+		t.Fatalf("stdout is not valid JSON: %v\noutput: %q", jsonErr, buf.String())
+	}
+
+	if result["Command"] != "git status" {
+		t.Errorf("Command: got %q, want %q", result["Command"], "git status")
+	}
+	if result["Decision"] != "ask" {
+		t.Errorf("Decision: got %q, want %q", result["Decision"], "ask")
+	}
+	if result["MCPTool"] != "status" {
+		t.Errorf("MCPTool: got %q, want %q", result["MCPTool"], "status")
+	}
+	if result["Reason"] == "" {
+		t.Error("Reason is empty — expected non-empty reason")
+	}
+}
+
+// TestHookCheckRun_NonGitCommand verifies a non-git command is classified as
+// allow and emitted as JSON on stdout.
+func TestHookCheckRun_NonGitCommand(t *testing.T) {
+	cmd := HookCheckCommand{}
+
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+
+	err := cmd.Run([]string{"ls -la"})
+
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	var result map[string]string
+	if jsonErr := json.Unmarshal(buf.Bytes(), &result); jsonErr != nil {
+		t.Fatalf("stdout is not valid JSON: %v\noutput: %q", jsonErr, buf.String())
+	}
+
+	if result["Command"] != "ls -la" {
+		t.Errorf("Command: got %q, want %q", result["Command"], "ls -la")
+	}
+	if result["Decision"] != "allow" {
+		t.Errorf("Decision: got %q, want %q", result["Decision"], "allow")
+	}
+	if result["MCPTool"] != "" {
+		t.Errorf("MCPTool: got %q, want empty", result["MCPTool"])
+	}
+}
+
+// TestHookCheckRun_NoArgs verifies Run returns an error when no args provided.
+func TestHookCheckRun_NoArgs(t *testing.T) {
+	cmd := HookCheckCommand{}
+
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+
+	err := cmd.Run([]string{})
+	if err == nil {
+		t.Fatal("expected error when no args provided, got nil")
+	}
+}
+
+// TestHookCheckRun_EmptyArg verifies Run returns an error when the single
+// argument is empty (nothing to classify).
+func TestHookCheckRun_EmptyArg(t *testing.T) {
+	cmd := HookCheckCommand{}
+
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+
+	err := cmd.Run([]string{""})
+	if err == nil {
+		t.Fatal("expected error when arg is empty, got nil")
+	}
+}
+
+// TestHookCheckStdin_GitCommand verifies stdin mode emits additionalContext
+// for git commands.
+func TestHookCheckStdin_GitCommand(t *testing.T) {
+	input := `{"event":{"input":{"command":"git status"}}}`
+	var stdinBuf bytes.Buffer
+	stdinBuf.WriteString(input)
+
+	var stdoutBuf bytes.Buffer
+	cmd := HookCheckCommand{
+		Stdin:  &stdinBuf,
+		Stdout: &stdoutBuf,
+	}
+
+	err := cmd.Run([]string{})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if stdoutBuf.Len() == 0 {
+		t.Fatal("expected output for git command, got empty")
+	}
+
+	var output codexHookOutput
+	if jsonErr := json.Unmarshal(stdoutBuf.Bytes(), &output); jsonErr != nil {
+		t.Fatalf("stdout is not valid JSON: %v\noutput: %q", jsonErr, stdoutBuf.String())
+	}
+
+	if output.HookSpecificOutput.HookEventName != "PreToolUse" {
+		t.Errorf("HookEventName: got %q, want %q", output.HookSpecificOutput.HookEventName, "PreToolUse")
+	}
+	if !strings.Contains(output.HookSpecificOutput.AdditionalContext, "git-courer/status") {
+		t.Errorf("AdditionalContext missing MCP tool suggestion: %q", output.HookSpecificOutput.AdditionalContext)
+	}
+}
+
+// TestHookCheckStdin_NonGitCommand verifies stdin mode produces no output
+// for non-git commands.
+func TestHookCheckStdin_NonGitCommand(t *testing.T) {
+	input := `{"event":{"input":{"command":"ls -la"}}}`
+	var stdinBuf bytes.Buffer
+	stdinBuf.WriteString(input)
+
+	var stdoutBuf bytes.Buffer
+	cmd := HookCheckCommand{
+		Stdin:  &stdinBuf,
+		Stdout: &stdoutBuf,
+	}
+
+	err := cmd.Run([]string{})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if stdoutBuf.Len() > 0 {
+		t.Errorf("expected no output for non-git command, got: %s", stdoutBuf.String())
+	}
+}
+
+// TestHookCheckStdin_InvalidJSON verifies stdin mode handles invalid JSON
+// gracefully (safe fallback, no error).
+func TestHookCheckStdin_InvalidJSON(t *testing.T) {
+	var stdinBuf bytes.Buffer
+	stdinBuf.WriteString("not json")
+
+	var stdoutBuf bytes.Buffer
+	cmd := HookCheckCommand{
+		Stdin:  &stdinBuf,
+		Stdout: &stdoutBuf,
+	}
+
+	err := cmd.Run([]string{})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if stdoutBuf.Len() > 0 {
+		t.Errorf("expected no output for invalid JSON, got: %s", stdoutBuf.String())
+	}
+}
+
+// TestSessionStartHookCommand_ReturnsGoldenRules verifies session-start-hook
+// returns golden rules as additionalContext.
+func TestSessionStartHookCommand_ReturnsGoldenRules(t *testing.T) {
+	var stdinBuf bytes.Buffer
+	stdinBuf.WriteString(`{"event":{"input":{"command":"startup"}}}`)
+
+	var stdoutBuf bytes.Buffer
+	cmd := SessionStartHookCommand{
+		Stdin:  &stdinBuf,
+		Stdout: &stdoutBuf,
+	}
+
+	err := cmd.Run([]string{})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	var output codexHookOutput
+	if jsonErr := json.Unmarshal(stdoutBuf.Bytes(), &output); jsonErr != nil {
+		t.Fatalf("stdout is not valid JSON: %v\noutput: %q", jsonErr, stdoutBuf.String())
+	}
+
+	if output.HookSpecificOutput.HookEventName != "SessionStart" {
+		t.Errorf("HookEventName: got %q, want %q", output.HookSpecificOutput.HookEventName, "SessionStart")
+	}
+	if !strings.Contains(output.HookSpecificOutput.AdditionalContext, "Golden Rules") {
+		t.Errorf("AdditionalContext missing golden rules: %q", output.HookSpecificOutput.AdditionalContext)
+	}
+}
+
+// TestSubagentStartHookCommand_ReturnsGoldenRules verifies subagent-start-hook
+// returns golden rules as additionalContext.
+func TestSubagentStartHookCommand_ReturnsGoldenRules(t *testing.T) {
+	var stdinBuf bytes.Buffer
+	stdinBuf.WriteString(`{"event":{"input":{"command":"spawn"}}}`)
+
+	var stdoutBuf bytes.Buffer
+	cmd := SubagentStartHookCommand{
+		Stdin:  &stdinBuf,
+		Stdout: &stdoutBuf,
+	}
+
+	err := cmd.Run([]string{})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	var output codexHookOutput
+	if jsonErr := json.Unmarshal(stdoutBuf.Bytes(), &output); jsonErr != nil {
+		t.Fatalf("stdout is not valid JSON: %v\noutput: %q", jsonErr, stdoutBuf.String())
+	}
+
+	if output.HookSpecificOutput.HookEventName != "SubagentStart" {
+		t.Errorf("HookEventName: got %q, want %q", output.HookSpecificOutput.HookEventName, "SubagentStart")
+	}
+	if !strings.Contains(output.HookSpecificOutput.AdditionalContext, "Golden Rules") {
+		t.Errorf("AdditionalContext missing golden rules: %q", output.HookSpecificOutput.AdditionalContext)
+	}
+}
+
+// TestHookCheckRun_GitCommand_OldStdout verifies backward compatibility with
+// the old os.Stdout-based output (for the existing test pattern).
+func TestHookCheckRun_GitCommand_OldStdout(t *testing.T) {
 	cmd := HookCheckCommand{}
 
 	oldStdout := os.Stdout
@@ -44,74 +275,5 @@ func TestHookCheckRun_GitCommand(t *testing.T) {
 	}
 	if result["Decision"] != "ask" {
 		t.Errorf("Decision: got %q, want %q", result["Decision"], "ask")
-	}
-	if result["MCPTool"] != "status" {
-		t.Errorf("MCPTool: got %q, want %q", result["MCPTool"], "status")
-	}
-	if result["Reason"] == "" {
-		t.Error("Reason is empty — expected non-empty reason")
-	}
-}
-
-// TestHookCheckRun_NonGitCommand verifies a non-git command is classified as
-// allow and emitted as JSON on stdout.
-func TestHookCheckRun_NonGitCommand(t *testing.T) {
-	cmd := HookCheckCommand{}
-
-	oldStdout := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
-	os.Stdout = w
-
-	err = cmd.Run([]string{"ls -la"})
-
-	w.Close()
-	os.Stdout = oldStdout
-
-	if err != nil {
-		t.Fatalf("Run returned error: %v", err)
-	}
-
-	var buf bytes.Buffer
-	if _, copyErr := buf.ReadFrom(r); copyErr != nil {
-		t.Fatalf("read pipe: %v", copyErr)
-	}
-
-	var result map[string]string
-	if jsonErr := json.Unmarshal(buf.Bytes(), &result); jsonErr != nil {
-		t.Fatalf("stdout is not valid JSON: %v\noutput: %q", jsonErr, buf.String())
-	}
-
-	if result["Command"] != "ls -la" {
-		t.Errorf("Command: got %q, want %q", result["Command"], "ls -la")
-	}
-	if result["Decision"] != "allow" {
-		t.Errorf("Decision: got %q, want %q", result["Decision"], "allow")
-	}
-	if result["MCPTool"] != "" {
-		t.Errorf("MCPTool: got %q, want empty", result["MCPTool"])
-	}
-}
-
-// TestHookCheckRun_NoArgs verifies Run returns an error when no args provided.
-func TestHookCheckRun_NoArgs(t *testing.T) {
-	cmd := HookCheckCommand{}
-
-	err := cmd.Run([]string{})
-	if err == nil {
-		t.Fatal("expected error when no args provided, got nil")
-	}
-}
-
-// TestHookCheckRun_EmptyArg verifies Run returns an error when the single
-// argument is empty (nothing to classify).
-func TestHookCheckRun_EmptyArg(t *testing.T) {
-	cmd := HookCheckCommand{}
-
-	err := cmd.Run([]string{""})
-	if err == nil {
-		t.Fatal("expected error when arg is empty, got nil")
 	}
 }

--- a/internal/installer/hooks.go
+++ b/internal/installer/hooks.go
@@ -2,11 +2,154 @@
 package installer
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
+
+// goldenRulesAdditionalContext is the markdown content returned by
+// session-start-hook and subagent-start-hook as additionalContext.
+const goldenRulesAdditionalContext = `## git-courer Golden Rules
+
+1. BEFORE any mutation → status
+2. BEFORE push → diff + review
+3. BEFORE PR → pr-review
+
+Use git-courer MCP tools instead of raw bash git.`
+
+// hooksJSON represents the structure of a Codex hooks.json file.
+type hooksJSON struct {
+	Hooks map[string][]hookEntry `json:"hooks"`
+}
+
+type hookEntry struct {
+	Matcher string      `json:"matcher"`
+	Hooks   []hookCmd   `json:"hooks"`
+}
+
+type hookCmd struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+}
+
+// installHook creates or updates hooks.json at hooksPath with PreToolUse,
+// SessionStart, and SubagentStart entries pointing to binPath.
+// It backs up existing hooks.json before mutation.
+// Idempotent: skips entries that already have the same matcher+command.
+func installHook(hooksPath, binPath string) error {
+	// Backup existing hooks.json before mutation.
+	if _, err := os.Stat(hooksPath); err == nil {
+		data, err := os.ReadFile(hooksPath)
+		if err != nil {
+			return fmt.Errorf("failed to read existing hooks.json: %w", err)
+		}
+		if err := os.WriteFile(hooksPath+".bak", data, 0644); err != nil {
+			return fmt.Errorf("failed to backup hooks.json: %w", err)
+		}
+	}
+
+	// Read existing hooks or start fresh.
+	hooks := hooksJSON{Hooks: make(map[string][]hookEntry)}
+	if data, err := os.ReadFile(hooksPath); err == nil {
+		_ = json.Unmarshal(data, &hooks)
+		if hooks.Hooks == nil {
+			hooks.Hooks = make(map[string][]hookEntry)
+		}
+	}
+
+	// Define the hooks to install.
+	entries := []struct {
+		event   string
+		matcher string
+		command string
+	}{
+		{event: "PreToolUse", matcher: "Bash", command: binPath + " hook-check"},
+		{event: "SessionStart", matcher: "startup|resume", command: binPath + " session-start-hook"},
+		{event: "SubagentStart", matcher: "general-purpose|Explore|Plan", command: binPath + " subagent-start-hook"},
+	}
+
+	for _, e := range entries {
+		// Check if this matcher+command already exists (idempotent).
+		existing := hooks.Hooks[e.event]
+		found := false
+		for _, entry := range existing {
+			if entry.Matcher == e.matcher && len(entry.Hooks) > 0 && entry.Hooks[0].Command == e.command {
+				found = true
+				break
+			}
+		}
+		if found {
+			continue
+		}
+
+		// Add the hook entry.
+		hooks.Hooks[e.event] = append(hooks.Hooks[e.event], hookEntry{
+			Matcher: e.matcher,
+			Hooks: []hookCmd{
+				{Type: "command", Command: e.command},
+			},
+		})
+	}
+
+	data, err := json.MarshalIndent(hooks, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal hooks.json: %w", err)
+	}
+	return os.WriteFile(hooksPath, data, 0644)
+}
+
+// RemoveHook deletes hooks.json and restores .bak if it exists.
+func RemoveHook(hooksPath string) error {
+	// Try to restore .bak first.
+	bakPath := hooksPath + ".bak"
+	if _, err := os.Stat(bakPath); err == nil {
+		data, err := os.ReadFile(bakPath)
+		if err != nil {
+			return fmt.Errorf("failed to read backup: %w", err)
+		}
+		if err := os.WriteFile(hooksPath, data, 0644); err != nil {
+			return fmt.Errorf("failed to restore backup: %w", err)
+		}
+		_ = os.Remove(bakPath)
+		return nil
+	}
+
+	// No backup — just remove hooks.json.
+	if err := os.Remove(hooksPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove hooks.json: %w", err)
+	}
+	return nil
+}
+
+// hooksStatus returns "installed" if hooks.json exists with a git-courer
+// PreToolUse entry, or "not_installed" otherwise.
+func hooksStatus(hooksPath string) string {
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		return "not_installed"
+	}
+
+	var hooks hooksJSON
+	if err := json.Unmarshal(data, &hooks); err != nil {
+		return "not_installed"
+	}
+
+	entries, ok := hooks.Hooks["PreToolUse"]
+	if !ok {
+		return "not_installed"
+	}
+
+	for _, entry := range entries {
+		if entry.Matcher == "Bash" && len(entry.Hooks) > 0 && strings.Contains(entry.Hooks[0].Command, "git-courer") {
+			return "installed"
+		}
+	}
+
+	return "not_installed"
+}
 
 // FindBinaryPath tries to find the git-courer binary path.
 // Supports Linux, macOS, and Windows.

--- a/internal/installer/hooks.go
+++ b/internal/installer/hooks.go
@@ -12,7 +12,7 @@ import (
 
 // goldenRulesAdditionalContext is the markdown content returned by
 // session-start-hook and subagent-start-hook as additionalContext.
-const goldenRulesAdditionalContext = `## git-courer Golden Rules
+const GoldenRulesAdditionalContext = `## git-courer Golden Rules
 
 1. BEFORE any mutation → status
 2. BEFORE push → diff + review

--- a/internal/installer/hooks_test.go
+++ b/internal/installer/hooks_test.go
@@ -1,0 +1,248 @@
+// Package installer_test verifies hook installation, removal, and status.
+package installer
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestInstallHook_CreatesHooksJSON verifies installHook creates hooks.json
+// with PreToolUse, SessionStart, and SubagentStart entries.
+func TestInstallHook_CreatesHooksJSON(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+
+	if err := installHook(hooksPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("installHook: %v", err)
+	}
+
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("hooks.json not created: %v", err)
+	}
+
+	var hooks struct {
+		Hooks map[string][]struct {
+			Matcher string `json:"matcher"`
+			Hooks   []struct {
+				Type    string `json:"type"`
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &hooks); err != nil {
+		t.Fatalf("hooks.json is not valid JSON: %v\ncontent: %s", err, data)
+	}
+
+	// Check PreToolUse entry
+	preToolUse, ok := hooks.Hooks["PreToolUse"]
+	if !ok {
+		t.Fatal("missing PreToolUse entry")
+	}
+	if len(preToolUse) != 1 {
+		t.Fatalf("PreToolUse: got %d entries, want 1", len(preToolUse))
+	}
+	if preToolUse[0].Matcher != "Bash" {
+		t.Errorf("PreToolUse matcher: got %q, want %q", preToolUse[0].Matcher, "Bash")
+	}
+	if len(preToolUse[0].Hooks) != 1 {
+		t.Fatalf("PreToolUse hooks: got %d, want 1", len(preToolUse[0].Hooks))
+	}
+	if !strings.Contains(preToolUse[0].Hooks[0].Command, "hook-check") {
+		t.Errorf("PreToolUse command missing hook-check: %q", preToolUse[0].Hooks[0].Command)
+	}
+
+	// Check SessionStart entry
+	sessionStart, ok := hooks.Hooks["SessionStart"]
+	if !ok {
+		t.Fatal("missing SessionStart entry")
+	}
+	if len(sessionStart) != 1 {
+		t.Fatalf("SessionStart: got %d entries, want 1", len(sessionStart))
+	}
+	if sessionStart[0].Matcher != "startup|resume" {
+		t.Errorf("SessionStart matcher: got %q, want %q", sessionStart[0].Matcher, "startup|resume")
+	}
+	if !strings.Contains(sessionStart[0].Hooks[0].Command, "session-start-hook") {
+		t.Errorf("SessionStart command missing session-start-hook: %q", sessionStart[0].Hooks[0].Command)
+	}
+
+	// Check SubagentStart entry
+	subagentStart, ok := hooks.Hooks["SubagentStart"]
+	if !ok {
+		t.Fatal("missing SubagentStart entry")
+	}
+	if len(subagentStart) != 1 {
+		t.Fatalf("SubagentStart: got %d entries, want 1", len(subagentStart))
+	}
+	if subagentStart[0].Matcher != "general-purpose|Explore|Plan" {
+		t.Errorf("SubagentStart matcher: got %q, want %q", subagentStart[0].Matcher, "general-purpose|Explore|Plan")
+	}
+	if !strings.Contains(subagentStart[0].Hooks[0].Command, "subagent-start-hook") {
+		t.Errorf("SubagentStart command missing subagent-start-hook: %q", subagentStart[0].Hooks[0].Command)
+	}
+}
+
+// TestInstallHook_Idempotent verifies installHook does not duplicate entries
+// when called a second time.
+func TestInstallHook_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+
+	if err := installHook(hooksPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("first installHook: %v", err)
+	}
+
+	if err := installHook(hooksPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("second installHook: %v", err)
+	}
+
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("hooks.json not found: %v", err)
+	}
+
+	var hooks struct {
+		Hooks map[string][]struct {
+			Matcher string `json:"matcher"`
+			Hooks   []struct {
+				Type    string `json:"type"`
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &hooks); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// Each hook type should have exactly 1 entry (no duplicates).
+	for _, hookType := range []string{"PreToolUse", "SessionStart", "SubagentStart"} {
+		entries := hooks.Hooks[hookType]
+		if len(entries) != 1 {
+			t.Errorf("%s: got %d entries, want 1 (duplicate detected)", hookType, len(entries))
+		}
+	}
+}
+
+// TestInstallHook_BackupsExisting verifies installHook backs up an existing
+// hooks.json before mutation.
+func TestInstallHook_BackupsExisting(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+
+	original := `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"echo hello"}]}]}}`
+	if err := os.WriteFile(hooksPath, []byte(original), 0644); err != nil {
+		t.Fatalf("write original: %v", err)
+	}
+
+	if err := installHook(hooksPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("installHook: %v", err)
+	}
+
+	// Verify backup exists with original content.
+	bakData, err := os.ReadFile(hooksPath + ".bak")
+	if err != nil {
+		t.Fatalf("backup not created: %v", err)
+	}
+	if string(bakData) != original {
+		t.Errorf("backup content mismatch:\ngot:  %s\nwant: %s", bakData, original)
+	}
+}
+
+// TestRemoveHook_RemovesHooksJSON verifies removeHook deletes hooks.json.
+func TestRemoveHook_RemovesHooksJSON(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+
+	if err := installHook(hooksPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("installHook: %v", err)
+	}
+
+	if err := RemoveHook(hooksPath); err != nil {
+		t.Fatalf("RemoveHook: %v", err)
+	}
+
+	if _, err := os.Stat(hooksPath); err == nil {
+		t.Error("hooks.json still exists after RemoveHook")
+	}
+}
+
+// TestRemoveHook_RestoresBackup verifies RemoveHook restores .bak when it exists.
+func TestRemoveHook_RestoresBackup(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+
+	original := `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"echo hello"}]}]}}`
+	if err := os.WriteFile(hooksPath, []byte(original), 0644); err != nil {
+		t.Fatalf("write original: %v", err)
+	}
+	if err := os.WriteFile(hooksPath+".bak", []byte(original), 0644); err != nil {
+		t.Fatalf("write backup: %v", err)
+	}
+
+	if err := RemoveHook(hooksPath); err != nil {
+		t.Fatalf("removeHook: %v", err)
+	}
+
+	// hooks.json should be restored from .bak.
+	restored, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("hooks.json not restored: %v", err)
+	}
+	if string(restored) != original {
+		t.Errorf("restored content mismatch:\ngot:  %s\nwant: %s", restored, original)
+	}
+
+	// .bak should be removed.
+	if _, err := os.Stat(hooksPath + ".bak"); err == nil {
+		t.Error("backup file should have been removed after restore")
+	}
+}
+
+// TestHooksStatus_Installed verifies hooksStatus returns "installed" when
+// hooks.json exists with a git-courer PreToolUse entry.
+func TestHooksStatus_Installed(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+
+	if err := installHook(hooksPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("installHook: %v", err)
+	}
+
+	status := hooksStatus(hooksPath)
+	if status != "installed" {
+		t.Errorf("hooksStatus: got %q, want %q", status, "installed")
+	}
+}
+
+// TestHooksStatus_NotInstalled verifies hooksStatus returns "not_installed"
+// when hooks.json does not exist.
+func TestHooksStatus_NotInstalled(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+
+	status := hooksStatus(hooksPath)
+	if status != "not_installed" {
+		t.Errorf("hooksStatus: got %q, want %q", status, "not_installed")
+	}
+}
+
+// TestHooksStatus_NotInstalledNoGitCourer verifies hooksStatus returns
+// "not_installed" when hooks.json exists but lacks a git-courer entry.
+func TestHooksStatus_NotInstalledNoGitCourer(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+
+	other := `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"echo hello"}]}]}}`
+	if err := os.WriteFile(hooksPath, []byte(other), 0644); err != nil {
+		t.Fatalf("write hooks.json: %v", err)
+	}
+
+	status := hooksStatus(hooksPath)
+	if status != "not_installed" {
+		t.Errorf("hooksStatus: got %q, want %q", status, "not_installed")
+	}
+}

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -22,10 +22,6 @@ const (
 	PostInstallEnv = "GIT_COURER_POSTINSTALL"
 )
 
-// statusNotImplemented is the HooksStatus value used while the hook
-// installation is still a stub (SDDs 2-5 fill in the real implementation).
-const statusNotImplemented = "not_implemented"
-
 // ClientDiagnostic is the per-client diagnostic returned by RunDoctor.
 //
 // Fields:
@@ -33,8 +29,7 @@ const statusNotImplemented = "not_implemented"
 //   - ConfigPath: the resolved config file path.
 //   - MCPConfigured: true if the config file exists and contains git-courer.
 //   - GitCourerMdPresent: true if GIT_COURER.md exists in the config directory.
-//   - HooksStatus: the hook installation status — "not_implemented" until
-//     SDDs 2-5 land the real hook installation logic.
+//   - HooksStatus: the hook installation status — "installed" or "not_installed".
 type ClientDiagnostic struct {
 	ClientName         string
 	ConfigPath         string
@@ -75,7 +70,8 @@ func RunPostInstall() error {
 func RunUninstall() error {
 	fmt.Println("Uninstalling git-courer...")
 
-	// Restore .bak backups for each detected agent's config before removing.
+	// Remove hooks and GIT_COURER.md for each detected client before
+	// restoring config backups.
 	for _, client := range DetectClients() {
 		configPath := client.Paths[0]
 		for _, path := range client.Paths {
@@ -84,6 +80,22 @@ func RunUninstall() error {
 				break
 			}
 		}
+
+		// Remove hooks.json if this client has hooks configured.
+		if client.HooksConfig != nil {
+			if err := RemoveHook(client.HooksConfig.HooksPath); err != nil {
+				fmt.Fprintf(os.Stderr, "  ⚠ Failed to remove hooks: %v\n", err)
+			} else {
+				fmt.Printf("  ✓ Removed hooks: %s\n", client.HooksConfig.HooksPath)
+			}
+		}
+
+		// Remove GIT_COURER.md.
+		rulesPath := filepath.Join(filepath.Dir(configPath), gitCourerMdFilename)
+		if err := os.Remove(rulesPath); err == nil {
+			fmt.Printf("  ✓ Removed: %s\n", rulesPath)
+		}
+
 		restoreBackup(configPath)
 	}
 
@@ -143,9 +155,15 @@ func RunDoctor() []ClientDiagnostic {
 		}
 
 		d := ClientDiagnostic{
-			ClientName:  client.Name,
-			ConfigPath:  configPath,
-			HooksStatus: statusNotImplemented,
+			ClientName: client.Name,
+			ConfigPath: configPath,
+		}
+
+		// Check hooks status if this client has hooks configured.
+		if client.HooksConfig != nil {
+			d.HooksStatus = hooksStatus(client.HooksConfig.HooksPath)
+		} else {
+			d.HooksStatus = "not_installed"
 		}
 
 		if data, err := os.ReadFile(configPath); err == nil {

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -70,9 +70,11 @@ func RunPostInstall() error {
 func RunUninstall() error {
 	fmt.Println("Uninstalling git-courer...")
 
-	// Remove hooks and GIT_COURER.md for each detected client before
-	// restoring config backups.
-	for _, client := range DetectClients() {
+	// Remove hooks and GIT_COURER.md for each known client before
+	// restoring config backups. Use MCPClients() (all known clients)
+	// instead of DetectClients() (only currently-detected) so hooks
+	// are cleaned up even if the client binary is no longer on PATH.
+	for _, client := range MCPClients() {
 		configPath := client.Paths[0]
 		for _, path := range client.Paths {
 			if _, err := os.Stat(path); err == nil {

--- a/internal/installer/mcp_config.go
+++ b/internal/installer/mcp_config.go
@@ -2,6 +2,7 @@
 package installer
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -10,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/BurntSushi/toml"
 	"github.com/blak0p/git-courer/internal/delivery/mcp/descriptions"
 )
 
@@ -55,10 +57,17 @@ type MCPClient struct {
 	Filename          string // config filename
 	RootKey           string // mcpServers, mcp, servers, context_servers
 	IsArray           bool   // continue uses array format
+	ConfigFormat      string // "json" (default) or "toml"
+	HooksConfig       *HooksConfig // nil = no hooks for this client
 	ConfigFn          func(binPath string) map[string]interface{}
 	PostInstallNotice func(binPath string) string // optional post-install warning check
 	Paths             []string                    // possible config file paths for this platform
 	Detect            func() bool
+}
+
+// HooksConfig specifies hook installation for an MCP client.
+type HooksConfig struct {
+	HooksPath string // e.g. "~/.codex/hooks.json"
 }
 
 // MCPServerConfig represents an MCP server entry.
@@ -131,9 +140,13 @@ func MCPClients() []*MCPClient {
 			},
 		},
 		{
-			Name:     "codex",
-			Filename: "config.toml",
-			RootKey:  "mcpServers",
+			Name:         "codex",
+			Filename:     "config.toml",
+			RootKey:      "mcp_servers",
+			ConfigFormat: "toml",
+			HooksConfig: &HooksConfig{
+				HooksPath: filepath.Join(home, ".codex/hooks.json"),
+			},
 			ConfigFn: func(binPath string) map[string]interface{} {
 				return map[string]interface{}{
 					"command": binPath,
@@ -237,6 +250,12 @@ func ConfigureMCP(client *MCPClient, binPath string) error {
 		if containsGitCourer(string(data)) {
 			// Already configured — still ensure GIT_COURER.md exists (idempotent).
 			ensureGitCourerMd(configPath)
+			// Also ensure hooks are installed (idempotent).
+			if client.HooksConfig != nil {
+				if hookErr := installHook(client.HooksConfig.HooksPath, binPath); hookErr != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to install hooks: %v\n", hookErr)
+				}
+			}
 			return nil // Already configured
 		}
 	}
@@ -253,8 +272,8 @@ func ConfigureMCP(client *MCPClient, binPath string) error {
 	if client.IsArray {
 		err = configureArrayFormat(configPath, entry)
 	} else {
-		// Handle object format
-		err = configureObjectFormat(configPath, client.RootKey, entry)
+		// Handle object format — pass ConfigFormat for TOML support
+		err = configureObjectFormatWithFormat(configPath, client.RootKey, entry, client.ConfigFormat)
 	}
 
 	if err != nil {
@@ -263,6 +282,13 @@ func ConfigureMCP(client *MCPClient, binPath string) error {
 
 	// Write GIT_COURER.md golden rules alongside the config (idempotent).
 	ensureGitCourerMd(configPath)
+
+	// Install hooks for clients that have HooksConfig.
+	if client.HooksConfig != nil {
+		if hookErr := installHook(client.HooksConfig.HooksPath, binPath); hookErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to install hooks: %v\n", hookErr)
+		}
+	}
 
 	if client.PostInstallNotice != nil {
 		if msg := client.PostInstallNotice(binPath); msg != "" {
@@ -298,7 +324,48 @@ func containsGitCourer(data string) bool {
 	return strings.Contains(data, "git-courer")
 }
 
+// configureTomlFormat writes the MCP server entry as TOML with the format
+// [rootKey."git-courer"]. It preserves any existing content in the file.
+func configureTomlFormat(configPath, rootKey string, entry map[string]interface{}) error {
+	// Read existing config to preserve user content.
+	existing := make(map[string]interface{})
+	if data, err := os.ReadFile(configPath); err == nil {
+		if err := toml.Unmarshal(data, &existing); err != nil {
+			// If we can't parse existing TOML, start fresh.
+			existing = make(map[string]interface{})
+		}
+	}
+
+	// Get or create the root key section.
+	var rootMap map[string]interface{}
+	if r, ok := existing[rootKey]; ok {
+		if m, ok := r.(map[string]interface{}); ok {
+			rootMap = m
+		} else {
+			rootMap = make(map[string]interface{})
+		}
+	} else {
+		rootMap = make(map[string]interface{})
+	}
+	existing[rootKey] = rootMap
+
+	rootMap["git-courer"] = entry
+
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(existing); err != nil {
+		return fmt.Errorf("failed to encode TOML: %w", err)
+	}
+	return os.WriteFile(configPath, buf.Bytes(), 0644)
+}
+
 func configureObjectFormat(configPath, rootKey string, entry map[string]interface{}) error {
+	return configureObjectFormatWithFormat(configPath, rootKey, entry, "json")
+}
+
+func configureObjectFormatWithFormat(configPath, rootKey string, entry map[string]interface{}, format string) error {
+	if format == "toml" {
+		return configureTomlFormat(configPath, rootKey, entry)
+	}
 	// Use map[string]interface{} to preserve unknown user config
 	config := make(map[string]interface{})
 

--- a/internal/installer/mcp_config_test.go
+++ b/internal/installer/mcp_config_test.go
@@ -1,0 +1,133 @@
+// Package installer_test verifies MCP config operations including TOML format
+// support and hook installation.
+package installer
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestConfigureTomlFormat_WritesValidTOML verifies configureTomlFormat writes
+// a valid TOML file with the correct [mcp_servers."git-courer"] section.
+func TestConfigureTomlFormat_WritesValidTOML(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	entry := map[string]interface{}{
+		"command": "/usr/local/bin/git-courer",
+		"args":    []string{"mcp"},
+	}
+
+	if err := configureTomlFormat(configPath, "mcp_servers", entry); err != nil {
+		t.Fatalf("configureTomlFormat: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, `[mcp_servers.git-courer]`) && !strings.Contains(content, `[mcp_servers."git-courer"]`) {
+		t.Errorf("TOML missing section header [mcp_servers.git-courer]\ncontent:\n%s", content)
+	}
+	if !strings.Contains(content, `command = "/usr/local/bin/git-courer"`) {
+		t.Errorf("TOML missing command field\ncontent:\n%s", content)
+	}
+	if !strings.Contains(content, `args = ["mcp"]`) {
+		t.Errorf("TOML missing args field\ncontent:\n%s", content)
+	}
+}
+
+// TestConfigureTomlFormat_PreservesExistingConfig verifies configureTomlFormat
+// preserves existing content in the config file when adding git-courer.
+func TestConfigureTomlFormat_PreservesExistingConfig(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	existing := `[mcp_servers."other-tool"]
+command = "other"
+`
+	if err := os.WriteFile(configPath, []byte(existing), 0644); err != nil {
+		t.Fatalf("write existing: %v", err)
+	}
+
+	entry := map[string]interface{}{
+		"command": "/usr/local/bin/git-courer",
+		"args":    []string{"mcp"},
+	}
+
+	if err := configureTomlFormat(configPath, "mcp_servers", entry); err != nil {
+		t.Fatalf("configureTomlFormat: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, `other-tool`) {
+		t.Errorf("existing section was removed\ncontent:\n%s", content)
+	}
+	if !strings.Contains(content, `git-courer`) {
+		t.Errorf("git-courer section missing\ncontent:\n%s", content)
+	}
+}
+
+// TestConfigureObjectFormat_DelegatesToToml verifies configureObjectFormat
+// delegates to configureTomlFormat when ConfigFormat is "toml".
+func TestConfigureObjectFormat_DelegatesToToml(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	entry := map[string]interface{}{
+		"command": "/usr/local/bin/git-courer",
+		"args":    []string{"mcp"},
+	}
+
+	if err := configureObjectFormatWithFormat(configPath, "mcp_servers", entry, "toml"); err != nil {
+		t.Fatalf("configureObjectFormatWithFormat: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, `[mcp_servers.git-courer]`) && !strings.Contains(content, `[mcp_servers."git-courer"]`) {
+		t.Errorf("expected TOML output, got:\n%s", content)
+	}
+}
+
+// TestConfigureObjectFormat_WritesJSON verifies configureObjectFormat writes
+// JSON when ConfigFormat is "json" (default).
+func TestConfigureObjectFormat_WritesJSON(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+
+	entry := map[string]interface{}{
+		"command": "/usr/local/bin/git-courer",
+		"args":    []string{"mcp"},
+	}
+
+	if err := configureObjectFormatWithFormat(configPath, "mcpServers", entry, "json"); err != nil {
+		t.Fatalf("configureObjectFormatWithFormat: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	content := string(data)
+	if !strings.Contains(content, `"mcpServers"`) {
+		t.Errorf("expected JSON output with mcpServers key, got:\n%s", content)
+	}
+	if !strings.Contains(content, `"git-courer"`) {
+		t.Errorf("expected JSON output with git-courer entry, got:\n%s", content)
+	}
+}

--- a/internal/installer/v26_test.go
+++ b/internal/installer/v26_test.go
@@ -186,8 +186,8 @@ func TestRunDoctor_ReportsDiagnostics(t *testing.T) {
 	if !d.GitCourerMdPresent {
 		t.Error("GitCourerMdPresent: got false, want true (GIT_COURER.md was written)")
 	}
-	if d.HooksStatus != statusNotImplemented {
-		t.Errorf("HooksStatus: got %q, want %q", d.HooksStatus, statusNotImplemented)
+	if d.HooksStatus != "not_installed" {
+		t.Errorf("HooksStatus: got %q, want %q", d.HooksStatus, "not_installed")
 	}
 }
 

--- a/tui/screens/uninstall.go
+++ b/tui/screens/uninstall.go
@@ -2,11 +2,14 @@
 package screens
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/BurntSushi/toml"
 	"github.com/blak0p/git-courer/internal/installer"
 	"github.com/blak0p/git-courer/tui/styles"
 	"github.com/charmbracelet/bubbletea"
@@ -78,8 +81,35 @@ func (m UninstallScreen) Done() bool {
 func (m *UninstallScreen) performUninstall() {
 	m.removedItems = []string{}
 	m.removeMCPConfigs()
+	m.removeHooks()
 	m.removeGlobalConfig()
 	m.removeBinary()
+}
+
+// removeHooks removes hooks.json and GIT_COURER.md for each client.
+func (m *UninstallScreen) removeHooks() {
+	clients := installer.MCPClients()
+	for _, client := range clients {
+		// Remove hooks.json if configured.
+		if client.HooksConfig != nil {
+			if err := installer.RemoveHook(client.HooksConfig.HooksPath); err == nil {
+				m.removedItems = append(m.removedItems, fmt.Sprintf("Hooks: %s", client.Name))
+			}
+		}
+
+		// Remove GIT_COURER.md.
+		configPath := client.Paths[0]
+		for _, path := range client.Paths {
+			if _, err := os.Stat(path); err == nil {
+				configPath = path
+				break
+			}
+		}
+		rulesPath := filepath.Join(filepath.Dir(configPath), "GIT_COURER.md")
+		if err := os.Remove(rulesPath); err == nil {
+			m.removedItems = append(m.removedItems, fmt.Sprintf("GIT_COURER.md: %s", client.Name))
+		}
+	}
 }
 
 // removeMCPConfigs removes git-courer from all MCP client configs.
@@ -113,10 +143,86 @@ func (m *UninstallScreen) removeMCPConfigs() {
 }
 
 // removeFromConfig removes git-courer from a client config file.
+// Supports JSON and TOML formats based on the client's ConfigFormat.
 func (m *UninstallScreen) removeFromConfig(configPath string, client *installer.MCPClient) error {
-	// For now, simple removal - in a full implementation we'd parse JSON/TOML properly
-	// This is a placeholder that just marks it as removed if the file contained git-courer
-	return nil // Implementation depends on the config format (JSON/TOML)
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return err
+	}
+
+	format := client.ConfigFormat
+	if format == "" {
+		format = "json"
+	}
+
+	switch format {
+	case "toml":
+		return removeFromTOMLConfig(configPath, client.RootKey, data)
+	default:
+		return removeFromJSONConfig(configPath, client.RootKey, data)
+	}
+}
+
+// removeFromJSONConfig removes the git-courer entry from a JSON config file.
+func removeFromJSONConfig(configPath, rootKey string, data []byte) error {
+	var config map[string]interface{}
+	if err := json.Unmarshal(data, &config); err != nil {
+		return err
+	}
+
+	rootMap, ok := config[rootKey].(map[string]interface{})
+	if !ok {
+		return nil // no root key — nothing to remove
+	}
+
+	delete(rootMap, "git-courer")
+
+	// If the root key is now empty, remove it too.
+	if len(rootMap) == 0 {
+		delete(config, rootKey)
+	}
+
+	// If the config is now empty, remove the file.
+	if len(config) == 0 {
+		return os.Remove(configPath)
+	}
+
+	output, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(configPath, output, 0644)
+}
+
+// removeFromTOMLConfig removes the git-courer entry from a TOML config file.
+func removeFromTOMLConfig(configPath, rootKey string, data []byte) error {
+	var config map[string]interface{}
+	if err := toml.Unmarshal(data, &config); err != nil {
+		return err
+	}
+
+	rootMap, ok := config[rootKey].(map[string]interface{})
+	if !ok {
+		return nil // no root key — nothing to remove
+	}
+
+	delete(rootMap, "git-courer")
+
+	// If the root key is now empty, remove it too.
+	if len(rootMap) == 0 {
+		delete(config, rootKey)
+	}
+
+	// If the config is now empty, remove the file.
+	if len(config) == 0 {
+		return os.Remove(configPath)
+	}
+
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(config); err != nil {
+		return err
+	}
+	return os.WriteFile(configPath, buf.Bytes(), 0644)
 }
 
 // removeGlobalConfig removes the global configuration file.

--- a/tui/screens/uninstall_test.go
+++ b/tui/screens/uninstall_test.go
@@ -1,0 +1,147 @@
+// Package screens_test verifies the TUI uninstall screen.
+package screens
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/blak0p/git-courer/internal/installer"
+)
+
+// TestRemoveFromJSONConfig_RemovesEntry verifies removeFromJSONConfig removes
+// the git-courer entry from a JSON config file.
+func TestRemoveFromJSONConfig_RemovesEntry(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+
+	config := `{"mcpServers":{"git-courer":{"command":"git-courer"},"other":{"command":"other"}}}`
+	if err := os.WriteFile(configPath, []byte(config), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	screen := &UninstallScreen{}
+	client := &installer.MCPClient{
+		Name:    "test",
+		RootKey: "mcpServers",
+	}
+
+	if err := screen.removeFromConfig(configPath, client); err != nil {
+		t.Fatalf("removeFromConfig: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	content := string(data)
+	if strings.Contains(content, "git-courer") {
+		t.Errorf("git-courer entry was not removed:\n%s", content)
+	}
+	if !strings.Contains(content, "other") {
+		t.Errorf("other entry was removed but should be preserved:\n%s", content)
+	}
+}
+
+// TestRemoveFromJSONConfig_RemovesEmptyRoot verifies removeFromJSONConfig
+// removes the root key when it becomes empty.
+func TestRemoveFromJSONConfig_RemovesEmptyRoot(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.json")
+
+	config := `{"mcpServers":{"git-courer":{"command":"git-courer"}}}`
+	if err := os.WriteFile(configPath, []byte(config), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	screen := &UninstallScreen{}
+	client := &installer.MCPClient{
+		Name:    "test",
+		RootKey: "mcpServers",
+	}
+
+	if err := screen.removeFromConfig(configPath, client); err != nil {
+		t.Fatalf("removeFromConfig: %v", err)
+	}
+
+	// File should be removed since config is empty.
+	if _, err := os.Stat(configPath); err == nil {
+		data, _ := os.ReadFile(configPath)
+		t.Errorf("config file should have been removed, but still exists:\n%s", data)
+	}
+}
+
+// TestRemoveFromTOMLConfig_RemovesEntry verifies removeFromTOMLConfig removes
+// the git-courer entry from a TOML config file.
+func TestRemoveFromTOMLConfig_RemovesEntry(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	config := `[mcp_servers]
+  [mcp_servers."git-courer"]
+  command = "git-courer"
+  [mcp_servers."other"]
+  command = "other"
+`
+	if err := os.WriteFile(configPath, []byte(config), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	screen := &UninstallScreen{}
+	client := &installer.MCPClient{
+		Name:         "test",
+		RootKey:      "mcp_servers",
+		ConfigFormat: "toml",
+	}
+
+	if err := screen.removeFromConfig(configPath, client); err != nil {
+		t.Fatalf("removeFromConfig: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+
+	content := string(data)
+	if strings.Contains(content, "git-courer") {
+		t.Errorf("git-courer entry was not removed:\n%s", content)
+	}
+	if !strings.Contains(content, "other") {
+		t.Errorf("other entry was removed but should be preserved:\n%s", content)
+	}
+}
+
+// TestRemoveFromTOMLConfig_RemovesEmptyRoot verifies removeFromTOMLConfig
+// removes the root key when it becomes empty.
+func TestRemoveFromTOMLConfig_RemovesEmptyRoot(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	config := `[mcp_servers]
+  [mcp_servers."git-courer"]
+  command = "git-courer"
+`
+	if err := os.WriteFile(configPath, []byte(config), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	screen := &UninstallScreen{}
+	client := &installer.MCPClient{
+		Name:         "test",
+		RootKey:      "mcp_servers",
+		ConfigFormat: "toml",
+	}
+
+	if err := screen.removeFromConfig(configPath, client); err != nil {
+		t.Fatalf("removeFromConfig: %v", err)
+	}
+
+	// File should be removed since config is empty.
+	if _, err := os.Stat(configPath); err == nil {
+		data, _ := os.ReadFile(configPath)
+		t.Errorf("config file should have been removed, but still exists:\n%s", data)
+	}
+}


### PR DESCRIPTION
## Why

Codex CLI agents default to running git commands via bash, bypassing git-courer's structured MCP tools (status, diff, commit, etc.) that provide JSON output, safety gates, and conflict detection. This change installs three Codex hooks that intercept agent behavior and redirect it to git-courer MCP tools.

## What

### Three Codex CLI hooks

- **PreToolUse** (Bash matcher): intercepts every bash command, classifies it via `git-courer hook-check`, and emits `additionalContext` suggesting the equivalent MCP tool. Never denies — Codex always asks the user for bash permission anyway, and the agent sees the suggestion alongside golden rules from SessionStart.
- **SessionStart** (startup|resume): runs `git-courer session-start-hook` which injects golden rules into the agent's context so it knows to prefer MCP tools from the start.
- **SubagentStart** (general-purpose|Explore|Plan): runs `git-courer subagent-start-hook` so spawned subagents also get the golden rules.

### Bug fixes

- **Codex RootKey**: was `"mcpServers"` (camelCase) but Codex uses `"mcp_servers"` (snake_case) in `config.toml`. Fixed.
- **TOML format**: `configureObjectFormat` always wrote JSON, but Codex expects TOML in `~/.codex/config.toml`. Added `ConfigFormat` field to `MCPClient` and `configureTomlFormat` function.

### New subcommands

- `git-courer session-start-hook` — returns golden rules as `additionalContext`
- `git-courer subagent-start-hook` — same for subagent context

### Integration

- `ConfigureMCP` calls `installHook` for Codex clients after writing MCP config
- `RunUninstall` removes hooks + GIT_COURER.md + restores backup
- `RunDoctor` reports real hooks status (`"installed"`/`"not_installed"`)
- TUI uninstall replaces no-op `removeFromConfig` with real JSON/TOML cleanup

### Known limitation

Codex returns `unsupported call` for MCP tools when using a non-OpenAI model (e.g., glm-5.2, llama.cpp). This is a [known Codex bug](https://github.com/openai/codex/issues/22970) — the MCP server itself works correctly. With OpenAI models, MCP tools work as expected.

## Files changed

15 files, +1296/−72. All tests pass.

Closes #158, #160