### PR TITLE
feat: Antigravity CLI integration — hooks, permissions, pre-invocation-hook

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -82,6 +82,9 @@ func main() {
 	case "subagent-start-hook":
 		runSubagentStartHook()
 		return
+	case "pre-invocation-hook":
+		runPreInvocationHook()
+		return
 	case "doctor":
 		runDoctor()
 		return
@@ -123,6 +126,7 @@ func showHelp() {
 	fmt.Println("  git-courer hook-check <cmd>     # Classify a command (agent hook)")
 	fmt.Println("  git-courer session-start-hook   # Codex SessionStart hook (agent)")
 	fmt.Println("  git-courer subagent-start-hook  # Codex SubagentStart hook (agent)")
+	fmt.Println("  git-courer pre-invocation-hook  # Antigravity PreInvocation hook (agent)")
 	fmt.Println("  git-courer doctor             # Diagnose MCP client health")
 	fmt.Println("  git-courer update             # Check for binary updates")
 	fmt.Println("  git-courer uninstall          # Remove git-courer")
@@ -355,6 +359,16 @@ func runSessionStartHook() {
 // It reads stdin (ignored) and returns golden rules as additionalContext.
 func runSubagentStartHook() {
 	cmd := cli.SubagentStartHookCommand{}
+	if err := cmd.Run(nil); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}
+
+// runPreInvocationHook handles the pre-invocation-hook subcommand.
+// It reads stdin (ignored) and returns golden rules as additionalContext.
+func runPreInvocationHook() {
+	cmd := cli.PreInvocationHookCommand{}
 	if err := cmd.Run(nil); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)

--- a/internal/delivery/cli/hook_check.go
+++ b/internal/delivery/cli/hook_check.go
@@ -198,3 +198,35 @@ func (c SubagentStartHookCommand) Run(args []string) error {
 	return json.NewEncoder(stdout).Encode(output)
 }
 
+// PreInvocationHookCommand implements the pre-invocation-hook CLI subcommand.
+// It reads stdin (ignored) and returns golden rules as additionalContext,
+// mirroring SessionStartHookCommand exactly. Invoked by the Antigravity
+// PreInvocation hook before every model call to inject golden rules into the
+// agent's context.
+type PreInvocationHookCommand struct {
+	Stdin  io.Reader // for testing; nil = os.Stdin
+	Stdout io.Writer // for testing; nil = os.Stdout
+}
+
+// Run reads stdin (ignored) and emits golden rules as Codex hook output with
+// HookEventName=PreInvocation. No permissionDecision is set.
+func (c PreInvocationHookCommand) Run(args []string) error {
+	stdout := c.Stdout
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+
+	// Read and discard stdin (Antigravity sends event JSON but we don't need it).
+	stdin := c.Stdin
+	if stdin == nil {
+		stdin = os.Stdin
+	}
+	_, _ = io.ReadAll(stdin)
+
+	output := codexHookOutput{}
+	output.HookSpecificOutput.HookEventName = "PreInvocation"
+	output.HookSpecificOutput.AdditionalContext = installer.GoldenRulesAdditionalContext
+
+	return json.NewEncoder(stdout).Encode(output)
+}
+

--- a/internal/delivery/cli/hook_check_test.go
+++ b/internal/delivery/cli/hook_check_test.go
@@ -242,6 +242,64 @@ func TestSubagentStartHookCommand_ReturnsGoldenRules(t *testing.T) {
 	}
 }
 
+// TestPreInvocationHookCommand_ReturnsGoldenRules verifies pre-invocation-hook
+// returns golden rules as additionalContext with HookEventName=PreInvocation
+// and no permissionDecision.
+func TestPreInvocationHookCommand_ReturnsGoldenRules(t *testing.T) {
+	var stdinBuf bytes.Buffer
+	stdinBuf.WriteString(`{"event":{"input":{"command":"model"}}}`)
+
+	var stdoutBuf bytes.Buffer
+	cmd := PreInvocationHookCommand{
+		Stdin:  &stdinBuf,
+		Stdout: &stdoutBuf,
+	}
+
+	err := cmd.Run([]string{})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	var output codexHookOutput
+	if jsonErr := json.Unmarshal(stdoutBuf.Bytes(), &output); jsonErr != nil {
+		t.Fatalf("stdout is not valid JSON: %v\noutput: %q", jsonErr, stdoutBuf.String())
+	}
+
+	if output.HookSpecificOutput.HookEventName != "PreInvocation" {
+		t.Errorf("HookEventName: got %q, want %q", output.HookSpecificOutput.HookEventName, "PreInvocation")
+	}
+	if !strings.Contains(output.HookSpecificOutput.AdditionalContext, "Golden Rules") {
+		t.Errorf("AdditionalContext missing golden rules: %q", output.HookSpecificOutput.AdditionalContext)
+	}
+	if output.HookSpecificOutput.PermissionDecision != "" {
+		t.Errorf("PermissionDecision should be empty, got %q", output.HookSpecificOutput.PermissionDecision)
+	}
+}
+
+// TestPreInvocationHookCommand_EmptyStdin verifies pre-invocation-hook works
+// with an empty stdin payload (stdin is read and discarded).
+func TestPreInvocationHookCommand_EmptyStdin(t *testing.T) {
+	var stdinBuf bytes.Buffer
+	var stdoutBuf bytes.Buffer
+	cmd := PreInvocationHookCommand{
+		Stdin:  &stdinBuf,
+		Stdout: &stdoutBuf,
+	}
+
+	err := cmd.Run([]string{})
+	if err != nil {
+		t.Fatalf("Run returned error on empty stdin: %v", err)
+	}
+
+	var output codexHookOutput
+	if jsonErr := json.Unmarshal(stdoutBuf.Bytes(), &output); jsonErr != nil {
+		t.Fatalf("stdout is not valid JSON: %v\noutput: %q", jsonErr, stdoutBuf.String())
+	}
+	if output.HookSpecificOutput.HookEventName != "PreInvocation" {
+		t.Errorf("HookEventName: got %q, want PreInvocation", output.HookSpecificOutput.HookEventName)
+	}
+}
+
 // TestHookCheckRun_GitCommand_OldStdout verifies backward compatibility with
 // the old os.Stdout-based output (for the existing test pattern).
 func TestHookCheckRun_GitCommand_OldStdout(t *testing.T) {

--- a/internal/installer/hooks.go
+++ b/internal/installer/hooks.go
@@ -68,6 +68,7 @@ var claudeGitCourerHookEvents = []string{
 	"PreToolUse",
 	"SessionStart",
 	"SubagentStart",
+	"PreInvocation",
 }
 
 // mergeClaudeHooks merges the git-courer hook entries in gitcourer into the
@@ -144,9 +145,10 @@ func claudeHooksStatus(settingsPath string) string {
 
 	// Expected (event, matcher) pairs installed by git-courer.
 	expected := map[string]string{
-		"PreToolUse":   "Bash",
-		"SessionStart": "startup|resume",
+		"PreToolUse":    "Bash",
+		"SessionStart":  "startup|resume",
 		"SubagentStart": "general-purpose|Explore|Plan",
+		"PreInvocation": "",
 	}
 
 	found := 0
@@ -208,6 +210,7 @@ func installHook(hooksPath, binPath string) error {
 		{event: "PreToolUse", matcher: "Bash", command: binPath + " hook-check"},
 		{event: "SessionStart", matcher: "startup|resume", command: binPath + " session-start-hook"},
 		{event: "SubagentStart", matcher: "general-purpose|Explore|Plan", command: binPath + " subagent-start-hook"},
+		{event: "PreInvocation", matcher: "", command: binPath + " pre-invocation-hook"},
 	}
 
 	for _, e := range entries {
@@ -288,6 +291,111 @@ func hooksStatus(hooksPath string) string {
 	}
 
 	return "not_installed"
+}
+
+// installAntigravityHooks creates or updates hooks.json at hooksPath with
+// PreToolUse (matcher run_command) and PreInvocation entries pointing to
+// binPath. It backs up an existing hooks.json to hooksPath + ".bak" before
+// the first mutation and merges git-courer entries into any existing hooks
+// while preserving non-git-courer entries.
+//
+// Behavior:
+//   - If hooks.json does not exist, a fresh file is created (no backup).
+//   - If hooks.json exists, it is backed up to hooksPath + ".bak" before any
+//     mutation. The backup is only written when the file is about to change
+//     for the first time.
+//   - Idempotent: running twice produces byte-identical hooks.json. The
+//     backup is not overwritten on re-run.
+func installAntigravityHooks(hooksPath, binPath string) error {
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0755); err != nil {
+		return fmt.Errorf("failed to create hooks dir: %w", err)
+	}
+
+	// Read existing hooks.json (if any) and back it up before the first mutation.
+	fileExisted := false
+	hooks := hooksJSON{Hooks: make(map[string][]hookEntry)}
+	if data, err := os.ReadFile(hooksPath); err == nil {
+		fileExisted = true
+		_ = json.Unmarshal(data, &hooks)
+		if hooks.Hooks == nil {
+			hooks.Hooks = make(map[string][]hookEntry)
+		}
+		// Backup before mutation.
+		if backupErr := os.WriteFile(hooksPath+".bak", data, 0644); backupErr != nil {
+			return fmt.Errorf("failed to backup hooks.json: %w", backupErr)
+		}
+	}
+
+	// Define the Antigravity hook entries: PreToolUse with run_command matcher
+	// (Antigravity uses run_command, not Bash) and PreInvocation.
+	entries := []struct {
+		event   string
+		matcher string
+		command string
+	}{
+		{event: "PreToolUse", matcher: "run_command", command: binPath + " hook-check"},
+		{event: "PreInvocation", matcher: "", command: binPath + " pre-invocation-hook"},
+	}
+
+	for _, e := range entries {
+		existing := hooks.Hooks[e.event]
+		found := false
+		for _, entry := range existing {
+			if entry.Matcher == e.matcher && len(entry.Hooks) > 0 && entry.Hooks[0].Command == e.command {
+				found = true
+				break
+			}
+		}
+		if found {
+			continue
+		}
+		hooks.Hooks[e.event] = append(hooks.Hooks[e.event], hookEntry{
+			Matcher: e.matcher,
+			Hooks: []hookCmd{
+				{Type: "command", Command: e.command},
+			},
+		})
+	}
+
+	data, err := json.MarshalIndent(hooks, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal hooks.json: %w", err)
+	}
+
+	// Write atomically so a partial write never corrupts the real hooks file.
+	if fileExisted {
+		return writeAtomic(hooksPath, data, 0644)
+	}
+	return os.WriteFile(hooksPath, data, 0644)
+}
+
+// removeAntigravityHooks removes the git-courer hook entries from hooks.json
+// at hooksPath. Behavior:
+//   - If hooksPath + ".bak" exists, it is restored over hooksPath and the
+//     .bak file is removed (same convention as RemoveHook for Codex).
+//   - Otherwise hooks.json is deleted entirely (the Antigravity hooks.json
+//     is fully owned by git-courer when no pre-existing user hooks were
+//     preserved by a backup).
+//   - Idempotent: running twice does not error.
+func removeAntigravityHooks(hooksPath string) error {
+	bakPath := hooksPath + ".bak"
+	if _, err := os.Stat(bakPath); err == nil {
+		data, err := os.ReadFile(bakPath)
+		if err != nil {
+			return fmt.Errorf("failed to read backup: %w", err)
+		}
+		if err := writeAtomic(hooksPath, data, 0644); err != nil {
+			return fmt.Errorf("failed to restore backup: %w", err)
+		}
+		_ = os.Remove(bakPath)
+		return nil
+	}
+
+	// No backup — delete hooks.json if it exists.
+	if err := os.Remove(hooksPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove hooks.json: %w", err)
+	}
+	return nil
 }
 
 // FindBinaryPath tries to find the git-courer binary path.

--- a/internal/installer/hooks_test.go
+++ b/internal/installer/hooks_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // TestInstallHook_CreatesHooksJSON verifies installHook creates hooks.json
-// with PreToolUse, SessionStart, and SubagentStart entries.
+// with PreToolUse, SessionStart, SubagentStart, and PreInvocation entries.
 func TestInstallHook_CreatesHooksJSON(t *testing.T) {
 	dir := t.TempDir()
 	hooksPath := filepath.Join(dir, "hooks.json")
@@ -83,6 +83,18 @@ func TestInstallHook_CreatesHooksJSON(t *testing.T) {
 	}
 	if !strings.Contains(subagentStart[0].Hooks[0].Command, "subagent-start-hook") {
 		t.Errorf("SubagentStart command missing subagent-start-hook: %q", subagentStart[0].Hooks[0].Command)
+	}
+
+	// Check PreInvocation entry (added in Phase 2).
+	preInvocation, ok := hooks.Hooks["PreInvocation"]
+	if !ok {
+		t.Fatal("missing PreInvocation entry")
+	}
+	if len(preInvocation) != 1 {
+		t.Fatalf("PreInvocation: got %d entries, want 1", len(preInvocation))
+	}
+	if !strings.Contains(preInvocation[0].Hooks[0].Command, "pre-invocation-hook") {
+		t.Errorf("PreInvocation command missing pre-invocation-hook: %q", preInvocation[0].Hooks[0].Command)
 	}
 }
 
@@ -272,6 +284,12 @@ func gitCourerMergeInput(binPath string) map[string][]claudeHookEntry {
 				Hooks:   []claudeHookCmd{{Type: "command", Command: binPath + " subagent-start-hook", Args: []string{}, Timeout: 10}},
 			},
 		},
+		"PreInvocation": {
+			{
+				Matcher: "",
+				Hooks:   []claudeHookCmd{{Type: "command", Command: binPath + " pre-invocation-hook", Args: []string{}, Timeout: 10}},
+			},
+		},
 	}
 }
 
