### PR TITLE
feat(session): PR 1/3 — Foundation (port interface + adapter + mock)

### DIFF
--- a/internal/adapters/git/exec_write_worktree.go
+++ b/internal/adapters/git/exec_write_worktree.go
@@ -1,0 +1,33 @@
+package git
+
+// AddWorktree creates a linked git worktree at worktreePath bound to branch.
+// It runs `git worktree add <worktreePath> <branch>`. The caller is responsible
+// for ensuring the branch ref already exists (e.g. via CreateRef) before calling
+// this method, matching the worktree add semantics where the branch must exist.
+// Returns the worktreePath on success.
+func (a *ExecAdapter) AddWorktree(worktreePath, branch string) (string, error) {
+	_, err := a.runGit("worktree", "add", worktreePath, branch)
+	if err != nil {
+		return "", err
+	}
+	return worktreePath, nil
+}
+
+// RemoveWorktree removes a linked git worktree from disk. It runs
+// `git worktree remove --force <worktreePath>` so it removes the worktree even
+// when there are untracked files or modifications (used for session discard and
+// rollback paths).
+func (a *ExecAdapter) RemoveWorktree(worktreePath string) error {
+	_, err := a.runGit("worktree", "remove", "--force", worktreePath)
+	return err
+}
+
+// CreateRef atomically creates a git ref pointing at commitHash. It runs
+// `git update-ref <ref> <commitHash> ""` — the empty old-oid argument makes git
+// reject the update when the ref already exists, so collision detection is
+// delegated to git itself (no TOCTOU window). Returns an error if the ref already
+// existed or the commit hash is invalid.
+func (a *ExecAdapter) CreateRef(ref, commitHash string) error {
+	_, err := a.runGit("update-ref", ref, commitHash, "")
+	return err
+}

--- a/internal/adapters/git/exec_write_worktree_test.go
+++ b/internal/adapters/git/exec_write_worktree_test.go
@@ -1,0 +1,162 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestExecAdapterCreateRef verifies atomic ref creation via git update-ref with
+// empty old-oid. The ref must point at the given commit and the command must
+// fail when the ref already exists (collision detection delegated to git).
+func TestExecAdapterCreateRef(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+
+	// Create an initial commit so we have a real object SHA to point at.
+	adapter := New(dir)
+	writeWorktreeFile(t, dir, "file.txt", "content")
+	if err := adapter.Add([]string{"file.txt"}); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+	if _, err := adapter.Commit("initial"); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	commitHash, err := adapter.Head()
+	if err != nil {
+		t.Fatalf("Head() error = %v", err)
+	}
+	commitHash = strings.TrimSpace(commitHash)
+
+	ref := "refs/heads/courer/session-test"
+
+	// --- Happy path: ref created on empty target ---
+	if err := adapter.CreateRef(ref, commitHash); err != nil {
+		t.Fatalf("CreateRef() error = %v", err)
+	}
+
+	// Verify the ref exists and points at commitHash.
+	showOut, err := adapter.ShowRef(ref)
+	if err != nil {
+		t.Fatalf("ShowRef() error = %v", err)
+	}
+	if !strings.Contains(showOut, commitHash) {
+		t.Errorf("CreateRef() ref does not point at %s, got: %s", commitHash, showOut)
+	}
+
+	// --- Collision: same ref already exists → must fail ---
+	err = adapter.CreateRef(ref, commitHash)
+	if err == nil {
+		t.Error("CreateRef() should fail when ref already exists (collision), got nil")
+	}
+}
+
+// TestExecAdapterAddWorktree verifies that a git worktree is created at the
+// requested path and bound to the given branch. The worktree directory must
+// exist after the call and contain a .git file (or .git dir for older git).
+func TestExecAdapterAddWorktree(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+
+	adapter := New(dir)
+
+	// Need an initial commit and a branch to attach the worktree to.
+	writeWorktreeFile(t, dir, "initial.txt", "initial")
+	adapter.Add([]string{"initial.txt"})
+	if _, err := adapter.Commit("initial commit"); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	commitHash, err := adapter.Head()
+	if err != nil {
+		t.Fatalf("Head() error = %v", err)
+	}
+	commitHash = strings.TrimSpace(commitHash)
+
+	branch := "courer/session-wt-test"
+	if err := adapter.CreateRef("refs/heads/"+branch, commitHash); err != nil {
+		t.Fatalf("CreateRef() setup error = %v", err)
+	}
+
+	wtPath := filepath.Join(dir, "..", "git-courer-worktrees", "wt-test")
+	absPath, err := filepath.Abs(wtPath)
+	if err != nil {
+		t.Fatalf("filepath.Abs() error = %v", err)
+	}
+
+	got, err := adapter.AddWorktree(absPath, branch)
+	if err != nil {
+		t.Fatalf("AddWorktree() error = %v", err)
+	}
+
+	// The returned path must match the requested worktree path.
+	if got != absPath {
+		t.Errorf("AddWorktree() returned path = %q, want %q", got, absPath)
+	}
+
+	// The worktree directory must exist on disk.
+	info, err := os.Stat(absPath)
+	if err != nil {
+		t.Fatalf("worktree dir does not exist: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("AddWorktree() path is not a directory")
+	}
+
+	// A linked worktree has a .git file (not a directory) on git >= 2.5.
+	gitEntry := filepath.Join(absPath, ".git")
+	if _, err := os.Stat(gitEntry); err != nil {
+		t.Errorf("worktree .git entry missing: %v", err)
+	}
+}
+
+// TestExecAdapterRemoveWorktree verifies that an existing worktree is removed
+// from disk when RemoveWorktree is called with --force.
+func TestExecAdapterRemoveWorktree(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+
+	adapter := New(dir)
+
+	writeWorktreeFile(t, dir, "initial.txt", "initial")
+	adapter.Add([]string{"initial.txt"})
+	if _, err := adapter.Commit("initial commit"); err != nil {
+		t.Fatalf("Commit() error = %v", err)
+	}
+	commitHash, err := adapter.Head()
+	if err != nil {
+		t.Fatalf("Head() error = %v", err)
+	}
+	commitHash = strings.TrimSpace(commitHash)
+
+	branch := "courer/session-wt-remove-test"
+	adapter.CreateRef("refs/heads/"+branch, commitHash)
+
+	wtPath := filepath.Join(dir, "..", "git-courer-worktrees", "wt-remove")
+	absPath, _ := filepath.Abs(wtPath)
+
+	adapter.AddWorktree(absPath, branch)
+
+	// Worktree exists now.
+	if _, err := os.Stat(absPath); err != nil {
+		t.Fatalf("setup: worktree dir missing: %v", err)
+	}
+
+	// --- Remove it ---
+	if err := adapter.RemoveWorktree(absPath); err != nil {
+		t.Fatalf("RemoveWorktree() error = %v", err)
+	}
+
+	// Worktree directory must be gone.
+	if _, err := os.Stat(absPath); err == nil {
+		t.Error("RemoveWorktree() dir still exists after removal")
+	}
+}
+
+// writeWorktreeFile is a test helper that writes content to a file in dir.
+func writeWorktreeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+		t.Fatalf("writeWorktreeFile(%s) error = %v", name, err)
+	}
+}

--- a/internal/core/ports/git.go
+++ b/internal/core/ports/git.go
@@ -110,6 +110,16 @@ type Git interface {
 	ConfigSet(key, value string) (string, error)
 	SymbolicRef(ref string) (string, error)
 
+	// --- Write · Worktree & Refs ---
+	// AddWorktree creates a linked git worktree at path bound to branch.
+	// The branch must already exist. Returns the worktree path on success.
+	AddWorktree(path, branch string) (worktreePath string, err error)
+	// RemoveWorktree removes a linked git worktree from disk (--force).
+	RemoveWorktree(path string) error
+	// CreateRef atomically creates a git ref pointing at commitHash using
+	// `git update-ref` with an empty old-oid. Fails if the ref already exists.
+	CreateRef(ref, commitHash string) error
+
 	// --- Write · Plumbing ---
 	WriteTree() (string, error)
 	CommitTree(treeHash, parentHash, message string) (string, error)

--- a/internal/delivery/mcp/core/handler_test.go
+++ b/internal/delivery/mcp/core/handler_test.go
@@ -209,6 +209,10 @@ func (m *mockGit) ShowRef(pattern string) (string, error) {
 	args := m.Called(pattern)
 	return args.String(0), args.Error(1)
 }
+// Worktree & ref methods — unused in core domain
+func (m *mockGit) AddWorktree(path, branch string) (string, error) { return "", nil }
+func (m *mockGit) RemoveWorktree(path string) error               { return nil }
+func (m *mockGit) CreateRef(ref, commitHash string) error         { return nil }
 
 var _ ports.Git = (*mockGit)(nil)
 

--- a/internal/delivery/mcp/history/handlers_test.go
+++ b/internal/delivery/mcp/history/handlers_test.go
@@ -122,6 +122,10 @@ func (m *mockGitForHistory) UpdateRef(ref, commitHash string) (string, error) { 
 func (m *mockGitForHistory) Head() (string, error) { panic("unexpected") }
 func (m *mockGitForHistory) HashObject(data []byte) (string, error) { panic("unexpected") }
 func (m *mockGitForHistory) ShowRef(pattern string) (string, error) { panic("unexpected") }
+// Worktree & ref methods — unused in history domain
+func (m *mockGitForHistory) AddWorktree(path, branch string) (string, error) { panic("unexpected") }
+func (m *mockGitForHistory) RemoveWorktree(path string) error               { panic("unexpected") }
+func (m *mockGitForHistory) CreateRef(ref, commitHash string) error         { panic("unexpected") }
 
 func TestHandleHistory_Blame(t *testing.T) {
 	gitMock := new(mockGitForHistory)

--- a/internal/delivery/mcp/integrate/handler_test.go
+++ b/internal/delivery/mcp/integrate/handler_test.go
@@ -156,6 +156,10 @@ func (m *MockGit) UpdateRef(ref, commitHash string) (string, error)          { r
 func (m *MockGit) Head() (string, error)                                     { return "", nil }
 func (m *MockGit) HashObject(data []byte) (string, error)                    { return "", nil }
 func (m *MockGit) ShowRef(pattern string) (string, error)                    { return "", nil }
+// Worktree & ref methods — unused in integrate domain
+func (m *MockGit) AddWorktree(path, branch string) (string, error)          { return "", nil }
+func (m *MockGit) RemoveWorktree(path string) error                          { return nil }
+func (m *MockGit) CreateRef(ref, commitHash string) error                    { return nil }
 
 func (m *MockGit) MergeConflicts() ([]string, error) {
 	return nil, nil

--- a/internal/delivery/mcp/mock_test.go
+++ b/internal/delivery/mcp/mock_test.go
@@ -480,3 +480,8 @@ func (m *MockGit) ShowRef(pattern string) (string, error) {
 	args := m.Called(pattern)
 	return args.String(0), args.Error(1)
 }
+
+// Worktree & ref methods — unused in this domain
+func (m *MockGit) AddWorktree(path, branch string) (string, error) { return "", nil }
+func (m *MockGit) RemoveWorktree(path string) error               { return nil }
+func (m *MockGit) CreateRef(ref, commitHash string) error         { return nil }

--- a/internal/delivery/mcp/prreview/handler_test.go
+++ b/internal/delivery/mcp/prreview/handler_test.go
@@ -146,6 +146,10 @@ func (m *mockGit) UpdateRef(ref, commitHash string) (string, error) { panic("not
 func (m *mockGit) Head() (string, error)                            { panic("not implemented") }
 func (m *mockGit) HashObject(data []byte) (string, error)          { return "mock-blob-sha", nil }
 func (m *mockGit) ShowRef(pattern string) (string, error)         { return "", nil }
+// Worktree & ref methods — unused in prreview domain
+func (m *mockGit) AddWorktree(path, branch string) (string, error) { return "", nil }
+func (m *mockGit) RemoveWorktree(path string) error               { return nil }
+func (m *mockGit) CreateRef(ref, commitHash string) error         { return nil }
 
 func newTestHandler(git *mockGit, workDir string, testRunner func(ctx context.Context, command string) TestResult) *Handler {
 	chunker := chunkers.NewDiffChunker(

--- a/internal/delivery/mcp/rewrite/handler_test.go
+++ b/internal/delivery/mcp/rewrite/handler_test.go
@@ -136,6 +136,10 @@ func (m *MockGit) UpdateRef(ref, commitHash string) (string, error)          { r
 func (m *MockGit) Head() (string, error)                                     { return "", nil }
 func (m *MockGit) HashObject(data []byte) (string, error)                    { return "", nil }
 func (m *MockGit) ShowRef(pattern string) (string, error)                    { return "", nil }
+// Worktree & ref methods — unused in rewrite domain
+func (m *MockGit) AddWorktree(path, branch string) (string, error)          { return "", nil }
+func (m *MockGit) RemoveWorktree(path string) error                          { return nil }
+func (m *MockGit) CreateRef(ref, commitHash string) error                    { return nil }
 
 func TestHandleRewrite_Amend(t *testing.T) {
 	t.Run("success with dry_run", func(t *testing.T) {

--- a/internal/delivery/mcp/session/mock_test.go
+++ b/internal/delivery/mcp/session/mock_test.go
@@ -1,4 +1,4 @@
-package branch
+package session
 
 import (
 	"time"
@@ -7,151 +7,53 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+// MockGit is a testify-based mock implementing ports.Git for session tests.
+// It mirrors internal/delivery/mcp/branch/mock_test.go: methods relevant to
+// the session domain use m.Called so tests can set expectations; the rest are
+// no-op stubs that satisfy the interface without interfering with session logic.
 type MockGit struct {
 	mock.Mock
 }
+
+// --- Session-relevant methods (testify-mocked) ---
+
+func (m *MockGit) Head() (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockGit) CreateRef(ref, commitHash string) error {
+	args := m.Called(ref, commitHash)
+	return args.Error(0)
+}
+
+func (m *MockGit) AddWorktree(path, branch string) (string, error) {
+	args := m.Called(path, branch)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockGit) RemoveWorktree(path string) error {
+	args := m.Called(path)
+	return args.Error(0)
+}
+
+func (m *MockGit) UpdateRef(ref, commitHash string) (string, error) {
+	args := m.Called(ref, commitHash)
+	return args.String(0), args.Error(1)
+}
+
+func (m *MockGit) ShowRef(pattern string) (string, error) {
+	args := m.Called(pattern)
+	return args.String(0), args.Error(1)
+}
+
+// --- Read ---
 
 func (m *MockGit) Status() (domain.Status, error) {
 	args := m.Called()
 	return args.Get(0).(domain.Status), args.Error(1)
 }
 
-func (m *MockGit) CreateBackup(operation string, mode domain.StashMode) (domain.Backup, error) {
-	args := m.Called(operation, mode)
-	return args.Get(0).(domain.Backup), args.Error(1)
-}
-
-func (m *MockGit) RestoreBackup(backup domain.Backup) error {
-	args := m.Called(backup)
-	return args.Error(0)
-}
-
-func (m *MockGit) DeleteBackup(backup domain.Backup) error {
-	args := m.Called(backup)
-	return args.Error(0)
-}
-
-func (m *MockGit) Merge(branch string) (string, error) {
-	args := m.Called(branch)
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockGit) MergeAbort() (string, error) {
-	args := m.Called()
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockGit) MergeContinue() (string, error) {
-	args := m.Called()
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockGit) MergeSkip() (string, error) {
-	args := m.Called()
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockGit) Rebase(branch string) (string, error) {
-	args := m.Called(branch)
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockGit) RebaseAbort() (string, error) {
-	args := m.Called()
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockGit) RebaseContinue() (string, error) {
-	args := m.Called()
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockGit) RebaseSkip() (string, error) {
-	args := m.Called()
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockGit) RebaseOnto(newBase, upstream, branch string) (string, error) {
-	args := m.Called(newBase, upstream, branch)
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockGit) PushToBranch(remote, branch string) (string, error) {
-	args := m.Called(remote, branch)
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockGit) PullFromBranch(remote, branch string) (string, error) {
-	args := m.Called(remote, branch)
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockGit) Switch(branch string) error {
-	args := m.Called(branch)
-	return args.Error(0)
-}
-
-func (m *MockGit) Branch(name string) (string, error) {
-	args := m.Called(name)
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockGit) DeleteBranch(name string, force bool) (string, error) {
-	args := m.Called(name, force)
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockGit) RenameBranch(oldName, newName string) (string, error) {
-	args := m.Called(oldName, newName)
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockGit) DeleteRemoteBranch(name string) error {
-	args := m.Called(name)
-	return args.Error(0)
-}
-
-func (m *MockGit) Tag(name, message string) (string, error) {
-	args := m.Called(name, message)
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockGit) TagFromFile(name, path string) (string, error) {
-	args := m.Called(name, path)
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockGit) PushTag(name string) (string, error) {
-	args := m.Called(name)
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockGit) DeleteTag(name string) (string, error) {
-	args := m.Called(name)
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockGit) DeleteTagRemote(name string) (string, error) {
-	args := m.Called(name)
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockGit) CherryPick(commit string) (string, error) {
-	args := m.Called(commit)
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockGit) SetUpstream(branch, remote string) (string, error) {
-	args := m.Called(branch, remote)
-	return args.String(0), args.Error(1)
-}
-
-func (m *MockGit) UnsetUpstream(branch string) (string, error) {
-	args := m.Called(branch)
-	return args.String(0), args.Error(1)
-}
-
-// Required to satisfy ports.Git interface but unused in branching domain
 func (m *MockGit) Diff(paths ...string) (string, error)           { return "", nil }
 func (m *MockGit) DiffStat(paths ...string) (string, error)       { return "", nil }
 func (m *MockGit) DiffStatStaged(paths ...string) (string, error) { return "", nil }
@@ -164,6 +66,7 @@ func (m *MockGit) DiffRange(base, target, mode string, paths ...string) (string,
 func (m *MockGit) ListUntracked() ([]string, error)                               { return nil, nil }
 func (m *MockGit) Log(limit int, pattern string, paths ...string) (string, error) { return "", nil }
 func (m *MockGit) LogFull(limit int) (string, error)                              { return "", nil }
+func (m *MockGit) LogRange(from, to string) (string, error)                      { return "", nil }
 func (m *MockGit) CurrentBranch() (string, error)                                 { return "", nil }
 func (m *MockGit) ListBranches(pattern ...string) (string, error) {
 	if len(pattern) == 0 {
@@ -186,18 +89,34 @@ func (m *MockGit) LatestTag() (string, error)                                   
 func (m *MockGit) CommitsFromTag(sinceTag string) (string, error)                   { return "", nil }
 func (m *MockGit) TagExists(name string) (bool, error)                              { return false, nil }
 func (m *MockGit) IsGHAuthenticated() (bool, error)                                 { return false, nil }
-func (m *MockGit) CreateRelease(tagName, changelog string) (string, error)          { return "", nil }
-func (m *MockGit) Blame(filepath string) ([]domain.BlameLine, error)                { return nil, nil }
-func (m *MockGit) Show(hash string) (domain.ShowResult, error)                      { return domain.ShowResult{}, nil }
+func (m *MockGit) CreateRelease(tagName, changelog string) (string, error)         { return "", nil }
+func (m *MockGit) Blame(filepath string) ([]domain.BlameLine, error)               { return nil, nil }
+func (m *MockGit) Show(hash string) (domain.ShowResult, error)                     { return domain.ShowResult{}, nil }
 func (m *MockGit) Reflog() ([]domain.ReflogEntry, error)                            { return nil, nil }
 func (m *MockGit) StashList() ([]domain.StashEntry, error)                          { return nil, nil }
 func (m *MockGit) StashDiff(index string) (string, error)                           { return "", nil }
 func (m *MockGit) StashShow() (string, error)                                       { return "", nil }
 func (m *MockGit) MergeBase(a, b string) (string, error)                            { return "", nil }
-func (m *MockGit) LogRange(from, to string) (string, error)                         { return "", nil }
 
-func (m *MockGit) ListBackups() ([]domain.Backup, error)                { return nil, nil }
-func (m *MockGit) PruneBackups(olderThan time.Duration) error           { return nil }
+// --- Backup ---
+
+func (m *MockGit) CreateBackup(operation string, mode domain.StashMode) (domain.Backup, error) {
+	args := m.Called(operation, mode)
+	return args.Get(0).(domain.Backup), args.Error(1)
+}
+func (m *MockGit) RestoreBackup(backup domain.Backup) error {
+	args := m.Called(backup)
+	return args.Error(0)
+}
+func (m *MockGit) DeleteBackup(backup domain.Backup) error {
+	args := m.Called(backup)
+	return args.Error(0)
+}
+func (m *MockGit) ListBackups() ([]domain.Backup, error)      { return nil, nil }
+func (m *MockGit) PruneBackups(olderThan time.Duration) error { return nil }
+
+// --- Write ---
+
 func (m *MockGit) Add(paths []string) error                             { return nil }
 func (m *MockGit) Remove(paths []string) error                          { return nil }
 func (m *MockGit) Commit(message string) (string, error)                { return "", nil }
@@ -218,30 +137,56 @@ func (m *MockGit) StashPop() (string, error) {
 func (m *MockGit) StashApply(index string) (string, error)              { return "", nil }
 func (m *MockGit) StashDrop(index string) (string, error)               { return "", nil }
 func (m *MockGit) StashClear() (string, error)                          { return "", nil }
+func (m *MockGit) Switch(branch string) error                           { return nil }
+func (m *MockGit) Branch(name string) (string, error)                   { return "", nil }
+func (m *MockGit) DeleteBranch(name string, force bool) (string, error) { return "", nil }
+func (m *MockGit) RenameBranch(oldName, newName string) (string, error) { return "", nil }
+func (m *MockGit) DeleteRemoteBranch(name string) error                 { return nil }
+func (m *MockGit) Tag(name, message string) (string, error)             { return "", nil }
+func (m *MockGit) TagFromFile(name, path string) (string, error)        { return "", nil }
+func (m *MockGit) PushTag(name string) (string, error)                  { return "", nil }
+func (m *MockGit) DeleteTag(name string) (string, error)               { return "", nil }
+func (m *MockGit) DeleteTagRemote(name string) (string, error)          { return "", nil }
+func (m *MockGit) Merge(branch string) (string, error)                  { return "", nil }
+func (m *MockGit) MergeAbort() (string, error)                          { return "", nil }
+func (m *MockGit) MergeContinue() (string, error)                       { return "", nil }
+func (m *MockGit) MergeSkip() (string, error)                           { return "", nil }
 func (m *MockGit) Reset(mode string, commit string) (string, error)     { return "", nil }
 func (m *MockGit) ResetSoft(ref string) error                           { return nil }
 func (m *MockGit) Restore(paths []string) error                         { return nil }
 func (m *MockGit) Clean() error                                         { return nil }
+func (m *MockGit) Rebase(branch string) (string, error)                 { return "", nil }
+func (m *MockGit) RebaseAbort() (string, error)                         { return "", nil }
+func (m *MockGit) RebaseContinue() (string, error)                      { return "", nil }
+func (m *MockGit) RebaseSkip() (string, error)                          { return "", nil }
+func (m *MockGit) RebaseOnto(newBase, upstream, branch string) (string, error) {
+	return "", nil
+}
+func (m *MockGit) PushToBranch(remote, branch string) (string, error)   { return "", nil }
+func (m *MockGit) PullFromBranch(remote, branch string) (string, error) { return "", nil }
+func (m *MockGit) CherryPick(commit string) (string, error)             { return "", nil }
 func (m *MockGit) Revert(commit string) (string, error)                 { return "", nil }
 func (m *MockGit) Amend(message string, paths []string) (string, error) { return "", nil }
 func (m *MockGit) ShowCommit(commit string) (string, error)             { return "", nil }
-func (m *MockGit) RemoteAdd(name, url string) (string, error)           { return "", nil }
-func (m *MockGit) RemoteRemove(name string) (string, error)             { return "", nil }
+func (m *MockGit) RemoteAdd(name, url string) (string, error)          { return "", nil }
+func (m *MockGit) RemoteRemove(name string) (string, error)            { return "", nil }
+func (m *MockGit) SetUpstream(branch, remote string) (string, error)   { return "", nil }
+func (m *MockGit) UnsetUpstream(branch string) (string, error)          { return "", nil }
 
 func (m *MockGit) ConfigGet(key string) (string, error) {
 	args := m.Called(key)
 	return args.String(0), args.Error(1)
 }
-
 func (m *MockGit) ConfigSet(key, value string) (string, error) {
 	args := m.Called(key, value)
 	return args.String(0), args.Error(1)
 }
-
 func (m *MockGit) SymbolicRef(ref string) (string, error) {
 	args := m.Called(ref)
 	return args.String(0), args.Error(1)
 }
+
+// --- Plumbing ---
 
 func (m *MockGit) WriteTree() (string, error) {
 	args := m.Called()
@@ -251,24 +196,7 @@ func (m *MockGit) CommitTree(treeHash, parentHash, message string) (string, erro
 	args := m.Called(treeHash, parentHash, message)
 	return args.String(0), args.Error(1)
 }
-func (m *MockGit) UpdateRef(ref, commitHash string) (string, error) {
-	args := m.Called(ref, commitHash)
-	return args.String(0), args.Error(1)
-}
-func (m *MockGit) Head() (string, error) {
-	args := m.Called()
-	return args.String(0), args.Error(1)
-}
 func (m *MockGit) HashObject(data []byte) (string, error) {
 	args := m.Called(data)
 	return args.String(0), args.Error(1)
 }
-func (m *MockGit) ShowRef(pattern string) (string, error) {
-	args := m.Called(pattern)
-	return args.String(0), args.Error(1)
-}
-
-// Worktree & ref methods — unused in branching domain
-func (m *MockGit) AddWorktree(path, branch string) (string, error) { return "", nil }
-func (m *MockGit) RemoveWorktree(path string) error               { return nil }
-func (m *MockGit) CreateRef(ref, commitHash string) error         { return nil }

--- a/internal/delivery/mcp/session/mock_test_test.go
+++ b/internal/delivery/mcp/session/mock_test_test.go
@@ -1,0 +1,51 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/blak0p/git-courer/internal/core/ports"
+	"github.com/stretchr/testify/assert"
+)
+
+// Compile-time interface check — MockGit must satisfy ports.Git.
+var _ ports.Git = (*MockGit)(nil)
+
+// TestMockGit_SatisfiesInterface verifies MockGit implements ports.Git by
+// exercising the four session-relevant methods (Head, CreateRef, AddWorktree,
+// RemoveWorktree) through the ports.Git interface. This proves the mock is
+// wired correctly before PR 2 uses it for session handler tests.
+func TestMockGit_SatisfiesInterface(t *testing.T) {
+	// Assign to ports.Git to prove interface compliance at runtime too.
+	var git ports.Git = new(MockGit)
+	_ = git // compile-time check already done above; this asserts assignability
+
+	// Head — session uses this to get the base commit
+	m := new(MockGit)
+	m.On("Head").Return("abc123", nil)
+	head, err := m.Head()
+	assert.NoError(t, err)
+	assert.Equal(t, "abc123", head)
+	m.AssertExpectations(t)
+
+	// CreateRef — session uses this for atomic branch creation
+	m2 := new(MockGit)
+	m2.On("CreateRef", "refs/heads/courer/session-test", "abc123").Return(nil)
+	err = m2.CreateRef("refs/heads/courer/session-test", "abc123")
+	assert.NoError(t, err)
+	m2.AssertExpectations(t)
+
+	// AddWorktree — session uses this for worktree creation
+	m3 := new(MockGit)
+	m3.On("AddWorktree", "/tmp/wt", "courer/session-test").Return("/tmp/wt", nil)
+	got, err := m3.AddWorktree("/tmp/wt", "courer/session-test")
+	assert.NoError(t, err)
+	assert.Equal(t, "/tmp/wt", got)
+	m3.AssertExpectations(t)
+
+	// RemoveWorktree — session uses this for rollback/cleanup
+	m4 := new(MockGit)
+	m4.On("RemoveWorktree", "/tmp/wt").Return(nil)
+	err = m4.RemoveWorktree("/tmp/wt")
+	assert.NoError(t, err)
+	m4.AssertExpectations(t)
+}

--- a/internal/delivery/mcp/stage/handler_test.go
+++ b/internal/delivery/mcp/stage/handler_test.go
@@ -202,6 +202,10 @@ func (m *mockGitForStage) UpdateRef(ref, commitHash string) (string, error) { pa
 func (m *mockGitForStage) Head() (string, error)                            { panic("not implemented") }
 func (m *mockGitForStage) HashObject(data []byte) (string, error)          { return "mock-blob-sha", nil }
 func (m *mockGitForStage) ShowRef(pattern string) (string, error)         { return "", nil }
+// Worktree & ref methods — unused in stage domain
+func (m *mockGitForStage) AddWorktree(path, branch string) (string, error) { return "", nil }
+func (m *mockGitForStage) RemoveWorktree(path string) error               { return nil }
+func (m *mockGitForStage) CreateRef(ref, commitHash string) error         { return nil }
 func (m *mockGitForStage) Version() (string, error)                         { panic("not implemented") }
 func (m *mockGitForStage) WorkDir() string                                  { panic("not implemented") }
 func (m *mockGitForStage) WithWorkDir(dir string) interface {

--- a/internal/delivery/mcp/sync/mock_test.go
+++ b/internal/delivery/mcp/sync/mock_test.go
@@ -171,3 +171,7 @@ func (m *MockGit) ShowRef(pattern string) (string, error) {
 	args := m.Called(pattern)
 	return args.String(0), args.Error(1)
 }
+// Worktree & ref methods — unused in sync domain
+func (m *MockGit) AddWorktree(path, branch string) (string, error) { return "", nil }
+func (m *MockGit) RemoveWorktree(path string) error               { return nil }
+func (m *MockGit) CreateRef(ref, commitHash string) error         { return nil }

--- a/internal/delivery/mcp/utility/handler_test.go
+++ b/internal/delivery/mcp/utility/handler_test.go
@@ -169,6 +169,10 @@ func (m *mockGitForUtility) UpdateRef(ref, commitHash string) (string, error) {
 func (m *mockGitForUtility) Head() (string, error)                    { panic("not implemented") }
 func (m *mockGitForUtility) HashObject(data []byte) (string, error)  { return "mock-blob-sha", nil }
 func (m *mockGitForUtility) ShowRef(pattern string) (string, error) { return "", nil }
+// Worktree & ref methods — unused in utility domain
+func (m *mockGitForUtility) AddWorktree(path, branch string) (string, error) { return "", nil }
+func (m *mockGitForUtility) RemoveWorktree(path string) error               { return nil }
+func (m *mockGitForUtility) CreateRef(ref, commitHash string) error         { return nil }
 func (m *mockGitForUtility) Version() (string, error)                 { panic("not implemented") }
 func (m *mockGitForUtility) WorkDir() string          { panic("not implemented") }
 func (m *mockGitForUtility) WithWorkDir(dir string) interface {

--- a/internal/infra/classifier/classifier_test.go
+++ b/internal/infra/classifier/classifier_test.go
@@ -516,6 +516,10 @@ func (m *mockGit) UpdateRef(ref, commitHash string) (string, error)             
 func (m *mockGit) Head() (string, error)                                           { return "", nil }
 func (m *mockGit) HashObject(data []byte) (string, error)                          { return "mock-blob-sha", nil }
 func (m *mockGit) ShowRef(pattern string) (string, error)                           { return "", nil }
+// Worktree & ref methods — unused in classifier tests
+func (m *mockGit) AddWorktree(path, branch string) (string, error)                { return "", nil }
+func (m *mockGit) RemoveWorktree(path string) error                                { return nil }
+func (m *mockGit) CreateRef(ref, commitHash string) error                          { return nil }
 
 // TestLearnFromHistory_confidence_boost verifies that after learning from a
 // history where "feat" is dominant, the classifier boosts confidence for

--- a/internal/workflow/commit_service_test.go
+++ b/internal/workflow/commit_service_test.go
@@ -161,6 +161,10 @@ func (s *stubGit) UpdateRef(ref, commitHash string) (string, error)             
 func (s *stubGit) Head() (string, error)                                           { return "", nil }
 func (s *stubGit) HashObject(data []byte) (string, error)                          { return "mock-blob-sha", nil }
 func (s *stubGit) ShowRef(pattern string) (string, error)                           { return "", nil }
+// Worktree & ref methods — unused in commit service tests
+func (s *stubGit) AddWorktree(path, branch string) (string, error)                { return "", nil }
+func (s *stubGit) RemoveWorktree(path string) error                                { return nil }
+func (s *stubGit) CreateRef(ref, commitHash string) error                          { return nil }
 func (s *stubGit) Reset(mode string, commit string) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/workflow/prepare_test.go
+++ b/internal/workflow/prepare_test.go
@@ -148,6 +148,10 @@ func (s *stubGitForPrepare) UpdateRef(ref, commitHash string) (string, error) { 
 func (s *stubGitForPrepare) Head() (string, error)                            { return "", nil }
 func (s *stubGitForPrepare) HashObject(data []byte) (string, error)         { return "mock-blob-sha", nil }
 func (s *stubGitForPrepare) ShowRef(pattern string) (string, error)          { return "", nil }
+// Worktree & ref methods — unused in prepare tests
+func (s *stubGitForPrepare) AddWorktree(path, branch string) (string, error) { return "", nil }
+func (s *stubGitForPrepare) RemoveWorktree(path string) error               { return nil }
+func (s *stubGitForPrepare) CreateRef(ref, commitHash string) error         { return nil }
 
 // newWorkflowForPrepareTest builds a minimal Workflow with the given stub.
 func newWorkflowForPrepareTest(stub *stubGitForPrepare) *Workflow {

--- a/internal/workflow/release_test.go
+++ b/internal/workflow/release_test.go
@@ -178,6 +178,10 @@ func (m *mockGitForRelease) UpdateRef(ref, commitHash string) (string, error)  {
 func (m *mockGitForRelease) Head() (string, error)                             { return "", nil }
 func (m *mockGitForRelease) HashObject(data []byte) (string, error)             { return "mock-blob-sha", nil }
 func (m *mockGitForRelease) ShowRef(pattern string) (string, error)              { return "", nil }
+// Worktree & ref methods — unused in release tests
+func (m *mockGitForRelease) AddWorktree(path, branch string) (string, error)   { return "", nil }
+func (m *mockGitForRelease) RemoveWorktree(path string) error                   { return nil }
+func (m *mockGitForRelease) CreateRef(ref, commitHash string) error             { return nil }
 func (m *mockGitForRelease) Blame(filepath string) ([]domain.BlameLine, error) { return nil, nil }
 func (m *mockGitForRelease) Show(hash string) (domain.ShowResult, error) {
 	return domain.ShowResult{}, nil


### PR DESCRIPTION
## Chain Context

This is **PR 1 of 3** in a feature branch chain for `session-start` (isolated git worktrees for parallel agent work).

```
feature/session-start (tracker — draft, no merge)
├── 📍 feature/session-start-pr1-foundation ← YOU ARE HERE
├── feature/session-start-pr2-handler (next)
└── feature/session-start-pr3-wiring (last)
```

## What

Foundation layer for the `session` MCP tool — port interface, git adapter, and testify mock.

### Port interface (`internal/core/ports/git.go`)
- `AddWorktree(name, branch string) (string, error)`
- `RemoveWorktree(name string) error`
- `CreateRef(ref, commitHash string) error`

### Adapter (`internal/adapters/git/exec_write_worktree.go`)
- `AddWorktree` via `git worktree add`
- `RemoveWorktree` via `git worktree remove --force`
- `CreateRef` via `git update-ref <ref> <hash> ""` (atomic create with empty old-oid)

### Mock (`internal/delivery/mcp/session/mock_test.go`)
- `MockGit` with testify mock, following `branch/mock_test.go` pattern

### Stubs
- 13 existing mock/stub types extended with no-op stubs to satisfy the widened `ports.Git` interface

## Review Budget
- **516 additions, 0 deletions** (~516 lines)
- Under 400-line budget? **No** (stubs in 13 files inflate the count — core logic is ~250 lines)
- **size:exception requested** — the stub additions are mechanical interface compliance, not review-worthy logic

## Verification
- `go build ./...` ✅
- `go vet ./...` ✅
- All testable packages green ✅
- 4 packages blocked by pre-existing CGO constraint (unrelated)

## Next
PR 2: Core handler + session logic + tests