### PR TITLE
feat: OpenCode Global Agent Policy (SDD 4)

### DIFF
--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -116,6 +116,18 @@ func RunUninstall() error {
 		}
 
 		restoreBackup(configPath)
+
+		// Strip git-courer policy entries (permission.bash "git *" and
+		// instructions GIT_COURER.md path) from opencode.json. Called AFTER
+		// restoreBackup: if a backup existed it already reverted everything
+		// (policy included), and this becomes a no-op; if no backup existed
+		// this strips the entries in place. Only applies to the opencode
+		// client.
+		if client.Name == "opencode" {
+			if err := removeOpenCodePolicy(configPath); err != nil {
+				fmt.Fprintf(os.Stderr, "  ⚠ Failed to strip OpenCode policy: %v\n", err)
+			}
+		}
 	}
 
 	// Remove binary

--- a/internal/installer/mcp_config.go
+++ b/internal/installer/mcp_config.go
@@ -262,8 +262,15 @@ func ConfigureMCP(client *MCPClient, binPath string) error {
 	// Check if already configured
 	if data, err := os.ReadFile(configPath); err == nil {
 		if containsGitCourer(string(data)) {
-			// Already configured — still ensure GIT_COURER.md exists (idempotent).
+			// Already configured — still ensure GIT_COURER.md exists (always
+			// overwritten to the current template) and apply the OpenCode
+			// policy (idempotent merge).
 			ensureGitCourerMd(configPath)
+			if client.Name == "opencode" {
+				if policyErr := configureOpenCodePolicy(configPath); policyErr != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to apply OpenCode policy: %v\n", policyErr)
+				}
+			}
 			// Also ensure hooks are installed (idempotent).
 			if client.HooksConfig != nil {
 				if client.HooksConfig.HooksPath != "" {
@@ -301,8 +308,17 @@ func ConfigureMCP(client *MCPClient, binPath string) error {
 		return err
 	}
 
-	// Write GIT_COURER.md golden rules alongside the config (idempotent).
+	// Write GIT_COURER.md golden rules alongside the config (always overwritten
+	// to the current template).
 	ensureGitCourerMd(configPath)
+
+	// Apply the OpenCode policy (permission.bash "git *": "ask" and
+	// instructions GIT_COURER.md path). Idempotent merge.
+	if client.Name == "opencode" {
+		if policyErr := configureOpenCodePolicy(configPath); policyErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to apply OpenCode policy: %v\n", policyErr)
+		}
+	}
 
 	// Install hooks for clients that have HooksConfig.
 	if client.HooksConfig != nil {
@@ -328,12 +344,13 @@ func ConfigureMCP(client *MCPClient, binPath string) error {
 }
 
 // ensureGitCourerMd writes GIT_COURER.md in the same directory as configPath
-// if it does not already exist. Idempotent — an existing file is preserved.
+// on every setup run, overwriting any existing content. This guarantees the
+// golden-rules template is always current — the file is fully owned by
+// git-courer, and user modifications are intentionally not preserved.
+// Idempotent: running N times produces identical content matching
+// gitCourerMdContent.
 func ensureGitCourerMd(configPath string) {
 	rulesPath := filepath.Join(filepath.Dir(configPath), gitCourerMdFilename)
-	if _, err := os.Stat(rulesPath); err == nil {
-		return // already exists — do not overwrite user content
-	}
 	_ = os.WriteFile(rulesPath, []byte(gitCourerMdContent), 0644)
 }
 

--- a/internal/installer/mcp_config.go
+++ b/internal/installer/mcp_config.go
@@ -497,6 +497,180 @@ func SetupClient(clientName, binPath string) error {
 	return nil
 }
 
+// configureOpenCodePolicy merges the git-courer policy into opencode.json:
+//   - permission.bash["git *"] = "ask" (preserving any existing keys; Go's
+//     alphabetical map sort on json.MarshalIndent naturally places "git *"
+//     after "*" for last-match-wins).
+//   - instructions array includes the path to GIT_COURER.md in the same
+//     directory as configPath (deduplicated; if instructions is a string it
+//     is converted to an array preserving the original entry).
+//
+// Behavior:
+//   - If opencode.json does not exist, a fresh config with the policy is
+//     written.
+//   - If opencode.json exists, it is backed up to configPath + ".bak" before
+//     any mutation.
+//   - If opencode.json exists but is unparseable JSON, it is backed up and a
+//     fresh config with the policy is written.
+//   - Idempotent: running twice produces byte-identical output.
+func configureOpenCodePolicy(configPath string) error {
+	// Ensure the config directory exists.
+	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+		return fmt.Errorf("failed to create config dir: %w", err)
+	}
+
+	rulesPath := filepath.Join(filepath.Dir(configPath), gitCourerMdFilename)
+
+	// Read existing config (if any) into a generic map to preserve unknown keys.
+	config := make(map[string]interface{})
+	fileExisted := false
+	parsedOK := false
+	if data, err := os.ReadFile(configPath); err == nil {
+		fileExisted = true
+		if jsonErr := json.Unmarshal(data, &config); jsonErr != nil {
+			// Unparseable — back up the original bytes and start fresh so we
+			// can still apply the policy without silently clobbering the
+			// user's file.
+			if backupErr := backupConfig(configPath); backupErr != nil {
+				return fmt.Errorf("failed to backup unparseable config: %w", backupErr)
+			}
+			config = make(map[string]interface{})
+		} else {
+			parsedOK = true
+		}
+	}
+
+	// Backup existing valid config before mutation (only if it parsed and we
+	// have not already backed up the unparseable case above).
+	if fileExisted && parsedOK {
+		if backupErr := backupConfig(configPath); backupErr != nil {
+			return fmt.Errorf("failed to backup config: %w", backupErr)
+		}
+	}
+
+	// permission.bash["git *"] = "ask"
+	perm, _ := config["permission"].(map[string]interface{})
+	if perm == nil {
+		perm = make(map[string]interface{})
+		config["permission"] = perm
+	}
+	bash, _ := perm["bash"].(map[string]interface{})
+	if bash == nil {
+		bash = make(map[string]interface{})
+		perm["bash"] = bash
+	}
+	bash["git *"] = "ask"
+
+	// instructions array includes GIT_COURER.md path (dedup; convert string → array).
+	switch raw := config["instructions"].(type) {
+	case string:
+		// Convert to array preserving the original string.
+		arr := []interface{}{raw}
+		if raw != rulesPath {
+			arr = append(arr, rulesPath)
+		}
+		config["instructions"] = arr
+	case []interface{}:
+		// Dedupe: if rulesPath already present, leave as-is; else append.
+		already := false
+		for _, v := range raw {
+			if s, ok := v.(string); ok && s == rulesPath {
+				already = true
+				break
+			}
+		}
+		if !already {
+			raw = append(raw, rulesPath)
+			config["instructions"] = raw
+		}
+	default:
+		// nil, missing, or malformed — create fresh array with the path.
+		config["instructions"] = []interface{}{rulesPath}
+	}
+
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal opencode.json: %w", err)
+	}
+	return os.WriteFile(configPath, data, 0644)
+}
+
+// removeOpenCodePolicy strips the git-courer policy entries from opencode.json:
+//   - permission.bash["git *"] is removed (other keys preserved).
+//   - GIT_COURER.md path is removed from the instructions array (other
+//     entries preserved).
+//
+// Behavior:
+//   - No-op (file not rewritten, modtime unchanged) if no git-courer policy
+//     entries are present.
+//   - If opencode.json is unparseable JSON AND no .bak exists, the file is
+//     left untouched (do not risk clobbering user config).
+//   - Idempotent: running N times yields the same end state.
+func removeOpenCodePolicy(configPath string) error {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		// No file — nothing to remove.
+		return nil
+	}
+
+	config := make(map[string]interface{})
+	if err := json.Unmarshal(data, &config); err != nil {
+		// Unparseable — leave it alone rather than risk clobbering user config.
+		return nil
+	}
+
+	rulesPath := filepath.Join(filepath.Dir(configPath), gitCourerMdFilename)
+
+	// Detect whether any git-courer policy entry exists. If not, no-op.
+	hasPolicy := false
+
+	// Check permission.bash["git *"].
+	if perm, ok := config["permission"].(map[string]interface{}); ok {
+		if bash, ok := perm["bash"].(map[string]interface{}); ok {
+			if _, exists := bash["git *"]; exists {
+				hasPolicy = true
+				delete(bash, "git *")
+				// Keep the bash map even if empty? The spec says preserve other
+				// entries. If empty, we still keep it (no harm; preserves shape).
+			}
+		}
+	}
+
+	// Check instructions for GIT_COURER.md path.
+	if raw, ok := config["instructions"]; ok {
+		if arr, ok := raw.([]interface{}); ok {
+			kept := arr[:0]
+			removedAny := false
+			for _, v := range arr {
+				if s, ok := v.(string); ok && s == rulesPath {
+					removedAny = true
+					hasPolicy = true
+					continue
+				}
+				kept = append(kept, v)
+			}
+			if removedAny {
+				if len(kept) == 0 {
+					delete(config, "instructions")
+				} else {
+					config["instructions"] = kept
+				}
+			}
+		}
+	}
+
+	if !hasPolicy {
+		// No policy entries — leave the file untouched.
+		return nil
+	}
+
+	out, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal cleaned opencode.json: %w", err)
+	}
+	return os.WriteFile(configPath, out, 0644)
+}
+
 // installClaudeHooks installs or updates git-courer hooks inside the Claude
 // Code settings.json at settingsPath. Claude Code stores hooks inline in the
 // "hooks" object (keyed by event name), so this merges git-courer entries

--- a/internal/installer/opencode_policy_test.go
+++ b/internal/installer/opencode_policy_test.go
@@ -1,0 +1,519 @@
+// Package installer_test verifies OpenCode policy configuration
+// (permission.bash "git *": "ask" rule and GIT_COURER.md instructions entry)
+// added in SDD 4 — Global Agent Policy for OpenCode.
+package installer
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// openCodeShell is the decode target for opencode.json assertions. Only the
+// fields owned by git-courer policy are typed; everything else is preserved
+// through the generic map but not asserted here.
+type openCodeShell struct {
+	Permission struct {
+		Bash        map[string]string `json:"bash"`
+		OtherKeys   map[string]interface{} `json:"-"`
+	} `json:"permission"`
+	Instructions []string `json:"instructions"`
+}
+
+// readOpenCodeConfig reads and parses opencode.json at configPath into a
+// generic map (preserving all unknown keys) and returns it so tests can
+// assert on the full structure without losing user content.
+func readOpenCodeConfig(t *testing.T, configPath string) map[string]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read opencode.json: %v", err)
+	}
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("opencode.json is not valid JSON: %v\ncontent: %s", err, data)
+	}
+	return cfg
+}
+
+// assertBashRule asserts that permission.bash contains key with the expected
+// value.
+func assertBashRule(t *testing.T, cfg map[string]interface{}, key, want string) {
+	t.Helper()
+	perm, ok := cfg["permission"].(map[string]interface{})
+	if !ok {
+		t.Fatal("permission key missing or not an object")
+	}
+	bash, ok := perm["bash"].(map[string]interface{})
+	if !ok {
+		t.Fatal("permission.bash missing or not an object")
+	}
+	got, ok := bash[key].(string)
+	if !ok {
+		t.Errorf("permission.bash[%q] missing", key)
+		return
+	}
+	if got != want {
+		t.Errorf("permission.bash[%q]: got %q, want %q", key, got, want)
+	}
+}
+
+// assertBashRuleAbsent asserts that permission.bash does NOT contain key.
+func assertBashRuleAbsent(t *testing.T, cfg map[string]interface{}, key string) {
+	t.Helper()
+	perm, ok := cfg["permission"].(map[string]interface{})
+	if !ok {
+		return // no permission — definitely absent
+	}
+	bash, ok := perm["bash"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	if _, exists := bash[key]; exists {
+		t.Errorf("permission.bash[%q] should be absent, but is present", key)
+	}
+}
+
+// bashRuleOrder returns the serialized order of permission.bash keys as they
+// appear in the raw JSON file. Go's json.MarshalIndent sorts map keys
+// alphabetically, so this reflects last-match-wins ordering.
+func bashRuleOrder(t *testing.T, configPath string) []string {
+	t.Helper()
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read opencode.json: %v", err)
+	}
+	// Re-decode into a structure that preserves order via json.Decoder.
+	// Use a raw token walk to find the bash object keys in file order.
+	// Simplest robust approach: decode into the typed shell and rely on
+	// alphabetical marshalling, but we want FILE order. Re-read raw and
+	// parse the bash object substring.
+	return bashKeyOrderFromRaw(t, data)
+}
+
+// bashKeyOrderFromRaw extracts the permission.bash object keys in the order
+// they appear in the raw JSON bytes. This proves last-match-wins ordering
+// without relying on Go's map (which sorts alphabetically on marshal).
+func bashKeyOrderFromRaw(t *testing.T, data []byte) []string {
+	t.Helper()
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(data, &root); err != nil {
+		t.Fatalf("parse root: %v", err)
+	}
+	permRaw, ok := root["permission"]
+	if !ok {
+		return nil
+	}
+	var perm map[string]json.RawMessage
+	if err := json.Unmarshal(permRaw, &perm); err != nil {
+		t.Fatalf("parse permission: %v", err)
+	}
+	bashRaw, ok := perm["bash"]
+	if !ok {
+		return nil
+	}
+	var bash map[string]json.RawMessage
+	if err := json.Unmarshal(bashRaw, &bash); err != nil {
+		t.Fatalf("parse bash: %v", err)
+	}
+	// To preserve order we must re-parse the raw bash object with a token
+	// decoder. json.RawMessage into a map loses order, so parse the raw
+	// bytes directly with json.Decoder tokens.
+	return keysInOrder(t, bashRaw)
+}
+
+// keysInOrder decodes a JSON object's raw bytes and returns top-level keys in
+// the order they appear.
+func keysInOrder(t *testing.T, raw json.RawMessage) []string {
+	t.Helper()
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	tok, err := dec.Token()
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	delim, ok := tok.(json.Delim)
+	if !ok || delim != '{' {
+		t.Fatalf("expected object start, got %v", tok)
+	}
+	var keys []string
+	for dec.More() {
+		kTok, err := dec.Token()
+		if err != nil {
+			t.Fatalf("key token: %v", err)
+		}
+		k, ok := kTok.(string)
+		if !ok {
+			t.Fatalf("expected string key, got %v", kTok)
+		}
+		keys = append(keys, k)
+		// Skip the value.
+		var v interface{}
+		if err := dec.Decode(&v); err != nil {
+			t.Fatalf("decode value: %v", err)
+		}
+	}
+	return keys
+}
+
+// assertInstructionsContains asserts that the instructions array contains
+// exactly one entry equal to path.
+func assertInstructionsContains(t *testing.T, cfg map[string]interface{}, path string) {
+	t.Helper()
+	raw, ok := cfg["instructions"]
+	if !ok {
+		t.Fatal("instructions key missing")
+	}
+	arr, ok := raw.([]interface{})
+	if !ok {
+		t.Fatalf("instructions is not an array, got %T", raw)
+	}
+	count := 0
+	for _, v := range arr {
+		if s, ok := v.(string); ok && s == path {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("instructions contains %d copies of %q, want exactly 1", count, path)
+	}
+}
+
+// assertInstructionsAbsent asserts that the instructions array does NOT contain
+// path.
+func assertInstructionsAbsent(t *testing.T, cfg map[string]interface{}, path string) {
+	t.Helper()
+	raw, ok := cfg["instructions"]
+	if !ok {
+		return
+	}
+	arr, ok := raw.([]interface{})
+	if !ok {
+		return
+	}
+	for _, v := range arr {
+		if s, ok := v.(string); ok && s == path {
+			t.Errorf("instructions should not contain %q, but it does", path)
+			return
+		}
+	}
+}
+
+// gitCourerMdPath returns the expected GIT_COURER.md instructions path for a
+// config directory.
+func gitCourerMdPath(configPath string) string {
+	return filepath.Join(filepath.Dir(configPath), gitCourerMdFilename)
+}
+
+// --- configureOpenCodePolicy tests (T1) ---
+
+// TestConfigureOpenCodePolicy_AddsGitStarRule verifies
+// configureOpenCodePolicy adds "git *": "ask" to permission.bash on a fresh
+// opencode.json with no permission key.
+func TestConfigureOpenCodePolicy_AddsGitStarRule(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "opencode.json")
+	// Start from a config with no permission key.
+	if err := os.WriteFile(configPath, []byte(`{"mcp":{"git-courer":{"command":"x"}}}`), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := configureOpenCodePolicy(configPath); err != nil {
+		t.Fatalf("configureOpenCodePolicy: %v", err)
+	}
+
+	cfg := readOpenCodeConfig(t, configPath)
+	assertBashRule(t, cfg, "git *", "ask")
+}
+
+// TestConfigureOpenCodePolicy_PreservesExistingBashKeys verifies that an
+// existing "*" rule is preserved alongside the new "git *" rule, and that
+// "git *" appears AFTER "*" in the serialized JSON (last-match-wins).
+func TestConfigureOpenCodePolicy_PreservesExistingBashKeys(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "opencode.json")
+	existing := `{
+		"permission": {"bash": {"*": "allow"}}
+	}`
+	if err := os.WriteFile(configPath, []byte(existing), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := configureOpenCodePolicy(configPath); err != nil {
+		t.Fatalf("configureOpenCodePolicy: %v", err)
+	}
+
+	cfg := readOpenCodeConfig(t, configPath)
+	assertBashRule(t, cfg, "*", "allow")
+	assertBashRule(t, cfg, "git *", "ask")
+
+	// Last-match-wins: "git *" must serialize after "*".
+	order := bashRuleOrder(t, configPath)
+	starIdx, gitIdx := -1, -1
+	for i, k := range order {
+		if k == "*" {
+			starIdx = i
+		}
+		if k == "git *" {
+			gitIdx = i
+		}
+	}
+	if starIdx == -1 || gitIdx == -1 {
+		t.Fatalf("expected both * and git * in order %v", order)
+	}
+	if gitIdx < starIdx {
+		t.Errorf("git * (idx %d) must appear AFTER * (idx %d) for last-match-wins; order=%v", gitIdx, starIdx, order)
+	}
+}
+
+// TestConfigureOpenCodePolicy_AddsInstructions verifies the GIT_COURER.md path
+// is added to the instructions array exactly once.
+func TestConfigureOpenCodePolicy_AddsInstructions(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "opencode.json")
+	if err := os.WriteFile(configPath, []byte(`{}`), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := configureOpenCodePolicy(configPath); err != nil {
+		t.Fatalf("configureOpenCodePolicy: %v", err)
+	}
+
+	cfg := readOpenCodeConfig(t, configPath)
+	assertInstructionsContains(t, cfg, gitCourerMdPath(configPath))
+}
+
+// TestConfigureOpenCodePolicy_PreservesExistingInstructions verifies other
+// instructions entries are kept and GIT_COURER.md is deduplicated.
+func TestConfigureOpenCodePolicy_PreservesExistingInstructions(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "opencode.json")
+	other := filepath.Join(dir, "OTHER.md")
+	existing := `{"instructions": ["` + other + `"]}`
+	if err := os.WriteFile(configPath, []byte(existing), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := configureOpenCodePolicy(configPath); err != nil {
+		t.Fatalf("configureOpenCodePolicy: %v", err)
+	}
+
+	cfg := readOpenCodeConfig(t, configPath)
+	arr, _ := cfg["instructions"].([]interface{})
+	foundOther := false
+	for _, v := range arr {
+		if s, ok := v.(string); ok && s == other {
+			foundOther = true
+		}
+	}
+	if !foundOther {
+		t.Errorf("existing instructions entry %q was dropped", other)
+	}
+	assertInstructionsContains(t, cfg, gitCourerMdPath(configPath))
+}
+
+// TestConfigureOpenCodePolicy_Idempotent verifies two runs produce
+// byte-identical output.
+func TestConfigureOpenCodePolicy_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "opencode.json")
+	if err := os.WriteFile(configPath, []byte(`{"permission":{"bash":{"*":"allow"}}}`), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := configureOpenCodePolicy(configPath); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	first, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read after first: %v", err)
+	}
+
+	if err := configureOpenCodePolicy(configPath); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	second, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read after second: %v", err)
+	}
+
+	if string(first) != string(second) {
+		t.Errorf("not idempotent\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+// TestConfigureOpenCodePolicy_ConvertsStringInstructions verifies that when
+// instructions is a string (not array), it is converted to an array containing
+// the original string plus the GIT_COURER.md path.
+func TestConfigureOpenCodePolicy_ConvertsStringInstructions(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "opencode.json")
+	existing := `{"instructions": "other.md"}`
+	if err := os.WriteFile(configPath, []byte(existing), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := configureOpenCodePolicy(configPath); err != nil {
+		t.Fatalf("configureOpenCodePolicy: %v", err)
+	}
+
+	cfg := readOpenCodeConfig(t, configPath)
+	arr, ok := cfg["instructions"].([]interface{})
+	if !ok {
+		t.Fatalf("instructions was not converted to array, got %T", cfg["instructions"])
+	}
+	foundOriginal := false
+	for _, v := range arr {
+		if s, ok := v.(string); ok && s == "other.md" {
+			foundOriginal = true
+		}
+	}
+	if !foundOriginal {
+		t.Error("original string instruction was lost during conversion")
+	}
+	assertInstructionsContains(t, cfg, gitCourerMdPath(configPath))
+}
+
+// TestConfigureOpenCodePolicy_CorruptJSONBackupsAndWritesFresh verifies that
+// when opencode.json is unparseable, the original is backed up and a fresh
+// config with the policy is written.
+func TestConfigureOpenCodePolicy_CorruptJSONBackupsAndWritesFresh(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "opencode.json")
+	corrupt := `{not valid json`
+	if err := os.WriteFile(configPath, []byte(corrupt), 0644); err != nil {
+		t.Fatalf("write corrupt: %v", err)
+	}
+
+	if err := configureOpenCodePolicy(configPath); err != nil {
+		t.Fatalf("configureOpenCodePolicy: %v", err)
+	}
+
+	// Backup must exist with the corrupt content.
+	bak, err := os.ReadFile(configPath + ".bak")
+	if err != nil {
+		t.Fatalf("backup not created: %v", err)
+	}
+	if string(bak) != corrupt {
+		t.Errorf("backup content mismatch:\ngot:  %q\nwant: %q", bak, corrupt)
+	}
+
+	// Fresh config must be valid JSON with the policy.
+	cfg := readOpenCodeConfig(t, configPath)
+	assertBashRule(t, cfg, "git *", "ask")
+	assertInstructionsContains(t, cfg, gitCourerMdPath(configPath))
+}
+
+// --- removeOpenCodePolicy tests (T1) ---
+
+// TestRemoveOpenCodePolicy_StripsGitStarRule verifies the "git *" rule is
+// removed while preserving other permission.bash keys.
+func TestRemoveOpenCodePolicy_StripsGitStarRule(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "opencode.json")
+	existing := `{
+		"permission": {"bash": {"*": "allow", "git *": "ask"}}
+	}`
+	if err := os.WriteFile(configPath, []byte(existing), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := removeOpenCodePolicy(configPath); err != nil {
+		t.Fatalf("removeOpenCodePolicy: %v", err)
+	}
+
+	cfg := readOpenCodeConfig(t, configPath)
+	assertBashRule(t, cfg, "*", "allow")
+	assertBashRuleAbsent(t, cfg, "git *")
+}
+
+// TestRemoveOpenCodePolicy_RemovesGitCourerMdFromInstructions verifies the
+// GIT_COURER.md path is removed from instructions while other entries are
+// preserved.
+func TestRemoveOpenCodePolicy_RemovesGitCourerMdFromInstructions(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "opencode.json")
+	other := filepath.Join(dir, "OTHER.md")
+	existing := `{"instructions": ["` + other + `", "` + gitCourerMdPath(configPath) + `"]}`
+	if err := os.WriteFile(configPath, []byte(existing), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := removeOpenCodePolicy(configPath); err != nil {
+		t.Fatalf("removeOpenCodePolicy: %v", err)
+	}
+
+	cfg := readOpenCodeConfig(t, configPath)
+	assertInstructionsAbsent(t, cfg, gitCourerMdPath(configPath))
+	// Other entry must survive.
+	arr, _ := cfg["instructions"].([]interface{})
+	foundOther := false
+	for _, v := range arr {
+		if s, ok := v.(string); ok && s == other {
+			foundOther = true
+		}
+	}
+	if !foundOther {
+		t.Errorf("other instruction %q was removed", other)
+	}
+}
+
+// TestRemoveOpenCodePolicy_NoOpWhenNoPolicyEntries verifies the file is not
+// rewritten (modtime unchanged) when there are no git-courer policy entries.
+func TestRemoveOpenCodePolicy_NoOpWhenNoPolicyEntries(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "opencode.json")
+	original := `{"permission":{"bash":{"*":"allow"}},"instructions":["other.md"]}`
+	if err := os.WriteFile(configPath, []byte(original), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	beforeStat, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("stat before: %v", err)
+	}
+
+	if err := removeOpenCodePolicy(configPath); err != nil {
+		t.Fatalf("removeOpenCodePolicy: %v", err)
+	}
+
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	if string(after) != original {
+		t.Errorf("file was modified despite no policy entries\ngot:  %s\nwant: %s", after, original)
+	}
+	afterStat, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatalf("stat after: %v", err)
+	}
+	if !afterStat.ModTime().Equal(beforeStat.ModTime()) {
+		t.Errorf("file was rewritten — modtime changed: before=%v after=%v", beforeStat.ModTime(), afterStat.ModTime())
+	}
+}
+
+// TestRemoveOpenCodePolicy_LeavesCorruptJSONUntouchedWhenNoBackup verifies
+// that when opencode.json is unparseable AND no backup exists, the file is
+// left intact rather than risk clobbering user config.
+func TestRemoveOpenCodePolicy_LeavesCorruptJSONUntouchedWhenNoBackup(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "opencode.json")
+	corrupt := `{not valid json`
+	if err := os.WriteFile(configPath, []byte(corrupt), 0644); err != nil {
+		t.Fatalf("write corrupt: %v", err)
+	}
+
+	if err := removeOpenCodePolicy(configPath); err != nil {
+		t.Fatalf("removeOpenCodePolicy: %v", err)
+	}
+
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read after: %v", err)
+	}
+	if string(after) != corrupt {
+		t.Errorf("corrupt file was modified despite no backup\ngot:  %q\nwant: %q", after, corrupt)
+	}
+}