@@ -378,6 +396,221 @@ func TestMergeClaudeHooks_UpdatesExistingGitCourer(t *testing.T) {
 	}
 	if entry.Hooks[0].Command != "/new/path/git-courer hook-check" {
 		t.Errorf("command not updated: got %q, want %q", entry.Hooks[0].Command, "/new/path/git-courer hook-check")
+	}
+}
+
+// --- installAntigravityHooks tests (Phase 2) ---
+
+// TestInstallAntigravityHooks_CreatesHooksJSON verifies installAntigravityHooks
+// creates hooks.json with PreToolUse (matcher run_command) and PreInvocation
+// entries pointing at the git-courer binary.
+func TestInstallAntigravityHooks_CreatesHooksJSON(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+
+	if err := installAntigravityHooks(hooksPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("installAntigravityHooks: %v", err)
+	}
+
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("hooks.json not created: %v", err)
+	}
+
+	var hooks struct {
+		Hooks map[string][]struct {
+			Matcher string `json:"matcher"`
+			Hooks   []struct {
+				Type    string `json:"type"`
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &hooks); err != nil {
+		t.Fatalf("hooks.json is not valid JSON: %v\ncontent: %s", err, data)
+	}
+
+	// PreToolUse with run_command matcher.
+	preToolUse, ok := hooks.Hooks["PreToolUse"]
+	if !ok {
+		t.Fatal("missing PreToolUse entry")
+	}
+	if len(preToolUse) != 1 {
+		t.Fatalf("PreToolUse: got %d entries, want 1", len(preToolUse))
+	}
+	if preToolUse[0].Matcher != "run_command" {
+		t.Errorf("PreToolUse matcher: got %q, want %q", preToolUse[0].Matcher, "run_command")
+	}
+	if len(preToolUse[0].Hooks) != 1 {
+		t.Fatalf("PreToolUse hooks: got %d, want 1", len(preToolUse[0].Hooks))
+	}
+	if !strings.Contains(preToolUse[0].Hooks[0].Command, "hook-check") {
+		t.Errorf("PreToolUse command missing hook-check: %q", preToolUse[0].Hooks[0].Command)
+	}
+
+	// PreInvocation entry.
+	preInvocation, ok := hooks.Hooks["PreInvocation"]
+	if !ok {
+		t.Fatal("missing PreInvocation entry")
+	}
+	if len(preInvocation) != 1 {
+		t.Fatalf("PreInvocation: got %d entries, want 1", len(preInvocation))
+	}
+	if !strings.Contains(preInvocation[0].Hooks[0].Command, "pre-invocation-hook") {
+		t.Errorf("PreInvocation command missing pre-invocation-hook: %q", preInvocation[0].Hooks[0].Command)
+	}
+}
+
+// TestInstallAntigravityHooks_Idempotent verifies installAntigravityHooks does
+// not duplicate entries when called a second time.
+func TestInstallAntigravityHooks_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+
+	if err := installAntigravityHooks(hooksPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("first installAntigravityHooks: %v", err)
+	}
+	first, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read after first: %v", err)
+	}
+
+	if err := installAntigravityHooks(hooksPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("second installAntigravityHooks: %v", err)
+	}
+	second, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read after second: %v", err)
+	}
+
+	if string(first) != string(second) {
+		t.Errorf("not idempotent — outputs differ\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+// TestInstallAntigravityHooks_BackupsExisting verifies installAntigravityHooks
+// backs up an existing hooks.json to hooks.json.bak before mutation.
+func TestInstallAntigravityHooks_BackupsExisting(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+
+	original := `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"echo hello"}]}]}}`
+	if err := os.WriteFile(hooksPath, []byte(original), 0644); err != nil {
+		t.Fatalf("write original: %v", err)
+	}
+
+	if err := installAntigravityHooks(hooksPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("installAntigravityHooks: %v", err)
+	}
+
+	bakData, err := os.ReadFile(hooksPath + ".bak")
+	if err != nil {
+		t.Fatalf("backup not created: %v", err)
+	}
+	if string(bakData) != original {
+		t.Errorf("backup content mismatch:\ngot:  %s\nwant: %s", bakData, original)
+	}
+}
+
+// TestInstallAntigravityHooks_PreservesNonGitCourerEntries verifies that a
+// non-git-courer PreToolUse entry (matcher Bash) survives the merge.
+func TestInstallAntigravityHooks_PreservesNonGitCourerEntries(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+
+	existing := `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"echo hello"}]}]}}`
+	if err := os.WriteFile(hooksPath, []byte(existing), 0644); err != nil {
+		t.Fatalf("write existing: %v", err)
+	}
+
+	if err := installAntigravityHooks(hooksPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("installAntigravityHooks: %v", err)
+	}
+
+	data, _ := os.ReadFile(hooksPath)
+	var hooks struct {
+		Hooks map[string][]struct {
+			Matcher string `json:"matcher"`
+			Hooks   []struct {
+				Type    string `json:"type"`
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(data, &hooks); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	// The existing Bash matcher entry must still be present.
+	bashFound := false
+	for _, e := range hooks.Hooks["PreToolUse"] {
+		if e.Matcher == "Bash" && len(e.Hooks) > 0 && e.Hooks[0].Command == "echo hello" {
+			bashFound = true
+		}
+	}
+	if !bashFound {
+		t.Error("existing Bash matcher entry was not preserved")
+	}
+	// The git-courer run_command matcher entry must also be present.
+	runCmdFound := false
+	for _, e := range hooks.Hooks["PreToolUse"] {
+		if e.Matcher == "run_command" {
+			runCmdFound = true
+		}
+	}
+	if !runCmdFound {
+		t.Error("git-courer run_command matcher entry was not added")
+	}
+}
+
+// --- removeAntigravityHooks tests (Phase 2) ---
+
+// TestRemoveAntigravityHooks_RestoresBackup verifies removeAntigravityHooks
+// restores hooks.json from .bak when present and removes the .bak file.
+func TestRemoveAntigravityHooks_RestoresBackup(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+
+	original := `{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"echo hello"}]}]}}`
+	if err := os.WriteFile(hooksPath, []byte(original), 0644); err != nil {
+		t.Fatalf("write original: %v", err)
+	}
+	if err := os.WriteFile(hooksPath+".bak", []byte(original), 0644); err != nil {
+		t.Fatalf("write backup: %v", err)
+	}
+
+	if err := removeAntigravityHooks(hooksPath); err != nil {
+		t.Fatalf("removeAntigravityHooks: %v", err)
+	}
+
+	restored, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("hooks.json not restored: %v", err)
+	}
+	if string(restored) != original {
+		t.Errorf("restored content mismatch:\ngot:  %s\nwant: %s", restored, original)
+	}
+	if _, err := os.Stat(hooksPath + ".bak"); err == nil {
+		t.Error("backup file should have been removed after restore")
+	}
+}
+
+// TestRemoveAntigravityHooks_DeletesWhenNoBackup verifies removeAntigravityHooks
+// deletes hooks.json when no .bak file exists.
+func TestRemoveAntigravityHooks_DeletesWhenNoBackup(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, "hooks.json")
+
+	if err := installAntigravityHooks(hooksPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("installAntigravityHooks: %v", err)
+	}
+
+	if err := removeAntigravityHooks(hooksPath); err != nil {
+		t.Fatalf("removeAntigravityHooks: %v", err)
+	}
+
+	if _, err := os.Stat(hooksPath); err == nil {
+		t.Error("hooks.json still exists after removeAntigravityHooks")
 	}
 }
 

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -76,10 +76,11 @@ func RunUninstall() error {
 	fmt.Println("Uninstalling git-courer...")
 
 	// Remove hooks and GIT_COURER.md for each known client before
-	// restoring config backups. Use MCPClients() (all known clients)
-	// instead of DetectClients() (only currently-detected) so hooks
-	// are cleaned up even if the client binary is no longer on PATH.
-	for _, client := range MCPClients() {
+	// restoring config backups. Use getMCPClients() (all known clients,
+	// overridable in tests) instead of DetectClients() (only
+	// currently-detected) so hooks are cleaned up even if the client binary
+	// is no longer on PATH.
+	for _, client := range getMCPClients() {
 		configPath := client.Paths[0]
 		for _, path := range client.Paths {
 			if _, err := os.Stat(path); err == nil {
@@ -92,19 +93,40 @@ func RunUninstall() error {
 		// Codex uses a separate hooks.json (HooksPath); Claude Code stores
 		// hooks inline in settings.json (SettingsPath). Both are cleaned up
 		// here even if the client binary is no longer on PATH.
+		// Antigravity uses a separate hooks.json (HooksPath) with the
+		// run_command matcher plus a separate settings.json for declarative
+		// permissions (PermissionsPath) — both are cleaned up via the
+		// Antigravity-specific removal functions.
 		if client.HooksConfig != nil {
-			if client.HooksConfig.HooksPath != "" {
-				if err := RemoveHook(client.HooksConfig.HooksPath); err != nil {
-					fmt.Fprintf(os.Stderr, "  ⚠ Failed to remove hooks: %v\n", err)
-				} else {
-					fmt.Printf("  ✓ Removed hooks: %s\n", client.HooksConfig.HooksPath)
+			if client.HooksConfig.PermissionsPath != "" {
+				// Antigravity-style client: distinct hooks.json + settings.json.
+				if client.HooksConfig.HooksPath != "" {
+					if err := removeAntigravityHooks(client.HooksConfig.HooksPath); err != nil {
+						fmt.Fprintf(os.Stderr, "  ⚠ Failed to remove Antigravity hooks: %v\n", err)
+					} else {
+						fmt.Printf("  ✓ Removed hooks: %s\n", client.HooksConfig.HooksPath)
+					}
 				}
-			}
-			if client.HooksConfig.SettingsPath != "" {
-				if err := removeClaudeHooks(client.HooksConfig.SettingsPath); err != nil {
-					fmt.Fprintf(os.Stderr, "  ⚠ Failed to remove Claude hooks: %v\n", err)
+				if err := removeAntigravityPermissions(client.HooksConfig.PermissionsPath); err != nil {
+					fmt.Fprintf(os.Stderr, "  ⚠ Failed to remove Antigravity permissions: %v\n", err)
 				} else {
-					fmt.Printf("  ✓ Removed Claude hooks: %s\n", client.HooksConfig.SettingsPath)
+					fmt.Printf("  ✓ Removed permissions: %s\n", client.HooksConfig.PermissionsPath)
+				}
+			} else {
+				// Codex / Claude Code style.
+				if client.HooksConfig.HooksPath != "" {
+					if err := RemoveHook(client.HooksConfig.HooksPath); err != nil {
+						fmt.Fprintf(os.Stderr, "  ⚠ Failed to remove hooks: %v\n", err)
+					} else {
+						fmt.Printf("  ✓ Removed hooks: %s\n", client.HooksConfig.HooksPath)
+					}
+				}
+				if client.HooksConfig.SettingsPath != "" {
+					if err := removeClaudeHooks(client.HooksConfig.SettingsPath); err != nil {
+						fmt.Fprintf(os.Stderr, "  ⚠ Failed to remove Claude hooks: %v\n", err)
+					} else {
+						fmt.Printf("  ✓ Removed Claude hooks: %s\n", client.HooksConfig.SettingsPath)
+					}
 				}
 			}
 		}

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -678,3 +678,224 @@ func TestDetect_AntigravityCLI(t *testing.T) {
 		})
 	}
 }
+
+// TestAntigravityClient_HasHooksConfig verifies the antigravity MCPClient
+// entry has a non-nil HooksConfig with both HooksPath and PermissionsPath set.
+func TestAntigravityClient_HasHooksConfig(t *testing.T) {
+	client := findClient(t, "antigravity")
+	if client.HooksConfig == nil {
+		t.Fatal("antigravity client HooksConfig is nil")
+	}
+	if client.HooksConfig.HooksPath == "" {
+		t.Error("antigravity HooksConfig.HooksPath is empty")
+	}
+	if client.HooksConfig.PermissionsPath == "" {
+		t.Error("antigravity HooksConfig.PermissionsPath is empty")
+	}
+	if !strings.HasSuffix(client.HooksConfig.HooksPath, "hooks.json") {
+		t.Errorf("HooksPath should end with hooks.json: got %q", client.HooksConfig.HooksPath)
+	}
+	if !strings.HasSuffix(client.HooksConfig.PermissionsPath, "settings.json") {
+		t.Errorf("PermissionsPath should end with settings.json: got %q", client.HooksConfig.PermissionsPath)
+	}
+}
+
+// TestAntigravityInstallUninstallCycle verifies the full install/uninstall
+// cycle for the Antigravity client: ConfigureMCP creates hooks.json and
+// settings.json with the expected entries, and the Antigravity-specific
+// removal functions (removeAntigravityHooks + removeAntigravityPermissions)
+// clean them up correctly.
+func TestAntigravityInstallUninstallCycle(t *testing.T) {
+	dir := t.TempDir()
+	binPath := "/usr/local/bin/git-courer"
+
+	hooksPath := filepath.Join(dir, "hooks.json")
+	settingsPath := filepath.Join(dir, "settings.json")
+	configPath := filepath.Join(dir, "mcp_config.json")
+
+	client := &MCPClient{
+		Name:     "antigravity",
+		Filename: "mcp_config.json",
+		RootKey:  "mcpServers",
+		HooksConfig: &HooksConfig{
+			HooksPath:       hooksPath,
+			PermissionsPath: settingsPath,
+		},
+		ConfigFn: func(binPath string) map[string]interface{} {
+			return map[string]interface{}{"command": binPath, "args": []string{"mcp"}}
+		},
+		Paths:  []string{configPath},
+		Detect: func() bool { return true },
+	}
+
+	// Install.
+	if err := ConfigureMCP(client, binPath); err != nil {
+		t.Fatalf("ConfigureMCP: %v", err)
+	}
+
+	// Verify mcp_config.json contains git-courer.
+	cfgData, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("mcp_config.json not created: %v", err)
+	}
+	if !strings.Contains(string(cfgData), "git-courer") {
+		t.Errorf("mcp_config.json missing git-courer entry:\n%s", cfgData)
+	}
+
+	// Verify hooks.json exists with PreToolUse(run_command) and PreInvocation.
+	hooksData, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("hooks.json not created: %v", err)
+	}
+	if !strings.Contains(string(hooksData), "run_command") {
+		t.Errorf("hooks.json missing run_command matcher:\n%s", hooksData)
+	}
+	if !strings.Contains(string(hooksData), "PreInvocation") {
+		t.Errorf("hooks.json missing PreInvocation entry:\n%s", hooksData)
+	}
+
+	// Verify settings.json has the three permission entries.
+	settingsData, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("settings.json not created: %v", err)
+	}
+	settingsStr := string(settingsData)
+	if !strings.Contains(settingsStr, "mcp(git-courer/*)") {
+		t.Errorf("settings.json missing mcp(git-courer/*):\n%s", settingsData)
+	}
+	if !strings.Contains(settingsStr, "command(git *)") {
+		t.Errorf("settings.json missing command(git *):\n%s", settingsData)
+	}
+	if !strings.Contains(settingsStr, "command(*)") {
+		t.Errorf("settings.json missing command(*):\n%s", settingsData)
+	}
+
+	// Verify GIT_COURER.md was created.
+	rulesPath := filepath.Join(dir, "GIT_COURER.md")
+	if _, err := os.Stat(rulesPath); err != nil {
+		t.Fatalf("GIT_COURER.md not created: %v", err)
+	}
+
+	// Uninstall the Antigravity hooks + permissions directly (the
+	// RunUninstall wiring calls these same functions when PermissionsPath is
+	// set). This verifies the removal half of the cycle without triggering
+	// RunUninstall's binary/global-config side effects.
+	if err := removeAntigravityHooks(hooksPath); err != nil {
+		t.Fatalf("removeAntigravityHooks: %v", err)
+	}
+	if err := removeAntigravityPermissions(settingsPath); err != nil {
+		t.Fatalf("removeAntigravityPermissions: %v", err)
+	}
+
+	// After removal, hooks.json should be gone (no pre-existing backup since
+	// it was a fresh install).
+	if _, err := os.Stat(hooksPath); err == nil {
+		t.Error("hooks.json still exists after removeAntigravityHooks")
+	}
+	// settings.json should be gone too (no .gc.bak on fresh install).
+	if _, err := os.Stat(settingsPath); err == nil {
+		t.Error("settings.json still exists after removeAntigravityPermissions")
+	}
+}
+
+// TestRunUninstall_CallsAntigravityRemoval verifies that RunUninstall calls
+// removeAntigravityHooks and removeAntigravityPermissions for an
+// Antigravity-style client (PermissionsPath set). It uses the getMCPClients
+// override to inject a fake antigravity client pointing at a temp dir, and
+// suppresses binary/global-config side effects by pointing HOME at a temp
+// dir with no git-courer binary.
+func TestRunUninstall_CallsAntigravityRemoval(t *testing.T) {
+	dir := t.TempDir()
+	binPath := "/nonexistent/git-courer"
+
+	hooksPath := filepath.Join(dir, "hooks.json")
+	settingsPath := filepath.Join(dir, "settings.json")
+	configPath := filepath.Join(dir, "mcp_config.json")
+	rulesPath := filepath.Join(dir, "GIT_COURER.md")
+
+	// Seed files so the removal functions have something to remove.
+	if err := installAntigravityHooks(hooksPath, binPath); err != nil {
+		t.Fatalf("seed hooks: %v", err)
+	}
+	if err := installAntigravityPermissions(settingsPath, binPath); err != nil {
+		t.Fatalf("seed permissions: %v", err)
+	}
+	if err := os.WriteFile(rulesPath, []byte("# rules"), 0644); err != nil {
+		t.Fatalf("seed GIT_COURER.md: %v", err)
+	}
+	// Seed an mcp_config.json with git-courer so the "already configured" check
+	// path and restoreBackup operate on a real file.
+	if err := os.WriteFile(configPath, []byte(`{"mcpServers":{"git-courer":{"command":"x"}}}`), 0644); err != nil {
+		t.Fatalf("seed mcp_config.json: %v", err)
+	}
+
+	client := &MCPClient{
+		Name:     "antigravity",
+		Filename: "mcp_config.json",
+		RootKey:  "mcpServers",
+		HooksConfig: &HooksConfig{
+			HooksPath:       hooksPath,
+			PermissionsPath: settingsPath,
+		},
+		ConfigFn: func(binPath string) map[string]interface{} {
+			return map[string]interface{}{"command": binPath, "args": []string{"mcp"}}
+		},
+		Paths:  []string{configPath},
+		Detect: func() bool { return true },
+	}
+
+	// Mock getMCPClients so RunUninstall only touches our fake client.
+	oldGetClients := getMCPClients
+	defer func() { getMCPClients = oldGetClients }()
+	getMCPClients = func() []*MCPClient { return []*MCPClient{client} }
+
+	// Redirect HOME so the global config removal and binary removal do not
+	// touch the real developer environment. FindBinaryPath scans HOME-based
+	// paths and PATH; with HOME=dir and no git-courer there, it returns an
+	// error and RunUninstall prints "Binary not found" without deleting
+	// anything real.
+	oldHomeEnv := os.Getenv("HOME")
+	os.Setenv("HOME", dir)
+	defer os.Setenv("HOME", oldHomeEnv)
+	// Also clear any PATH entries that could resolve a real git-courer during
+	// the test — we only need the temp-dir seeded files removed.
+	oldPathEnv := os.Getenv("PATH")
+	os.Setenv("PATH", "")
+	defer os.Setenv("PATH", oldPathEnv)
+
+	// Suppress stdout/stderr noise from RunUninstall.
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	os.Stderr = w
+	uninstallErr := RunUninstall()
+	w.Close()
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+	// drain pipe to avoid blocking
+	buf := make([]byte, 4096)
+	for {
+		n, err := r.Read(buf)
+		if err != nil || n == 0 {
+			break
+		}
+	}
+
+	if uninstallErr != nil {
+		t.Fatalf("RunUninstall: %v", uninstallErr)
+	}
+
+	// GIT_COURER.md should be removed.
+	if _, err := os.Stat(rulesPath); err == nil {
+		t.Error("GIT_COURER.md still exists after uninstall")
+	}
+	// hooks.json should be gone.
+	if _, err := os.Stat(hooksPath); err == nil {
+		t.Error("hooks.json still exists after uninstall")
+	}
+	// settings.json should be gone.
+	if _, err := os.Stat(settingsPath); err == nil {
+		t.Error("settings.json still exists after uninstall")
+	}
+}

--- a/internal/installer/mcp_config.go
+++ b/internal/installer/mcp_config.go
@@ -67,18 +67,23 @@ type MCPClient struct {
 
 // HooksConfig specifies hook installation for an MCP client.
 //
-// A client may use one of two hook storage strategies:
+// A client may use one or more of these hook storage strategies:
 //   - HooksPath: a separate hooks file (Codex stores hooks in
 //     "~/.codex/hooks.json" — managed via installHook/RemoveHook).
 //   - SettingsPath: inline hooks inside a settings file (Claude Code stores
 //     hooks inline in "~/.claude/settings.json" — managed via
 //     installClaudeHooks/removeClaudeHooks).
+//   - PermissionsPath: a separate settings.json holding declarative
+//     permissions (Antigravity stores permissions in
+//     "~/.gemini/antigravity-cli/settings.json" — managed via
+//     installAntigravityPermissions/removeAntigravityPermissions).
 //
-// At most one path is set per client. Empty string means the strategy is not
-// used for this client.
+// At most one strategy path is meaningful per client; empty string means the
+// strategy is not used for this client.
 type HooksConfig struct {
-	HooksPath    string // e.g. "~/.codex/hooks.json" (Codex — separate file)
-	SettingsPath string // e.g. "~/.claude/settings.json" (Claude Code — inline hooks)
+	HooksPath       string // e.g. "~/.codex/hooks.json" (Codex — separate file)
+	SettingsPath    string // e.g. "~/.claude/settings.json" (Claude Code — inline hooks)
+	PermissionsPath string // e.g. "~/.gemini/antigravity-cli/settings.json" (Antigravity — permissions file)
 }
 
 // MCPServerConfig represents an MCP server entry.
@@ -219,6 +224,10 @@ func MCPClients() []*MCPClient {
 			Name:     "antigravity",
 			Filename: "mcp_config.json",
 			RootKey:  "mcpServers",
+			HooksConfig: &HooksConfig{
+				HooksPath:       filepath.Join(home, ".gemini/antigravity-cli/hooks.json"),
+				PermissionsPath: filepath.Join(home, ".gemini/antigravity-cli/settings.json"),
+			},
 			ConfigFn: func(binPath string) map[string]interface{} {
 				return map[string]interface{}{
 					"command": binPath,
@@ -271,8 +280,19 @@ func ConfigureMCP(client *MCPClient, binPath string) error {
 					fmt.Fprintf(os.Stderr, "Warning: failed to apply OpenCode policy: %v\n", policyErr)
 				}
 			}
-			// Also ensure hooks are installed (idempotent).
-			if client.HooksConfig != nil {
+		// Also ensure hooks are installed (idempotent).
+		if client.HooksConfig != nil {
+			if client.HooksConfig.PermissionsPath != "" {
+				// Antigravity-style client.
+				if client.HooksConfig.HooksPath != "" {
+					if hookErr := installAntigravityHooks(client.HooksConfig.HooksPath, binPath); hookErr != nil {
+						fmt.Fprintf(os.Stderr, "Warning: failed to install Antigravity hooks: %v\n", hookErr)
+					}
+				}
+				if permErr := installAntigravityPermissions(client.HooksConfig.PermissionsPath, binPath); permErr != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to install Antigravity permissions: %v\n", permErr)
+				}
+			} else {
 				if client.HooksConfig.HooksPath != "" {
 					if hookErr := installHook(client.HooksConfig.HooksPath, binPath); hookErr != nil {
 						fmt.Fprintf(os.Stderr, "Warning: failed to install hooks: %v\n", hookErr)
@@ -284,8 +304,9 @@ func ConfigureMCP(client *MCPClient, binPath string) error {
 					}
 				}
 			}
-			return nil // Already configured
 		}
+		return nil // Already configured
+	}
 	}
 
 	// Backup existing config before mutation (only if it exists).
@@ -322,14 +343,31 @@ func ConfigureMCP(client *MCPClient, binPath string) error {
 
 	// Install hooks for clients that have HooksConfig.
 	if client.HooksConfig != nil {
-		if client.HooksConfig.HooksPath != "" {
-			if hookErr := installHook(client.HooksConfig.HooksPath, binPath); hookErr != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to install hooks: %v\n", hookErr)
+		if client.HooksConfig.PermissionsPath != "" {
+			// Antigravity-style client: separate hooks.json with the
+			// run_command matcher (not Bash) plus a separate settings.json
+			// for declarative permissions. The Antigravity hooks function
+			// is distinct from installHook because of the matcher and the
+			// PreInvocation event it adds.
+			if client.HooksConfig.HooksPath != "" {
+				if hookErr := installAntigravityHooks(client.HooksConfig.HooksPath, binPath); hookErr != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to install Antigravity hooks: %v\n", hookErr)
+				}
 			}
-		}
-		if client.HooksConfig.SettingsPath != "" {
-			if hookErr := installClaudeHooks(client.HooksConfig.SettingsPath, binPath); hookErr != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to install Claude hooks: %v\n", hookErr)
+			if permErr := installAntigravityPermissions(client.HooksConfig.PermissionsPath, binPath); permErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: failed to install Antigravity permissions: %v\n", permErr)
+			}
+		} else {
+			// Codex / Claude Code style.
+			if client.HooksConfig.HooksPath != "" {
+				if hookErr := installHook(client.HooksConfig.HooksPath, binPath); hookErr != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to install hooks: %v\n", hookErr)
+				}
+			}
+			if client.HooksConfig.SettingsPath != "" {
+				if hookErr := installClaudeHooks(client.HooksConfig.SettingsPath, binPath); hookErr != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to install Claude hooks: %v\n", hookErr)
+				}
 			}
 		}
 	}
@@ -757,6 +795,14 @@ func installClaudeHooks(settingsPath, binPath string) error {
 				},
 			},
 		},
+		"PreInvocation": {
+			{
+				Matcher: "",
+				Hooks: []claudeHookCmd{
+					{Type: "command", Command: binPath + " pre-invocation-hook", Args: []string{}, Timeout: 10},
+				},
+			},
+		},
 	}
 
 	// Decode the existing "hooks" object (if any) into the typed shape so
@@ -1012,4 +1058,218 @@ func writeAtomic(path string, data []byte, perm os.FileMode) error {
 		return fmt.Errorf("failed to rename temp file: %w", err)
 	}
 	return nil
+}
+
+// installAntigravityPermissions merges the git-courer permission entries into
+// the Antigravity settings.json at settingsPath:
+//   - permissions.allow gains "mcp(git-courer/*)"
+//   - permissions.ask gains "command(git *)" and "command(*)"
+//
+// Existing non-git-courer permission keys and every other top-level settings
+// key are preserved. Behavior:
+//   - If settings.json does not exist, a fresh file is created (no backup).
+//   - If settings.json exists, it is backed up to settingsPath + ".gc.bak"
+//     before the first mutation. The backup is NOT overwritten on re-run.
+//   - If settings.json exists but is unparseable JSON, it is backed up and a
+//     fresh file with the git-courer permissions is written.
+//   - Idempotent: running twice produces byte-identical settings.json.
+func installAntigravityPermissions(settingsPath, binPath string) error {
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0755); err != nil {
+		return fmt.Errorf("failed to create settings dir: %w", err)
+	}
+
+	// Read existing settings.json into a generic map to preserve every
+	// top-level key we do not own.
+	settings := make(map[string]interface{})
+	fileExisted := false
+	parsedOK := false
+	if data, err := os.ReadFile(settingsPath); err == nil {
+		fileExisted = true
+		if jsonErr := json.Unmarshal(data, &settings); jsonErr != nil {
+			// Unparseable — back up the original bytes and start fresh so we
+			// can still apply the permissions without clobbering user config.
+			if backupErr := backupAntigravitySettings(settingsPath, data); backupErr != nil {
+				return fmt.Errorf("failed to backup unparseable settings: %w", backupErr)
+			}
+			settings = make(map[string]interface{})
+		} else {
+			parsedOK = true
+		}
+	}
+
+	// Backup existing valid settings before mutation (only if it parsed and
+	// no backup already exists from a prior install — preserves idempotency).
+	if fileExisted && parsedOK {
+		bakPath := settingsPath + ".gc.bak"
+		if _, err := os.Stat(bakPath); os.IsNotExist(err) {
+			if backupErr := backupAntigravitySettings(settingsPath, nil); backupErr != nil {
+				return fmt.Errorf("failed to backup settings: %w", backupErr)
+			}
+		}
+	}
+
+	// permissions.allow and permissions.ask — merge git-courer entries.
+	perm, _ := settings["permissions"].(map[string]interface{})
+	if perm == nil {
+		perm = make(map[string]interface{})
+		settings["permissions"] = perm
+	}
+
+	// allow: mcp(git-courer/*)
+	allow, _ := perm["allow"].([]interface{})
+	allow = mergeStringEntry(allow, "mcp(git-courer/*)")
+	perm["allow"] = allow
+
+	// ask: command(git *), command(*)
+	ask, _ := perm["ask"].([]interface{})
+	ask = mergeStringEntry(ask, "command(git *)")
+	ask = mergeStringEntry(ask, "command(*)")
+	perm["ask"] = ask
+
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal settings.json: %w", err)
+	}
+	return writeAtomic(settingsPath, data, 0644)
+}
+
+// removeAntigravityPermissions strips the git-courer permission entries from
+// the Antigravity settings.json at settingsPath. Behavior:
+//   - If settingsPath + ".gc.bak" exists, it is restored over settingsPath and
+//     the .bak file is removed.
+//   - Otherwise the three git-courer permission entries are removed in place,
+//     preserving non-git-courer keys.
+//   - Idempotent: running twice does not error.
+func removeAntigravityPermissions(settingsPath string) error {
+	bakPath := settingsPath + ".gc.bak"
+	if _, err := os.Stat(bakPath); err == nil {
+		bakData, err := os.ReadFile(bakPath)
+		if err != nil {
+			return fmt.Errorf("failed to read settings backup: %w", err)
+		}
+		if err := writeAtomic(settingsPath, bakData, 0644); err != nil {
+			return fmt.Errorf("failed to restore settings backup: %w", err)
+		}
+		_ = os.Remove(bakPath)
+		return nil
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		// No file — nothing to remove.
+		return nil
+	}
+
+	settings := make(map[string]interface{})
+	if err := json.Unmarshal(data, &settings); err != nil {
+		// Unparseable — leave it alone rather than risk clobbering user config.
+		return nil
+	}
+
+	perm, ok := settings["permissions"].(map[string]interface{})
+	if !ok {
+		return nil // no permissions section — nothing to strip
+	}
+
+	changed := false
+	if allow, ok := perm["allow"].([]interface{}); ok {
+		filtered := filterStringEntries(allow, []string{"mcp(git-courer/*)"})
+		if len(filtered) != len(allow) {
+			changed = true
+			if len(filtered) == 0 {
+				delete(perm, "allow")
+			} else {
+				perm["allow"] = filtered
+			}
+		}
+	}
+	if ask, ok := perm["ask"].([]interface{}); ok {
+		filtered := filterStringEntries(ask, []string{"command(git *)", "command(*)"})
+		if len(filtered) != len(ask) {
+			changed = true
+			if len(filtered) == 0 {
+				delete(perm, "ask")
+			} else {
+				perm["ask"] = filtered
+			}
+		}
+	}
+
+	if !changed {
+		return nil // no git-courer entries — leave the file untouched
+	}
+
+	// If the permissions map is now empty (all entries were git-courer-owned
+	// and got dropped), drop the permissions key too.
+	if len(perm) == 0 {
+		delete(settings, "permissions")
+	}
+
+	// If the settings map is now empty (all keys were git-courer-owned and got
+	// dropped), delete the file entirely rather than leaving an empty {}.
+	if len(settings) == 0 {
+		_ = os.Remove(settingsPath)
+		return nil
+	}
+
+	out, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal cleaned settings.json: %w", err)
+	}
+	// If the marshaled output is just an empty object, delete the file.
+	if string(out) == "{}" {
+		_ = os.Remove(settingsPath)
+		return nil
+	}
+	return writeAtomic(settingsPath, out, 0644)
+}
+
+// backupAntigravitySettings copies settingsPath to settingsPath + ".gc.bak"
+// so removeAntigravityPermissions can restore it. If extra is non-nil it is
+// written instead of reading the file (used for the unparseable case).
+func backupAntigravitySettings(settingsPath string, extra []byte) error {
+	var data []byte
+	var err error
+	if extra != nil {
+		data = extra
+	} else {
+		data, err = os.ReadFile(settingsPath)
+		if err != nil {
+			return err
+		}
+	}
+	return os.WriteFile(settingsPath+".gc.bak", data, 0644)
+}
+
+// mergeStringEntry appends s to slice if it is not already present, returning
+// the possibly-extended slice. Idempotent: re-adding a present entry is a no-op.
+func mergeStringEntry(slice []interface{}, s string) []interface{} {
+	for _, v := range slice {
+		if str, ok := v.(string); ok && str == s {
+			return slice // already present
+		}
+	}
+	return append(slice, s)
+}
+
+// filterStringEntries returns slice with every entry equal to any of removed
+// excluded, preserving order and non-string entries.
+func filterStringEntries(slice []interface{}, removed []string) []interface{} {
+	out := make([]interface{}, 0, len(slice))
+	for _, v := range slice {
+		if s, ok := v.(string); ok {
+			drop := false
+			for _, r := range removed {
+				if s == r {
+					drop = true
+					break
+				}
+			}
+			if drop {
+				continue
+			}
+		}
+		out = append(out, v)
+	}
+	return out
 }

