### PR TITLE
fix: release wizard regenerate (r) and edit (e) actions lose state

### DIFF
--- a/internal/adapters/llm/openai_standard/adapter_release.go
+++ b/internal/adapters/llm/openai_standard/adapter_release.go
@@ -88,6 +88,34 @@ func (a *OpenAIStandardAdapter) GenerateChangelogGrouped(formattedGroups string,
 	return result, nil
 }
 
+// RegenerateChangelog regenerates a release changelog from the previous output and
+// user feedback. It uses the dedicated changelog_regenerate prompt template, which
+// reuses the same output rules as the changelog template but is grounded in the
+// previous changelog and the feedback rather than raw commits.
+func (a *OpenAIStandardAdapter) RegenerateChangelog(prevChangelog, feedback string) (string, error) {
+	tmpl, err := prompts.Get("changelog_regenerate")
+	if err != nil {
+		return "", fmt.Errorf("prompt not found: %w", err)
+	}
+	prompt, err := prompts.Render(tmpl, map[string]string{
+		"PreviousChangelog": prevChangelog,
+		"Feedback":           feedback,
+	})
+	if err != nil {
+		return "", fmt.Errorf("render changelog_regenerate prompt: %w", err)
+	}
+	result, err := a.chatCompletion(prompt, chatCompletionOpts{
+		operation:       "changelog",
+		reasoningEffort: "none",
+		temperature:     floatPtr(changelogTemp),
+		maxTokens:       changelogMaxTokens,
+	})
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
 // RegenerateMessage generates new commit messages based on feedback.
 func (a *OpenAIStandardAdapter) RegenerateMessage(previousMessages []string, feedback string, chunks []domain.DiffChunk) ([]string, error) {
 	if len(previousMessages) != len(chunks) {

--- a/internal/adapters/llm/openai_standard/adapter_test.go
+++ b/internal/adapters/llm/openai_standard/adapter_test.go
@@ -1751,3 +1751,86 @@ func TestAdapter_GenerateChangelogGrouped_PromptUsesFreeformFormat(t *testing.T)
 		t.Fatalf("GenerateChangelogGrouped failed: %v", err)
 	}
 }
+
+// --- RegenerateChangelog (release regenerate action) ---
+
+func TestAdapter_RegenerateChangelog_PromptContainsPrevChangelogAndFeedback(t *testing.T) {
+	// RED: verify the prompt sent to the LLM contains both the previous changelog
+	// and the user feedback, so the regeneration is grounded in both.
+	prevChangelog := "## Features\n- Added login flow"
+	feedback := "make the tone more direct and add examples"
+	expectedMarkdown := "## Features\n- Added login flow (revised)"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		promptContent := req.Messages[len(req.Messages)-1].Content
+
+		if !strings.Contains(promptContent, prevChangelog) {
+			t.Errorf("prompt should contain previous changelog, got:\n%s", promptContent)
+		}
+		if !strings.Contains(promptContent, feedback) {
+			t.Errorf("prompt should contain user feedback, got:\n%s", promptContent)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(chatCompletionResponse(expectedMarkdown))
+	}))
+	defer server.Close()
+
+	adapter := newTestAdapter(server)
+	result, err := adapter.RegenerateChangelog(prevChangelog, feedback)
+	if err != nil {
+		t.Fatalf("RegenerateChangelog failed: %v", err)
+	}
+	if !strings.Contains(result, "revised") {
+		t.Errorf("expected revised markdown, got: %s", result)
+	}
+}
+
+func TestAdapter_RegenerateChangelog_EmptyFeedbackStillRegenerates(t *testing.T) {
+	// TRIANGULATE: empty feedback must still produce a changelog using the
+	// previous changelog as context (spec: Empty feedback scenario).
+	prevChangelog := "## Features\n- Added login flow"
+	expectedMarkdown := "## Features\n- Added login flow"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req ChatRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		promptContent := req.Messages[len(req.Messages)-1].Content
+		if !strings.Contains(promptContent, prevChangelog) {
+			t.Errorf("prompt should contain previous changelog even with empty feedback, got:\n%s", promptContent)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(chatCompletionResponse(expectedMarkdown))
+	}))
+	defer server.Close()
+
+	adapter := newTestAdapter(server)
+	result, err := adapter.RegenerateChangelog(prevChangelog, "")
+	if err != nil {
+		t.Fatalf("RegenerateChangelog failed: %v", err)
+	}
+	if !strings.Contains(result, "login flow") {
+		t.Errorf("expected regenerated markdown, got: %s", result)
+	}
+}
+
+func TestAdapter_RegenerateChangelog_PropagatesProviderError(t *testing.T) {
+	// TRIANGULATE: a failing provider call must surface an error, not return empty.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	adapter := newTestAdapter(server)
+	_, err := adapter.RegenerateChangelog("prev", "feedback")
+	if err == nil {
+		t.Fatal("expected error from provider failure, got nil")
+	}
+}