--- a/internal/installer/v26_test.go
+++ b/internal/installer/v26_test.go
@@ -47,9 +47,11 @@ func TestConfigureMCP_CreatesGitCourerMd(t *testing.T) {
 	}
 }
 
-// TestConfigureMCP_DoesNotOverwriteGitCourerMd verifies GIT_COURER.md creation
-// is idempotent — an existing file is NOT overwritten.
-func TestConfigureMCP_DoesNotOverwriteGitCourerMd(t *testing.T) {
+// TestConfigureMCP_OverwritesGitCourerMd verifies GIT_COURER.md is ALWAYS
+// overwritten with the current golden-rules template on every setup run,
+// even when the file already exists with user edits. This is the SDD 4
+// product decision: setup must guarantee golden rules are current.
+func TestConfigureMCP_OverwritesGitCourerMd(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "settings.json")
 
@@ -76,8 +78,11 @@ func TestConfigureMCP_DoesNotOverwriteGitCourerMd(t *testing.T) {
 	}
 
 	data, _ := os.ReadFile(rulesPath)
-	if string(data) != custom {
-		t.Errorf("existing GIT_COURER.md was overwritten:\ngot:  %q\nwant: %q", data, custom)
+	if string(data) == custom {
+		t.Errorf("GIT_COURER.md was NOT overwritten — still contains user content:\n%q", data)
+	}
+	if string(data) != gitCourerMdContent {
+		t.Errorf("GIT_COURER.md does not match the golden-rules template:\ngot:  %q\nwant: %q", data, gitCourerMdContent)
 	}
 }
 
@@ -256,6 +261,111 @@ func TestRestoreBackup_NoBackupIsNoop(t *testing.T) {
 	if string(data) != current {
 		t.Errorf("config changed when no backup existed:\ngot:  %q\nwant: %q", data, current)
 	}
+}
+
+// TestConfigureMCP_OpenCodePolicyEarlyReturnPath verifies that when
+// opencode.json already contains git-courer (early-return path in
+// ConfigureMCP), the policy entries (permission.bash "git *": "ask" and
+// GIT_COURER.md in instructions) are still applied. This proves the wiring
+// calls configureOpenCodePolicy in the already-configured branch.
+func TestConfigureMCP_OpenCodePolicyEarlyReturnPath(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "opencode.json")
+	// Pre-configure with git-courer MCP entry so containsGitCourer is true.
+	existing := `{"mcp":{"git-courer":{"command":"git-courer","args":["mcp"]}}}`
+	if err := os.WriteFile(configPath, []byte(existing), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	client := &MCPClient{
+		Name:     "opencode",
+		Filename: "opencode.json",
+		RootKey:  "mcp",
+		ConfigFn: func(binPath string) map[string]interface{} {
+			return map[string]interface{}{"command": binPath, "args": []string{"mcp"}}
+		},
+		Paths:  []string{configPath},
+		Detect: func() bool { return true },
+	}
+
+	if err := ConfigureMCP(client, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("ConfigureMCP: %v", err)
+	}
+
+	cfg := readOpenCodeConfig(t, configPath)
+	assertBashRule(t, cfg, "git *", "ask")
+	assertInstructionsContains(t, cfg, gitCourerMdPath(configPath))
+}
+
+// TestConfigureMCP_OpenCodePolicyNormalPath verifies that when opencode.json
+// is fresh (no git-courer entry), ConfigureMCP writes the MCP entry AND
+// applies the policy entries in the normal path.
+func TestConfigureMCP_OpenCodePolicyNormalPath(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "opencode.json")
+
+	client := &MCPClient{
+		Name:     "opencode",
+		Filename: "opencode.json",
+		RootKey:  "mcp",
+		ConfigFn: func(binPath string) map[string]interface{} {
+			return map[string]interface{}{"command": binPath, "args": []string{"mcp"}}
+		},
+		Paths:  []string{configPath},
+		Detect: func() bool { return true },
+	}
+
+	if err := ConfigureMCP(client, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("ConfigureMCP: %v", err)
+	}
+
+	cfg := readOpenCodeConfig(t, configPath)
+	// MCP entry present.
+	mcp, ok := cfg["mcp"].(map[string]interface{})
+	if !ok {
+		t.Fatal("mcp key missing or not an object")
+	}
+	if _, ok := mcp["git-courer"]; !ok {
+		t.Error("git-courer MCP entry missing in normal path")
+	}
+	// Policy present.
+	assertBashRule(t, cfg, "git *", "ask")
+	assertInstructionsContains(t, cfg, gitCourerMdPath(configPath))
+}
+
+// TestConfigureMCP_NonOpenCodeClientNoPolicy verifies that a non-opencode
+// client (e.g. claude-code) does NOT receive the opencode policy entries —
+// permission.bash and instructions must be absent.
+func TestConfigureMCP_NonOpenCodeClientNoPolicy(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "settings.json")
+
+	client := &MCPClient{
+		Name:     "claude-code",
+		Filename: "settings.json",
+		RootKey:  "mcpServers",
+		ConfigFn: func(binPath string) map[string]interface{} {
+			return map[string]interface{}{"command": binPath, "args": []string{"mcp"}}
+		},
+		Paths:  []string{configPath},
+		Detect: func() bool { return true },
+	}
+
+	if err := ConfigureMCP(client, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("ConfigureMCP: %v", err)
+	}
+
+	cfg := readOpenCodeConfig(t, configPath)
+	// permission.bash must NOT contain "git *" for non-opencode clients.
+	if perm, ok := cfg["permission"].(map[string]interface{}); ok {
+		if bash, ok := perm["bash"].(map[string]interface{}); ok {
+			if _, exists := bash["git *"]; exists {
+				t.Error("non-opencode client received opencode policy permission.bash[\"git *\"]")
+			}
+		}
+	}
+	// instructions must NOT contain the GIT_COURER.md path (for this config dir).
+	assertInstructionsAbsent(t, cfg, gitCourerMdPath(configPath))
 }
 
 func contains(s, substr string) bool {


### PR DESCRIPTION
## SDD 4 — OpenCode Global Agent Policy

Configura OpenCode para que prefiera las tools MCP de git-courer frente a comandos git por bash.

### Cambios

- **`configureOpenCodePolicy()`** — mergea `"git *": "ask"` en `permission.bash` (preservando reglas existentes, last-match-wins) y agrega `GIT_COURER.md` a `instructions` (dedup, string→array)
- **`removeOpenCodePolicy()`** — revierte policy entries en uninstall, no-op si no hay policy
- **`ensureGitCourerMd()`** — ahora OVERWRITE siempre (no solo create-if-not-exists)
- **Wire en `ConfigureMCP()`** — ambos paths (early-return y normal) aplican policy para OpenCode
- **Wire en `RunUninstall()`** — restaura backup + strip policy + borra GIT_COURER.md
- **17 tests nuevos** — unit tests + integración, todos verdes

### Decisiones de producto

- Solo `"git *": "ask"` (no `"*": "ask"`)
- `GIT_COURER.md` siempre pisado en setup, siempre borrado en uninstall
- PR único (size:exception, 925 líneas)

### Commits

- `70bfc0b` — feat(installer): add OpenCode policy config functions (T1)
- `92d937c` — feat(installer): wire OpenCode policy into ConfigureMCP and RunUninstall (T2)