--- a/internal/installer/mcp_config_test.go
+++ b/internal/installer/mcp_config_test.go
@@ -181,7 +181,7 @@ func assertGitCourerHookPresent(t *testing.T, s claudeSettingsShell, event, matc
 }
 
 // TestInstallClaudeHooks_CreatesHooksInEmptyFile verifies installClaudeHooks
-// creates all three git-courer hook events in a non-existent settings.json
+// creates all four git-courer hook events in a non-existent settings.json
 // with the expected matchers and a command containing "git-courer".
 func TestInstallClaudeHooks_CreatesHooksInEmptyFile(t *testing.T) {
 	dir := t.TempDir()
@@ -195,6 +195,7 @@ func TestInstallClaudeHooks_CreatesHooksInEmptyFile(t *testing.T) {
 	assertGitCourerHookPresent(t, s, "PreToolUse", "Bash")
 	assertGitCourerHookPresent(t, s, "SessionStart", "startup|resume")
 	assertGitCourerHookPresent(t, s, "SubagentStart", "general-purpose|Explore|Plan")
+	assertGitCourerHookPresent(t, s, "PreInvocation", "")
 }
 
 // TestInstallClaudeHooks_MergesWithExistingHooks verifies installClaudeHooks
@@ -229,6 +230,7 @@ func TestInstallClaudeHooks_MergesWithExistingHooks(t *testing.T) {
 	assertGitCourerHookPresent(t, s, "PreToolUse", "Bash")
 	assertGitCourerHookPresent(t, s, "SessionStart", "startup|resume")
 	assertGitCourerHookPresent(t, s, "SubagentStart", "general-purpose|Explore|Plan")
+	assertGitCourerHookPresent(t, s, "PreInvocation", "")
 
 	// tokensave hooks preserved.
 	tokensavePre := false
@@ -524,5 +526,328 @@ func TestRemoveClaudeHooks_NoOpWhenNoFile(t *testing.T) {
 
 	if err := removeClaudeHooks(settingsPath); err != nil {
 		t.Errorf("removeClaudeHooks on missing file returned error: %v", err)
+	}
+}
+
+// --- installAntigravityPermissions tests (Phase 2) ---
+
+// antigravitySettingsShell is the decode target for assertions on the
+// Antigravity settings.json. Only the fields the tests care about are typed.
+type antigravitySettingsShell struct {
+	Permissions struct {
+		Allow []string `json:"allow"`
+		Ask   []string `json:"ask"`
+	} `json:"permissions"`
+	Theme string `json:"theme"`
+}
+
+// readAntigravitySettings reads and parses settings.json.
+func readAntigravitySettings(t *testing.T, path string) antigravitySettingsShell {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read settings.json: %v", err)
+	}
+	var s antigravitySettingsShell
+	if err := json.Unmarshal(data, &s); err != nil {
+		t.Fatalf("settings.json is not valid JSON: %v\ncontent: %s", err, data)
+	}
+	return s
+}
+
+// containsString reports whether the slice contains s.
+func containsString(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// TestInstallAntigravityPermissions_CreatesFreshFile verifies that when
+// settings.json does not exist, the three git-courer permission entries are
+// written and no backup is created.
+func TestInstallAntigravityPermissions_CreatesFreshFile(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	if err := installAntigravityPermissions(settingsPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("installAntigravityPermissions: %v", err)
+	}
+
+	s := readAntigravitySettings(t, settingsPath)
+	if !containsString(s.Permissions.Allow, "mcp(git-courer/*)") {
+		t.Errorf("permissions.allow missing mcp(git-courer/*): %v", s.Permissions.Allow)
+	}
+	if !containsString(s.Permissions.Ask, "command(git *)") {
+		t.Errorf("permissions.ask missing command(git *): %v", s.Permissions.Ask)
+	}
+	if !containsString(s.Permissions.Ask, "command(*)") {
+		t.Errorf("permissions.ask missing command(*): %v", s.Permissions.Ask)
+	}
+
+	// No backup should be created when the file did not exist.
+	if _, err := os.Stat(settingsPath + ".gc.bak"); err == nil {
+		t.Error("backup should not be created when settings.json did not exist")
+	}
+}
+
+// TestInstallAntigravityPermissions_MergesPreservingExisting verifies that
+// existing non-git-courer permission keys are preserved and the three
+// git-courer entries are added, with a backup created.
+func TestInstallAntigravityPermissions_MergesPreservingExisting(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	original := `{"permissions":{"allow":["command(npm *)"]},"theme":"dark"}`
+	if err := os.WriteFile(settingsPath, []byte(original), 0644); err != nil {
+		t.Fatalf("write original: %v", err)
+	}
+
+	if err := installAntigravityPermissions(settingsPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("installAntigravityPermissions: %v", err)
+	}
+
+	s := readAntigravitySettings(t, settingsPath)
+	// Existing key preserved.
+	if !containsString(s.Permissions.Allow, "command(npm *)") {
+		t.Errorf("existing command(npm *) was not preserved: %v", s.Permissions.Allow)
+	}
+	// git-courer entries present.
+	if !containsString(s.Permissions.Allow, "mcp(git-courer/*)") {
+		t.Errorf("permissions.allow missing mcp(git-courer/*): %v", s.Permissions.Allow)
+	}
+	if !containsString(s.Permissions.Ask, "command(git *)") {
+		t.Errorf("permissions.ask missing command(git *): %v", s.Permissions.Ask)
+	}
+	if !containsString(s.Permissions.Ask, "command(*)") {
+		t.Errorf("permissions.ask missing command(*): %v", s.Permissions.Ask)
+	}
+	// Non-permission key preserved.
+	if s.Theme != "dark" {
+		t.Errorf("theme was not preserved: got %q", s.Theme)
+	}
+
+	// Backup created with original content.
+	bakData, err := os.ReadFile(settingsPath + ".gc.bak")
+	if err != nil {
+		t.Fatalf("backup not created: %v", err)
+	}
+	if string(bakData) != original {
+		t.Errorf("backup content mismatch:\ngot:  %s\nwant: %s", bakData, original)
+	}
+}
+
+// TestInstallAntigravityPermissions_Idempotent verifies that running
+// installAntigravityPermissions twice produces byte-identical settings.json
+// and does not overwrite the backup on the second run.
+func TestInstallAntigravityPermissions_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	if err := installAntigravityPermissions(settingsPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	first, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read after first: %v", err)
+	}
+
+	// Capture the backup mtime after the first run.
+	firstBakStat, err := os.Stat(settingsPath + ".gc.bak")
+	if err != nil {
+		// On a fresh file there is no backup the first time. Create one by
+		// pre-populating settings.json then installing so a backup exists.
+		_ = os.WriteFile(settingsPath, []byte(`{"permissions":{"allow":["command(npm *)"]}}`), 0644)
+		_ = os.Remove(settingsPath + ".gc.bak")
+		if err := installAntigravityPermissions(settingsPath, "/usr/local/bin/git-courer"); err != nil {
+			t.Fatalf("install for backup: %v", err)
+		}
+		firstBakStat, err = os.Stat(settingsPath + ".gc.bak")
+		if err != nil {
+			t.Fatalf("backup still not created: %v", err)
+		}
+		first, err = os.ReadFile(settingsPath)
+		if err != nil {
+			t.Fatalf("read after install: %v", err)
+		}
+	}
+
+	if err := installAntigravityPermissions(settingsPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	second, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read after second: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Errorf("not idempotent — outputs differ\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+
+	// Backup should not be overwritten on re-run.
+	secondBakStat, err := os.Stat(settingsPath + ".gc.bak")
+	if err != nil {
+		t.Fatalf("backup missing after second run: %v", err)
+	}
+	if !secondBakStat.ModTime().Equal(firstBakStat.ModTime()) {
+		t.Errorf("backup was overwritten on second run: before=%v after=%v", firstBakStat.ModTime(), secondBakStat.ModTime())
+	}
+}
+
+// TestInstallAntigravityPermissions_NoDuplicateEntries verifies that
+// re-running does not add duplicate git-courer permission entries.
+func TestInstallAntigravityPermissions_NoDuplicateEntries(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	if err := installAntigravityPermissions(settingsPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	if err := installAntigravityPermissions(settingsPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("second: %v", err)
+	}
+
+	s := readAntigravitySettings(t, settingsPath)
+	countAllow := 0
+	for _, v := range s.Permissions.Allow {
+		if v == "mcp(git-courer/*)" {
+			countAllow++
+		}
+	}
+	if countAllow != 1 {
+		t.Errorf("expected 1 mcp(git-courer/*) in allow, got %d (duplicate detected)", countAllow)
+	}
+	countAskGit := 0
+	for _, v := range s.Permissions.Ask {
+		if v == "command(git *)" {
+			countAskGit++
+		}
+	}
+	if countAskGit != 1 {
+		t.Errorf("expected 1 command(git *) in ask, got %d (duplicate detected)", countAskGit)
+	}
+}
+
+// TestInstallAntigravityPermissions_HandlesUnparseable verifies that when
+// settings.json exists but is invalid JSON, it is backed up to .gc.bak and a
+// fresh file with the git-courer permissions is written.
+func TestInstallAntigravityPermissions_HandlesUnparseable(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	corrupt := `{not valid json`
+	if err := os.WriteFile(settingsPath, []byte(corrupt), 0644); err != nil {
+		t.Fatalf("write corrupt: %v", err)
+	}
+
+	if err := installAntigravityPermissions(settingsPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("installAntigravityPermissions on corrupt file: %v", err)
+	}
+
+	s := readAntigravitySettings(t, settingsPath)
+	if !containsString(s.Permissions.Allow, "mcp(git-courer/*)") {
+		t.Errorf("permissions.allow missing mcp(git-courer/*) after recovering: %v", s.Permissions.Allow)
+	}
+
+	bakData, err := os.ReadFile(settingsPath + ".gc.bak")
+	if err != nil {
+		t.Fatalf("backup of corrupt file not created: %v", err)
+	}
+	if string(bakData) != corrupt {
+		t.Errorf("backup content mismatch:\ngot:  %s\nwant: %s", bakData, corrupt)
+	}
+}
+
+// --- removeAntigravityPermissions tests (Phase 2) ---
+
+// TestRemoveAntigravityPermissions_RestoresBackup verifies that when a .gc.bak
+// exists, removeAntigravityPermissions restores it and removes the .bak.
+func TestRemoveAntigravityPermissions_RestoresBackup(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	current := `{"permissions":{"allow":["mcp(git-courer/*)"],"ask":["command(git *)","command(*)"]}}`
+	if err := os.WriteFile(settingsPath, []byte(current), 0644); err != nil {
+		t.Fatalf("write current: %v", err)
+	}
+	backup := `{"permissions":{"allow":["command(npm *)"]}}`
+	if err := os.WriteFile(settingsPath+".gc.bak", []byte(backup), 0644); err != nil {
+		t.Fatalf("write backup: %v", err)
+	}
+
+	if err := removeAntigravityPermissions(settingsPath); err != nil {
+		t.Fatalf("removeAntigravityPermissions: %v", err)
+	}
+
+	restored, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("settings.json not restored: %v", err)
+	}
+	if string(restored) != backup {
+		t.Errorf("restored content mismatch:\ngot:  %s\nwant: %s", restored, backup)
+	}
+	if _, err := os.Stat(settingsPath + ".gc.bak"); err == nil {
+		t.Error("backup file should have been removed after restore")
+	}
+}
+
+// TestRemoveAntigravityPermissions_StripsWithoutBackup verifies that when no
+// .gc.bak exists, removeAntigravityPermissions strips the git-courer entries
+// while preserving non-git-courer keys.
+func TestRemoveAntigravityPermissions_StripsWithoutBackup(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	existing := `{"permissions":{"allow":["command(npm *)","mcp(git-courer/*)"],"ask":["command(git *)","command(*)"]}}`
+	if err := os.WriteFile(settingsPath, []byte(existing), 0644); err != nil {
+		t.Fatalf("write existing: %v", err)
+	}
+
+	if err := removeAntigravityPermissions(settingsPath); err != nil {
+		t.Fatalf("removeAntigravityPermissions: %v", err)
+	}
+
+	s := readAntigravitySettings(t, settingsPath)
+	if !containsString(s.Permissions.Allow, "command(npm *)") {
+		t.Errorf("non-git-courer allow entry was stripped: %v", s.Permissions.Allow)
+	}
+	if containsString(s.Permissions.Allow, "mcp(git-courer/*)") {
+		t.Errorf("mcp(git-courer/*) was not stripped: %v", s.Permissions.Allow)
+	}
+	if containsString(s.Permissions.Ask, "command(git *)") {
+		t.Errorf("command(git *) was not stripped: %v", s.Permissions.Ask)
+	}
+	if containsString(s.Permissions.Ask, "command(*)") {
+		t.Errorf("command(*) was not stripped: %v", s.Permissions.Ask)
+	}
+}
+
+// TestRemoveAntigravityPermissions_Idempotent verifies that running
+// removeAntigravityPermissions twice does not error.
+func TestRemoveAntigravityPermissions_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	if err := installAntigravityPermissions(settingsPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	if err := removeAntigravityPermissions(settingsPath); err != nil {
+		t.Fatalf("first remove: %v", err)
+	}
+	if err := removeAntigravityPermissions(settingsPath); err != nil {
+		t.Fatalf("second remove: %v", err)
+	}
+}
+
+// TestRemoveAntigravityPermissions_NoOpWhenNoFile verifies that
+// removeAntigravityPermissions returns nil when settings.json does not exist.
+func TestRemoveAntigravityPermissions_NoOpWhenNoFile(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "does-not-exist.json")
+
+	if err := removeAntigravityPermissions(settingsPath); err != nil {
+		t.Errorf("removeAntigravityPermissions on missing file returned error: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Configure Antigravity CLI to prefer git-courer MCP tools over raw bash git commands, with declarative permissions, hook-based suggestions, and golden rules injected before every model invocation.

## Changes

### HooksConfig extension
- Added `PermissionsPath` field to `HooksConfig` for clients with a separate permissions file
- Set `HooksConfig` on the existing Antigravity `MCPClient` entry

### Antigravity hooks (`hooks.json`)
- `PreToolUse` (matcher: `run_command`) — runs `git-courer hook-check`, returns MCP tool suggestion as `additionalContext` without denying
- `PreInvocation` — runs `git-courer pre-invocation-hook`, injects golden rules before every model call

### Antigravity permissions (`settings.json`)
- `command(git *)` → `ask`
- `command(*)` → `ask`
- `mcp(git-courer/*)` → `allow`
- Merges into existing settings.json, preserves non-git-courer keys, backs up to `.gc.bak`

### New subcommand
- `git-courer pre-invocation-hook` — returns golden rules as `additionalContext`, same pattern as `session-start-hook`

### Install/Uninstall
- `git-courer mcp setup` installs hooks + permissions for Antigravity
- `git-courer uninstall` removes hooks + permissions and restores backups

## Files changed (9 files, +1306/-33)

| File | Change |
|---|---|
| `internal/installer/mcp_config.go` | PermissionsPath + Antigravity HooksConfig + wiring + permission functions |
| `internal/installer/hooks.go` | PreInvocation event + Antigravity hooks functions |
| `internal/installer/installer.go` | Uninstall wiring for Antigravity |
| `internal/delivery/cli/hook_check.go` | PreInvocationHookCommand |
| `cmd/main.go` | pre-invocation-hook subcommand |
| Tests (4 files) | 17 new tests, all passing |

## Testing
- `go test ./... -short` — 30 packages, 0 failures
- `go vet ./...` — clean
- Strict TDD: RED/GREEN/TRIANGULATE/SAFETY NET verified

## Notes
- IDE de Antigravity queda fuera de scope (CLI ahora, IDE después)
- Single PR con size:exception (~1300 lines, includes ~800 lines of tests)