--- a/internal/core/ports/llm.go
+++ b/internal/core/ports/llm.go
@@ -36,6 +36,12 @@ type LLM interface {
 	// customMessage is optional user instructions injected into the prompt.
 	GenerateChangelogGrouped(formattedGroups string, nameMap map[string]string, customMessage string, mode string) (string, error)
 
+	// RegenerateChangelog regenerates a release changelog based on user feedback.
+	// prevChangelog is the previously generated changelog markdown.
+	// feedback is the user's natural language feedback on what to change.
+	// Returns the revised changelog markdown, or an error if the provider call fails.
+	RegenerateChangelog(prevChangelog, feedback string) (string, error)
+
 	// RegenerateMessage generates new commit messages based on feedback.
 	// Used when the user requests regeneration of commit messages in preview mode.
 	RegenerateMessage(previousMessages []string, feedback string, chunks []domain.DiffChunk) ([]string, error)

--- a/internal/delivery/cli/release.go
+++ b/internal/delivery/cli/release.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -137,62 +138,83 @@ func (c *ReleaseCommand) Run() error {
 			return fmt.Errorf("release: generate failed: %w", err)
 		}
 
-		// 5. Show preview with glamour
-		preview := svc.BuildPreview(intent, changelog)
-		rendered, renderErr := glamour.Render(preview, "dark")
-		if renderErr != nil {
-			rendered = preview
-		}
-		fmt.Fprint(c.writer(), rendered)
+	preview:
+		for {
+			// 5. Show preview with glamour
+			preview := svc.BuildPreview(intent, changelog)
+			rendered, renderErr := glamour.Render(preview, "dark")
+			if renderErr != nil {
+				rendered = preview
+			}
+			fmt.Fprint(c.writer(), rendered)
 
-		// 6. Ask action
-		fmt.Fprint(c.writer(), "Apply? (s/N/r/e): ")
-		action := strings.TrimSpace(strings.ToLower(c.readLine(reader)))
+			// 6. Ask action
+			fmt.Fprint(c.writer(), "Apply? (s/N/r/e): ")
+			action := strings.TrimSpace(strings.ToLower(c.readLine(reader)))
 
-		switch action {
-		case "s":
-			svc.SaveIntent(intent)
-			svc.SaveChangelog(changelog)
-			result, err := svc.Execute(intent, changelog)
-			if err != nil {
-				return fmt.Errorf("release: apply failed: %w", err)
-			}
-			fmt.Fprintln(c.writer(), result)
-			return nil
-		case "r":
-			fmt.Fprint(c.writer(), "Feedback to regenerate changelog: ")
-			feedback := c.readLine(reader)
-			if feedback != "" {
-				svc.SetCustomMessage(feedback)
-			}
-			continue
-		case "e":
-			svc.SaveChangelog(changelog)
-			editor := os.Getenv("EDITOR")
-			if editor == "" {
-				editor = os.Getenv("VISUAL")
-			}
-			if editor == "" {
-				if runtime.GOOS == "windows" {
-					editor = "notepad"
-				} else {
-					editor = "vi"
+			switch action {
+			case "s":
+				svc.SaveIntent(intent)
+				svc.SaveChangelog(changelog)
+				result, err := svc.Execute(intent, changelog)
+				if err != nil {
+					return fmt.Errorf("release: apply failed: %w", err)
 				}
+				fmt.Fprintln(c.writer(), result)
+				return nil
+			case "r":
+				fmt.Fprint(c.writer(), "Feedback to regenerate changelog: ")
+				feedback := c.readLine(reader)
+				regenerated, regErr := c.llm.RegenerateChangelog(changelog, feedback)
+				if regErr != nil {
+					fmt.Fprintf(c.writer(), "Regenerate failed: %v\n", regErr)
+					continue // stay on preview, keep state intact
+				}
+				changelog = regenerated
+				continue preview // skip tag/message re-prompts
+			case "e":
+				changelogPath := filepath.Join(c.workDir, domain.MetadataDir, "release_changelog.md")
+				// Persist the current changelog to the real on-disk path so the editor
+				// opens on a populated file. We write directly rather than relying on
+				// svc.SaveChangelog's filesystem side effect — this keeps the edit
+				// flow self-contained and testable with a mock service.
+				if mkErr := os.MkdirAll(filepath.Dir(changelogPath), 0o755); mkErr != nil {
+					fmt.Fprintf(c.writer(), "Edit failed: %v\n", mkErr)
+					continue
+				}
+				if writeErr := os.WriteFile(changelogPath, []byte(changelog), 0o644); writeErr != nil {
+					fmt.Fprintf(c.writer(), "Edit failed: %v\n", writeErr)
+					continue
+				}
+				editor := os.Getenv("EDITOR")
+				if editor == "" {
+					editor = os.Getenv("VISUAL")
+				}
+				if editor == "" {
+					if runtime.GOOS == "windows" {
+						editor = "notepad"
+					} else {
+						editor = "vi"
+					}
+				}
+				editCmd := exec.Command(editor, changelogPath)
+				editCmd.Stdin = os.Stdin
+				editCmd.Stdout = os.Stdout
+				editCmd.Stderr = os.Stderr
+				_ = editCmd.Run()
+				edited, readErr := os.ReadFile(changelogPath)
+				if readErr != nil {
+					fmt.Fprintf(c.writer(), "Read edited changelog failed: %v\n", readErr)
+					continue // stay on preview, keep state intact
+				}
+				changelog = string(edited)
+				svc.SaveChangelog(changelog)
+				continue preview // skip tag/message re-prompts
+			default:
+				svc.ClearPending()
+				fmt.Fprintln(c.writer(), "Release cancelled")
+				return nil
 			}
-			editCmd := exec.Command(editor, "release_changelog.md")
-			editCmd.Stdin = os.Stdin
-			editCmd.Stdout = os.Stdout
-			editCmd.Stderr = os.Stderr
-			_ = editCmd.Run()
-			edited, _ := svc.LoadChangelog()
-			if edited != "" {
-				changelog = edited
-			}
-			continue
-		default:
-			svc.ClearPending()
-			fmt.Fprintln(c.writer(), "Release cancelled")
-			return nil
 		}
 	}
 }

--- a/internal/delivery/cli/release_test.go
+++ b/internal/delivery/cli/release_test.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -9,6 +11,51 @@ import (
 	"github.com/blak0p/git-courer/internal/core/domain"
 	"github.com/blak0p/git-courer/internal/core/ports"
 )
+
+// --- Mock LLM for CLI release tests ---
+
+type mockLLMForCLI struct {
+	regenerateCalled      bool
+	regeneratePrev        string
+	regenerateFeedback    string
+	regenerateResult      string
+	regenerateErr         error
+}
+
+func (m *mockLLMForCLI) GenerateChunkMessage(chunk domain.DiffChunk) (string, error) { return "", nil }
+func (m *mockLLMForCLI) GenerateCommitSynthesis(combinedChunk domain.DiffChunk, fileMessages []string) (string, error) {
+	return "", nil
+}
+func (m *mockLLMForCLI) InterpretGitOp(op, instruction string, ctx map[string]string) (map[string]string, error) {
+	return nil, nil
+}
+func (m *mockLLMForCLI) SetRetryContext(msg string)    {}
+func (m *mockLLMForCLI) ClearRetryContext()            {}
+func (m *mockLLMForCLI) IsAvailable() bool             { return true }
+func (m *mockLLMForCLI) VerifySecrets(diff string, findings []domain.SecretDetection) (bool, error) {
+	return false, nil
+}
+func (m *mockLLMForCLI) AuditBinaryContent(filename, content string) (bool, error) { return false, nil }
+func (m *mockLLMForCLI) GenerateChangelogGrouped(formattedGroups string, nameMap map[string]string, customMessage string, mode string) (string, error) {
+	return "", nil
+}
+func (m *mockLLMForCLI) RegenerateMessage(previousMessages []string, feedback string, chunks []domain.DiffChunk) ([]string, error) {
+	return nil, nil
+}
+func (m *mockLLMForCLI) RegenerateChangelog(prevChangelog, feedback string) (string, error) {
+	m.regenerateCalled = true
+	m.regeneratePrev = prevChangelog
+	m.regenerateFeedback = feedback
+	if m.regenerateErr != nil {
+		return "", m.regenerateErr
+	}
+	return m.regenerateResult, nil
+}
+func (m *mockLLMForCLI) ProjectInit(repoRoot string) (*domain.ProjectConfig, error) { return nil, nil }
+func (m *mockLLMForCLI) ClassifyBinary(prompt string) (string, error)               { return "fix", nil }
+
+// Compile-time interface check
+var _ ports.LLM = (*mockLLMForCLI)(nil)
 
 // --- Mock ReleaseSvc for testing ---
 
@@ -29,7 +76,8 @@ type mockReleaseSvc struct {
 	clearCalled         bool
 	saveIntentCalled    bool
 	saveChangelogCalled bool
-	customMessage       string // tracks SetCustomMessage calls
+	lastSavedChangelog   string
+	customMessage        string // tracks SetCustomMessage calls
 }
 
 func (m *mockReleaseSvc) Prepare(instruction, userBump string) (*domain.ReleaseIntent, string, []string, error) {
@@ -51,6 +99,7 @@ func (m *mockReleaseSvc) LoadIntent() (*domain.ReleaseIntent, error) {
 }
 func (m *mockReleaseSvc) SaveChangelog(changelog string) {
 	m.saveChangelogCalled = true
+	m.lastSavedChangelog = changelog
 }
 func (m *mockReleaseSvc) LoadChangelog() (string, error) {
 	return "changelog content", nil
@@ -225,7 +274,10 @@ func TestReleaseCommand_Interactive_Abort(t *testing.T) {
 
 func TestReleaseCommand_Interactive_Regenerate(t *testing.T) {
 	store := &mockCommitStoreForCLI{}
-	cmd := NewReleaseCommand(nil, nil, nil, store, "/tmp")
+	llm := &mockLLMForCLI{
+		regenerateResult: "## Features\n- clearer feature",
+	}
+	cmd := NewReleaseCommand(nil, llm, nil, store, "/tmp")
 	svc := &mockReleaseSvc{
 		prepareResult: &domain.ReleaseIntent{
 			TagName:     "v1.1.0",
@@ -237,19 +289,96 @@ func TestReleaseCommand_Interactive_Regenerate(t *testing.T) {
 		executeResult:  `{"operation":"release","tag_name":"v1.1.0"}`,
 	}
 	cmd.SetReleaseService(svc)
-	// Enter for tag, Enter for message, "r" → feedback → loop back → Enter tag, Enter message, "s"
-	cmd.Stdin = strings.NewReader("\n\nr\nmake it clearer\n\n\ns\n")
+	// Enter for tag, Enter for message, "r" → feedback → preview (no tag/message
+	// re-prompts because goto preview skips them), then "s" to apply.
+	cmd.Stdin = strings.NewReader("\n\nr\nmake it clearer\ns\n")
 	cmd.Stdout = io.Discard
 
 	err := cmd.Run()
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
-	if svc.customMessage != "make it clearer" {
-		t.Errorf("SetCustomMessage = %q, want %q", svc.customMessage, "make it clearer")
+	// RegenerateChangelog MUST be called with the previous changelog and feedback.
+	if !llm.regenerateCalled {
+		t.Fatal("expected RegenerateChangelog to be called")
+	}
+	if llm.regenerateFeedback != "make it clearer" {
+		t.Errorf("RegenerateChangelog feedback = %q, want %q", llm.regenerateFeedback, "make it clearer")
+	}
+	if llm.regeneratePrev != "## Features\n- new thing" {
+		t.Errorf("RegenerateChangelog prev = %q, want %q", llm.regeneratePrev, "## Features\n- new thing")
+	}
+	// tag/message were NOT re-asked: Prepare was called only once (initial).
+	if svc.prepareInstruction != "" {
+		t.Errorf("Prepare should not be called again after regenerate, got instruction = %q", svc.prepareInstruction)
+	}
+	if svc.customMessage != "" {
+		t.Errorf("SetCustomMessage should not be called by regenerate, got = %q", svc.customMessage)
 	}
 	if !svc.saveIntentCalled {
-		t.Error("expected SaveIntent to be called after regenerate")
+		t.Error("expected SaveIntent to be called after apply")
+	}
+}
+
+func TestReleaseCommand_Interactive_Edit(t *testing.T) {
+	// The wizard saves the changelog to the real metadata-dir path, opens the
+	// editor on that path, reads the edited content on close, persists it via
+	// SaveChangelog, then returns to preview WITHOUT re-asking tag/message.
+	workDir := t.TempDir()
+	// Create a helper editor script that overwrites its first arg with edited content.
+	editorPath := filepath.Join(workDir, "fakeeditor.sh")
+	editedContent := "## Features\n- edited by user"
+	editorScript := "#!/bin/sh\ncat > \"$1\" <<'EOF'\n" + editedContent + "\nEOF\n"
+	if err := os.WriteFile(editorPath, []byte(editorScript), 0o755); err != nil {
+		t.Fatalf("write editor script: %v", err)
+	}
+	t.Setenv("EDITOR", editorPath)
+
+	store := &mockCommitStoreForCLI{}
+	cmd := NewReleaseCommand(nil, nil, nil, store, workDir)
+	svc := &mockReleaseSvc{
+		prepareResult: &domain.ReleaseIntent{
+			TagName:     "v1.1.0",
+			IsRelease:   true,
+			VersionBump: "minor",
+		},
+		prepareCommits: "feat: new feature",
+		generateResult: "## Features\n- new thing",
+		executeResult:  `{"operation":"release","tag_name":"v1.1.0"}`,
+	}
+	cmd.SetReleaseService(svc)
+	// Enter for tag, Enter for message, "e" → editor runs → preview (no tag/message
+	// re-prompts), then "s" to apply.
+	cmd.Stdin = strings.NewReader("\n\ne\ns\n")
+	cmd.Stdout = io.Discard
+
+	err := cmd.Run()
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	// The edited file MUST be written to the real metadata-dir path.
+	changelogPath := filepath.Join(workDir, domain.MetadataDir, "release_changelog.md")
+	onDisk, err := os.ReadFile(changelogPath)
+	if err != nil {
+		t.Fatalf("edited changelog file should exist at %s: %v", changelogPath, err)
+	}
+	// The fake editor writes the content via a heredoc which appends a trailing newline.
+	wantOnDisk := editedContent + "\n"
+	if string(onDisk) != wantOnDisk {
+		t.Errorf("on-disk changelog = %q, want %q", string(onDisk), wantOnDisk)
+	}
+	// SaveChangelog MUST be called with the edited content (not the original).
+	if !svc.saveChangelogCalled {
+		t.Error("expected SaveChangelog to be called with edited content")
+	} else if svc.lastSavedChangelog != wantOnDisk {
+		t.Errorf("SaveChangelog content = %q, want %q", svc.lastSavedChangelog, wantOnDisk)
+	}
+	// tag/message were NOT re-asked: Prepare was called only once (initial).
+	if svc.prepareInstruction != "" {
+		t.Errorf("Prepare should not be called again after edit, got instruction = %q", svc.prepareInstruction)
+	}
+	if !svc.saveIntentCalled {
+		t.Error("expected SaveIntent to be called after apply")
 	}
 }
 

--- a/internal/delivery/mcp/core/handler_test.go
+++ b/internal/delivery/mcp/core/handler_test.go
@@ -1529,6 +1529,10 @@ func (m *mockLLM) RegenerateMessage(previousMessages []string, feedback string, 
 	args := m.Called(previousMessages, feedback, chunks)
 	return args.Get(0).([]string), args.Error(1)
 }
+func (m *mockLLM) RegenerateChangelog(prevChangelog, feedback string) (string, error) {
+	args := m.Called(prevChangelog, feedback)
+	return args.String(0), args.Error(1)
+}
 func (m *mockLLM) ProjectInit(repoRoot string) (*domain.ProjectConfig, error) {
 	args := m.Called(repoRoot)
 	if args.Get(0) == nil {

--- a/internal/shared/prompts/md/changelog_regenerate.md
+++ b/internal/shared/prompts/md/changelog_regenerate.md
@@ -1,0 +1,84 @@
+Output ONLY the markdown. No JSON, no code fences, no explanation.
+
+## Previous Changelog
+
+{{.PreviousChangelog}}
+
+## Feedback
+
+{{.Feedback}}
+
+## Task
+You are a senior technical writer revising release notes for a developer tool.
+The user reviewed the previous changelog above and gave feedback. Regenerate the
+changelog applying that feedback. Keep the same format and structure as the previous
+changelog unless the feedback explicitly asks otherwise.
+
+Your job is to communicate WHY each change exists and what problem it solves, while
+being honest about the technical reality. Every bullet must answer "why should a
+human care?" and "what changed under the hood?".
+
+## Rules
+1. **Communicate the WHY and the WHAT**: Every commit has a reason. Extract it. Say WHY it changed AND what changed, in that order.
+   - ❌ "Improved path validation"
+   - ✅ "Metadata could be lost during automated Git operations because path validation was too loose — now the system reliably detects and preserves metadata directories"
+   - ❌ "Added log range support"
+   - ✅ "Developers couldn't inspect specific periods of commit history without wading through the full log — now you can query by range and find what you need instantly"
+
+2. **Ground in commits**: Every bullet must trace to actual commit content. Never invent. If you can't find the WHY in the commit, say what the commit does and infer the problem from context.
+
+3. **Technical when it helps**: Strip unnecessary code jargon (internal variable names, AST node types, line numbers), but keep architectural and domain terms when they matter for understanding. If a change touches the "commit tree", "merge base", "plumbing", or "reconciler", name those concepts — they help the reader understand what part of the system changed. Translate implementation details into system behavior.
+   - ❌ "Changed CommitTree call in applyPlumbing from commitHash to parentHash on line 641"
+   - ✅ "Fixed duplicate commits in the release history by ensuring the plumbing amend rewrites the original commit instead of chaining a new one"
+   - ❌ "Updated adapter_release.go string from changelog_areas to changelog"
+   - ✅ "Fixed release pipeline failure where the changelog prompt key was stale after removing the predefined Areas system"
+
+4. **Deduplicate and Consolidate**: Merge related commits into one strong bullet explaining the unified WHY.
+
+5. **Skip Merge and Internal Noise**: No branch merges, CI/CD, test-only changes.
+
+6. **Invent Your Own Categories**: Look at ALL the commits below. Invent meaningful category names that group related changes together. Use real descriptive names like "Authentication", "API Improvements", "Developer Experience" — NOT generic labels like "group_1" or "Category A".
+
+7. **Lead with a plain-text summary**: Before any `##` heading in YOUR output, write one plain sentence that summarizes the whole release. No markdown formatting on this line.
+   - ❌ "## Authentication"
+   - ✅ "This release hardens authentication and exposes webhook endpoints for integrations."
+
+   ✅ CORRECT:
+   This release hardens authentication and exposes webhook endpoints for integrations.
+
+   ## Authentication
+   - Added **JWT token** flow so users can securely access their accounts
+
+   ❌ WRONG (heading first):
+   ## Authentication
+   - Added **JWT token** flow so users can securely access their accounts
+
+## Tone
+Professional, clear, and precise. Use active verbs. Write like a senior engineer explaining changes to another engineer — accessible, but not afraid of the right technical word when it clarifies what changed.
+
+## Language
+Default to English unless the feedback or previous changelog specify another language. Match the language of the previous changelog when in doubt.
+
+## Output Format
+Use `##` for category headings, `-` for bullet points, and **bold** for technical terms.
+Use markdown tables when comparing features, versions, or options — they make
+side-by-side data clearer than bullet lists.
+
+✅ CORRECT:
+## Authentication
+- Added **JWT token** flow so users can securely access their accounts
+- Implemented **token refresh** to prevent unexpected logouts
+
+## API
+- Exposed **webhook** endpoints for third-party integrations
+
+❌ WRONG (JSON):
+```json
+{"Authentication": ["Added login"]}
+```
+
+❌ WRONG (obfuscated keys):
+## group_1
+- Added login
+
+Use meaningful category names that reflect the actual content. Never use generic placeholders like "group_N", "Category A", or "Section 1".

--- a/internal/shared/prompts/prompts.go
+++ b/internal/shared/prompts/prompts.go
@@ -99,6 +99,14 @@ func GetChangelog() string {
 	return tmpl
 }
 
+// GetChangelogRegenerate returns the changelog_regenerate template used by
+// RegenerateChangelog. It renders a revised changelog from the previous output
+// and user feedback, reusing the same output rules as the changelog template.
+func GetChangelogRegenerate() string {
+	tmpl, _ := Get("changelog_regenerate")
+	return tmpl
+}
+
 // GetChangelogAreas returns the changelog_areas template
 // Deprecated: Use GetChangelog() for freeform mode
 func GetChangelogAreas() string {

--- a/internal/shared/prompts/prompts_test.go
+++ b/internal/shared/prompts/prompts_test.go
@@ -187,3 +187,43 @@ func TestGetChangelog(t *testing.T) {
 		t.Error("changelog.md should NOT contain area names like 'area_name'")
 	}
 }
+
+func TestGetChangelogRegenerate(t *testing.T) {
+	tmpl := GetChangelogRegenerate()
+	if tmpl == "" {
+		t.Fatal("GetChangelogRegenerate() returned empty string")
+	}
+	// Regenerate template must declare both variables used by the adapter.
+	if !strings.Contains(tmpl, "{{.PreviousChangelog}}") {
+		t.Error("changelog_regenerate.md should reference the PreviousChangelog variable")
+	}
+	if !strings.Contains(tmpl, "{{.Feedback}}") {
+		t.Error("changelog_regenerate.md should reference the Feedback variable")
+	}
+	// Must reuse the same output rules as the changelog template.
+	if !strings.Contains(tmpl, "Invent Your Own Categories") {
+		t.Error("changelog_regenerate.md should reuse the changelog output rules (category naming)")
+	}
+	if !strings.Contains(tmpl, "markdown") {
+		t.Error("changelog_regenerate.md should specify markdown output")
+	}
+}
+
+func TestRender_ChangelogRegenerate_InjectsPrevChangelogAndFeedback(t *testing.T) {
+	tmpl := GetChangelogRegenerate()
+	prev := "## Features\n- existing bullet"
+	feedback := "make the tone more direct"
+	got, err := Render(tmpl, map[string]string{
+		"PreviousChangelog": prev,
+		"Feedback":          feedback,
+	})
+	if err != nil {
+		t.Fatalf("Render(changelog_regenerate) error: %v", err)
+	}
+	if !strings.Contains(got, prev) {
+		t.Errorf("rendered prompt must contain PreviousChangelog verbatim; got:\n%s", got)
+	}
+	if !strings.Contains(got, feedback) {
+		t.Errorf("rendered prompt must contain Feedback verbatim; got:\n%s", got)
+	}
+}

--- a/internal/workflow/commit_service_test.go
+++ b/internal/workflow/commit_service_test.go
@@ -217,6 +217,9 @@ func (l *stubLLM) ProjectInit(repoRoot string) (*domain.ProjectConfig, error) { 
 func (l *stubLLM) GenerateChangelogGrouped(formattedGroups string, nameMap map[string]string, customMessage string, mode string) (string, error) {
 	return "", nil
 }
+func (l *stubLLM) RegenerateChangelog(prevChangelog, feedback string) (string, error) {
+	return "", nil
+}
 func (l *stubLLM) ClassifyBinary(prompt string) (string, error) {
 	return "fix", nil // Default to "fix" for testing
 }

--- a/internal/workflow/release_generate_test.go
+++ b/internal/workflow/release_generate_test.go
@@ -292,6 +292,9 @@ func (m *mockFreeformLLM) GenerateChangelogGrouped(formattedGroups string, nameM
 func (m *mockFreeformLLM) RegenerateMessage(prev []string, feedback string, chunks []domain.DiffChunk) ([]string, error) {
 	return nil, nil
 }
+func (m *mockFreeformLLM) RegenerateChangelog(prevChangelog, feedback string) (string, error) {
+	return "", nil
+}
 func (m *mockFreeformLLM) ProjectInit(repoRoot string) (*domain.ProjectConfig, error) { return nil, nil }
 func (m *mockFreeformLLM) ClassifyBinary(prompt string) (string, error) {
 	return "fix", nil

--- a/internal/workflow/release_test.go
+++ b/internal/workflow/release_test.go
@@ -226,6 +226,9 @@ func (m *mockLLMForRelease) GenerateChangelogGrouped(formattedGroups string, nam
 func (m *mockLLMForRelease) RegenerateMessage(previousMessages []string, feedback string, chunks []domain.DiffChunk) ([]string, error) {
 	return nil, nil
 }
+func (m *mockLLMForRelease) RegenerateChangelog(prevChangelog, feedback string) (string, error) {
+	return "", nil
+}
 func (m *mockLLMForRelease) ProjectInit(repoRoot string) (*domain.ProjectConfig, error) {
 	return nil, nil
 }


### PR DESCRIPTION
Closes #171

## Summary

- **`r` (regenerate)**: Now calls `RegenerateChangelog()` with the previous changelog + user feedback via a dedicated prompt, instead of re-asking for tag/message and regenerating from scratch
- **`e` (edit)**: Writes changelog to the real metadata path, opens editor there, reads back the edited file, and persists it — no more wrong-path bugs
- Both actions use `goto preview` to skip tag/message re-prompts

## Changes

| File | Change |
|------|--------|
| `internal/core/ports/llm.go` | Added `RegenerateChangelog()` to the LLM interface |
| `internal/adapters/llm/openai_standard/adapter_release.go` | Implemented `RegenerateChangelog()` |
| `internal/adapters/llm/openai_standard/adapter_test.go` | 3 new tests: prompt contains prev+feedback, empty feedback, provider error |
| `internal/shared/prompts/md/changelog_regenerate.md` | New prompt template (84 lines) |
| `internal/shared/prompts/prompts.go` | Added `GetChangelogRegenerate()` |
| `internal/shared/prompts/prompts_test.go` | 2 new tests: template vars, render injection |
| `internal/delivery/cli/release.go` | Refactored loop with `goto preview:`, fixed `r` and `e` logic |
| `internal/delivery/cli/release_test.go` | New mock LLM, `TestReleaseCommand_Interactive_Edit`, updated regenerate test |
| `internal/delivery/mcp/core/handler_test.go` | Added `RegenerateChangelog` to mock |
| `internal/workflow/commit_service_test.go` | Added `RegenerateChangelog` to stub |
| `internal/workflow/release_generate_test.go` | Added `RegenerateChangelog` to mock |
| `internal/workflow/release_test.go` | Added `RegenerateChangelog` to mock |

## Test Plan

- [x] `go build ./...` — no errors
- [x] `go test ./internal/delivery/cli/...` — pass
- [x] `go test ./internal/adapters/llm/openai_standard/...` — pass
- [x] `go test ./internal/shared/prompts/...` — pass
- [x] Manually verified the release wizard loop logic in tests

## Checklist

- [x] Linked an approved issue (#171)
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers