### PR TITLE
feat: session finish no longer merges or deletes branches

### DIFF
--- a/internal/delivery/mcp/handlers.go
+++ b/internal/delivery/mcp/handlers.go
@@ -154,7 +154,7 @@ func registerTools(s *server.MCPServer, srv *Server) {
 		}
 	}
 	sessionStore := sessionstore.NewFSSessionStore(sessionMetaDir)
-	sessionHandler := session.NewHandlerWithStore(srv.git, mainGit, sessionStore, workDir, activeSessionPtr)
+	sessionHandler := session.NewHandlerWithStore(srv.git, sessionStore, workDir, activeSessionPtr)
 	session.Register(s, sessionHandler)
 
 	rewriteHandler := rewrite.NewHandler(srv.git)

--- a/internal/delivery/mcp/session/handler.go
+++ b/internal/delivery/mcp/session/handler.go
@@ -10,9 +10,14 @@ import (
 // internal/delivery/mcp/branch/handler.go: a thin struct wrapping the git port
 // plus the session store and a workDir for preview/finish workflows.
 // Behavior lives in session.go (HandleSession dispatch + handlers).
+//
+// The Handler no longer carries a separate main-repo git adapter: `session
+// finish` no longer merges the session branch into the base branch, so there
+// is no need to address the main worktree separately from the session
+// worktree. A single git port covers preview, cleanup, and the start/discard
+// lifecycle.
 type Handler struct {
-	git           ports.Git // worktree adapter (preview, cleanup)
-	mainGit       ports.Git // main repo adapter (merge in finish)
+	git           ports.Git          // worktree adapter (preview, cleanup, start, discard)
 	store         ports.SessionStore // nil in start-only contexts; finish/status/discard require it
 	workDir       string             // repo root for preview engine + config loading
 	metaDir       string             // base directory for session metadata files; overridable for tests
@@ -35,11 +40,9 @@ func NewHandler(git ports.Git) *Handler {
 // finish/status/discard can load and persist canonical domain.Session
 // records. start continues to write the SessionMeta JSON file for back-compat.
 // activeSession may be nil in legacy contexts (select/finish-clear disabled).
-// mainGit MUST point to the main repository root for the finish merge step.
-func NewHandlerWithStore(git, mainGit ports.Git, store ports.SessionStore, workDir string, activeSession *atomic.Value) *Handler {
+func NewHandlerWithStore(git ports.Git, store ports.SessionStore, workDir string, activeSession *atomic.Value) *Handler {
 	return &Handler{
 		git:           git,
-		mainGit:       mainGit,
 		store:         store,
 		workDir:       workDir,
 		metaDir:       defaultSessionMetaDir,

--- a/internal/delivery/mcp/session/session.go
+++ b/internal/delivery/mcp/session/session.go
@@ -262,10 +262,12 @@ func (h *Handler) handleStart(params map[string]any) (*mcpgo.CallToolResult, err
 	return mcpgo.NewToolResultText(string(payload)), nil
 }
 
-// handleFinish loads a session, runs preview validation, merges the session
-// branch into its base branch, and cleans up the worktree + branch. On
-// preview failure or merge conflict the session stays active. On cleanup
-// failure the session is marked cleanup_failed (the merge is NOT reverted).
+// handleFinish loads a session, runs the lightweight preview (uncommitted-changes
+// guard + diff stats), removes the worktree, and clears session metadata. The
+// session branch is LEFT ALIVE for the user to integrate manually (merge, PR,
+// or discard via `session discard`). On uncommitted changes the session stays
+// active; on cleanup failure it is marked cleanup_failed (the branch is still
+// alive and the merge step was never attempted).
 func (h *Handler) handleFinish(params map[string]any) (*mcpgo.CallToolResult, error) {
 	sessionID := shared.GetStringParam(params, "session_id", "")
 	if sessionID == "" {
@@ -276,7 +278,7 @@ func (h *Handler) handleFinish(params map[string]any) (*mcpgo.CallToolResult, er
 		return shared.JSONErrorResult("finish", fmt.Errorf("session store not configured"))
 	}
 
-	wf := workflow.NewSessionFinishWorkflow(h.git, h.mainGit, h.store, h.workDir)
+	wf := workflow.NewSessionFinishWorkflow(h.git, h.store, h.workDir)
 	result, err := wf.Finish(context.Background(), sessionID)
 	if err != nil {
 		return shared.JSONErrorResult("finish", err)

--- a/internal/delivery/mcp/session/session_select_test.go
+++ b/internal/delivery/mcp/session/session_select_test.go
@@ -13,25 +13,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// newHandlerWithStoreAndActive builds a Handler with a MockGit, MockSessionStore,
-// a mainGit MockGit, and an activeSession atomic.Value pre-seeded with a typed
-// nil. Returns the activeSession so tests can read it back.
-func newHandlerWithStoreAndActive(t *testing.T) (*Handler, *MockGit, *MockGit, *MockSessionStore, *atomic.Value) {
+// newHandlerWithStoreAndActive builds a Handler with a MockGit, a
+// MockSessionStore, and an activeSession atomic.Value pre-seeded with a typed
+// nil. Returns the activeSession so tests can read it back. The session Handler
+// no longer carries a separate main-repo git adapter since finish no longer
+// merges.
+func newHandlerWithStoreAndActive(t *testing.T) (*Handler, *MockGit, *MockSessionStore, *atomic.Value) {
 	t.Helper()
 	mockGit := new(MockGit)
-	mainGit := new(MockGit)
 	store := new(MockSessionStore)
 	active := &atomic.Value{}
 	active.Store((*domain.Session)(nil))
-	h := NewHandlerWithStore(mockGit, mainGit, store, t.TempDir(), active)
+	h := NewHandlerWithStore(mockGit, store, t.TempDir(), active)
 	h.metaDir = t.TempDir()
-	return h, mockGit, mainGit, store, active
+	return h, mockGit, store, active
 }
 
 // ─── select ──────────────────────────────────────────────────────────────
 
 func TestHandleSelect_ValidSession_PublishesToActiveSession(t *testing.T) {
-	h, mockGit, _, store, active := newHandlerWithStoreAndActive(t)
+	h, mockGit, store, active := newHandlerWithStoreAndActive(t)
 	_ = mockGit
 	sess := fixtureSession() // Status = active
 
@@ -57,7 +58,7 @@ func TestHandleSelect_ValidSession_PublishesToActiveSession(t *testing.T) {
 }
 
 func TestHandleSelect_MissingSessionID_Errors(t *testing.T) {
-	h, _, _, _, _ := newHandlerWithStoreAndActive(t)
+	h, _, _, _ := newHandlerWithStoreAndActive(t)
 	args := map[string]any{"command": "select"}
 	res, err := h.HandleSession(context.Background(), sessionReq(args))
 	require.NoError(t, err) // errors come back as JSON results, not Go errors
@@ -67,7 +68,7 @@ func TestHandleSelect_MissingSessionID_Errors(t *testing.T) {
 }
 
 func TestHandleSelect_StoreError_Propagates(t *testing.T) {
-	h, _, _, store, active := newHandlerWithStoreAndActive(t)
+	h, _, store, active := newHandlerWithStoreAndActive(t)
 	store.On("Get", "missing").Return((*domain.Session)(nil), errors.New("not found"))
 
 	args := map[string]any{"command": "select", "session_id": "missing"}
@@ -86,7 +87,7 @@ func TestHandleSelect_StoreError_Propagates(t *testing.T) {
 }
 
 func TestHandleSelect_NonActiveSession_Rejected(t *testing.T) {
-	h, _, _, store, active := newHandlerWithStoreAndActive(t)
+	h, _, store, active := newHandlerWithStoreAndActive(t)
 	finished := fixtureSession()
 	finished.Status = domain.SessionFinished
 	store.On("Get", "fix-bug").Return(finished, nil)
@@ -108,7 +109,7 @@ func TestHandleSelect_NonActiveSession_Rejected(t *testing.T) {
 // ─── status list mode ────────────────────────────────────────────────────
 
 func TestHandleStatus_NoSessionID_ListsAllSessions(t *testing.T) {
-	h, _, _, store, _ := newHandlerWithStoreAndActive(t)
+	h, _, store, _ := newHandlerWithStoreAndActive(t)
 	list := []*domain.Session{
 		{ID: "s1", Status: domain.SessionActive, Worktree: "/wt/s1"},
 		{ID: "s2", Status: domain.SessionFinished, Worktree: "/wt/s2"},
@@ -128,7 +129,7 @@ func TestHandleStatus_NoSessionID_ListsAllSessions(t *testing.T) {
 }
 
 func TestHandleStatus_WithSessionID_ReturnsSingle(t *testing.T) {
-	h, _, _, store, _ := newHandlerWithStoreAndActive(t)
+	h, _, store, _ := newHandlerWithStoreAndActive(t)
 	sess := fixtureSession()
 	store.On("Get", "fix-bug").Return(sess, nil)
 
@@ -143,21 +144,18 @@ func TestHandleStatus_WithSessionID_ReturnsSingle(t *testing.T) {
 // ─── finish clears active session ─────────────────────────────────────────
 
 func TestHandleFinish_ClearsActiveSession_WhenIDMatches(t *testing.T) {
-	h, mockGit, mainGit, store, active := newHandlerWithStoreAndActive(t)
+	h, mockGit, store, active := newHandlerWithStoreAndActive(t)
 	sess := fixtureSession()
 
 	// Pre-select the session so we can verify finish clears it.
 	active.Store(sess)
 
-	mockGit.On("Status").Return(cleanStatus(), nil).Times(2)
-	mockGit.On("Head").Return(fixedBaseCommit, nil)
-	mockGit.On("Merge", "main").Return("", nil)
-	mockGit.On("MergeAbort").Return("", nil)
-	mockGit.On("Reset", "--hard", fixedBaseCommit).Return("", nil)
+	// PreviewLight: clean status + MergeBase (no merge base → empty diff).
+	// No merge/dry-run/head/reset expectations — finish no longer merges.
+	mockGit.On("Status").Return(cleanStatus(), nil)
 	mockGit.On("MergeBase", "main", "fix-bug").Return("", assertError("none"))
-	mainGit.On("Merge", "fix-bug").Return("", nil)
 	mockGit.On("RemoveWorktree", "../git-courer-worktrees/fix-bug").Return(nil)
-	mockGit.On("DeleteBranch", "fix-bug", true).Return("", nil)
+	// DeleteBranch is intentionally NOT expected — branch stays alive.
 
 	store.On("Get", "fix-bug").Return(sess, nil)
 	store.On("Delete", "fix-bug").Return(nil)
@@ -167,6 +165,7 @@ func TestHandleFinish_ClearsActiveSession_WhenIDMatches(t *testing.T) {
 	require.NoError(t, err)
 	text := resultText(t, res)
 	assert.Contains(t, text, `"status":"success"`)
+	assert.Contains(t, text, `"branch_alive":true`)
 
 	// activeSession should now be nil.
 	v := active.Load()
@@ -174,12 +173,11 @@ func TestHandleFinish_ClearsActiveSession_WhenIDMatches(t *testing.T) {
 		t.Errorf("activeSession should be cleared after finish, got %v", s)
 	}
 	mockGit.AssertExpectations(t)
-	mainGit.AssertExpectations(t)
 	store.AssertExpectations(t)
 }
 
 func TestHandleFinish_DoesNotClearActiveSession_WhenIDMismatches(t *testing.T) {
-	h, mockGit, mainGit, store, active := newHandlerWithStoreAndActive(t)
+	h, mockGit, store, active := newHandlerWithStoreAndActive(t)
 	// A *different* session is selected.
 	other := fixtureSession()
 	other.ID = "other-session"
@@ -189,15 +187,9 @@ func TestHandleFinish_DoesNotClearActiveSession_WhenIDMismatches(t *testing.T) {
 
 	// Finish a different session (fix-bug).
 	sess := fixtureSession()
-	mockGit.On("Status").Return(cleanStatus(), nil).Times(2)
-	mockGit.On("Head").Return(fixedBaseCommit, nil)
-	mockGit.On("Merge", "main").Return("", nil)
-	mockGit.On("MergeAbort").Return("", nil)
-	mockGit.On("Reset", "--hard", fixedBaseCommit).Return("", nil)
+	mockGit.On("Status").Return(cleanStatus(), nil)
 	mockGit.On("MergeBase", "main", "fix-bug").Return("", assertError("none"))
-	mainGit.On("Merge", "fix-bug").Return("", nil)
 	mockGit.On("RemoveWorktree", "../git-courer-worktrees/fix-bug").Return(nil)
-	mockGit.On("DeleteBranch", "fix-bug", true).Return("", nil)
 
 	store.On("Get", "fix-bug").Return(sess, nil)
 	store.On("Delete", "fix-bug").Return(nil)
@@ -213,14 +205,13 @@ func TestHandleFinish_DoesNotClearActiveSession_WhenIDMismatches(t *testing.T) {
 	require.NotNil(t, s)
 	assert.Equal(t, "other-session", s.ID)
 	mockGit.AssertExpectations(t)
-	mainGit.AssertExpectations(t)
 	store.AssertExpectations(t)
 }
 
 // ─── unknown command suggestion includes select ──────────────────────────
 
 func TestHandleSession_UnknownCommandSuggestsSelect(t *testing.T) {
-	h, _, _, _, _ := newHandlerWithStoreAndActive(t)
+	h, _, _, _ := newHandlerWithStoreAndActive(t)
 	// "selct" is close to "select" — suggestion should fire.
 	args := map[string]any{"command": "selct"}
 	res, err := h.HandleSession(context.Background(), sessionReq(args))

--- a/internal/delivery/mcp/session/session_test.go
+++ b/internal/delivery/mcp/session/session_test.go
@@ -446,19 +446,20 @@ func parseRFC3339(s string) (any, error) {
 
 // ─── finish / status / discard (spec: session finish lifecycle) ────────────
 
-// newHandlerWithStore builds a Handler with a MockGit, MockSessionStore,
-// and a mainGit MockGit, redirecting metadata writes to a temp dir. Used by
-// finish/status/discard tests so the canonical domain.Session path is exercised.
-func newHandlerWithStore(t *testing.T) (*Handler, *MockGit, *MockGit, *MockSessionStore) {
+// newHandlerWithStore builds a Handler with a MockGit and a MockSessionStore,
+// redirecting metadata writes to a temp dir. Used by finish/status/discard
+// tests so the canonical domain.Session path is exercised. The session Handler
+// no longer carries a separate main-repo git adapter since finish no longer
+// merges — there is one git port for the worktree/preview/cleanup path.
+func newHandlerWithStore(t *testing.T) (*Handler, *MockGit, *MockSessionStore) {
 	t.Helper()
 	mockGit := new(MockGit)
-	mainGit := new(MockGit)
 	store := new(MockSessionStore)
 	active := &atomic.Value{}
 	active.Store((*domain.Session)(nil))
-	h := NewHandlerWithStore(mockGit, mainGit, store, t.TempDir(), active)
+	h := NewHandlerWithStore(mockGit, store, t.TempDir(), active)
 	h.metaDir = t.TempDir()
-	return h, mockGit, mainGit, store
+	return h, mockGit, store
 }
 
 // fixtureSession returns a canonical domain.Session for finish/status/discard
@@ -482,33 +483,17 @@ func cleanStatus() domain.Status {
 	return domain.Status{IsClean: true, Branch: "fix-bug", Files: []domain.FileStatus{}}
 }
 
-// conflictStatus returns a domain.Status with one conflicted file.
-func conflictStatus() domain.Status {
-	return domain.Status{
-		IsClean:    false,
-		Branch:     "fix-bug",
-		Conflicted: 1,
-		Files: []domain.FileStatus{
-			{Path: "file.go", Status: "UU"},
-		},
-	}
-}
-
 func TestHandleFinish_Success(t *testing.T) {
-	h, mockGit, mainGit, store := newHandlerWithStore(t)
+	h, mockGit, store := newHandlerWithStore(t)
 	sess := fixtureSession()
 
-	// Preview: clean status, no test command (config loader errors on temp dir),
-	// dry-run merge clean, then reset back. Finish: merge via mainGit + cleanup.
-	mockGit.On("Status").Return(cleanStatus(), nil).Times(2)
-	mockGit.On("Head").Return(fixedBaseCommit, nil)
-	mockGit.On("Merge", "main").Return("", nil)           // dry-run merge clean
-	mockGit.On("MergeAbort").Return("", nil)
-	mockGit.On("Reset", "--hard", fixedBaseCommit).Return("", nil)
+	// PreviewLight: clean status + MergeBase (returns no merge base → empty
+	// diff stats). No Head/Merge/MergeAbort/Reset expectations because
+	// PreviewLight does not run them.
+	mockGit.On("Status").Return(cleanStatus(), nil)
 	mockGit.On("MergeBase", "main", "fix-bug").Return("", assertError("none"))
-	mainGit.On("Merge", "fix-bug").Return("", nil)
 	mockGit.On("RemoveWorktree", "../git-courer-worktrees/fix-bug").Return(nil)
-	mockGit.On("DeleteBranch", "fix-bug", true).Return("", nil)
+	// NOTE: DeleteBranch is intentionally NOT expected — the branch stays alive.
 
 	store.On("Get", "fix-bug").Return(sess, nil)
 	store.On("Delete", "fix-bug").Return(nil)
@@ -519,27 +504,27 @@ func TestHandleFinish_Success(t *testing.T) {
 	require.NotNil(t, res)
 	text := resultText(t, res)
 	assert.Contains(t, text, `"status":"success"`)
+	assert.Contains(t, text, `"branch_alive":true`)
 	mockGit.AssertExpectations(t)
-	mainGit.AssertExpectations(t)
 	store.AssertExpectations(t)
 }
 
-func TestHandleFinish_TestFailure(t *testing.T) {
-	h, mockGit, _, store := newHandlerWithStore(t)
-	// Override the workflow's test runner by pointing workDir at a temp dir
-	// with no config — the preview reports skipped, so this test actually
-	// exercises the no-test-command path. To test a real failure we'd need a
-	// config file; instead we verify the preview_failed path via uncommitted
-	// changes (simpler and deterministic without a real test runner).
+// TestHandleFinish_UncommittedAborts verifies that uncommitted changes are the
+// ONLY abort gate: when the worktree is dirty, finish returns preview_failed,
+// preserves the worktree and metadata, and never reaches cleanup.
+func TestHandleFinish_UncommittedAborts(t *testing.T) {
+	h, mockGit, store := newHandlerWithStore(t)
 	sess := fixtureSession()
 
-	dirtyStatus := domain.Status{IsClean: false, Branch: "fix-bug", Files: []domain.FileStatus{{Path: "x.go", Status: "M "}}}
+	dirtyStatus := domain.Status{
+		IsClean: false,
+		Branch:  "fix-bug",
+		Files:   []domain.FileStatus{{Path: "x.go", Status: "M "}},
+	}
 	mockGit.On("Status").Return(dirtyStatus, nil)
-	mockGit.On("Head").Return(fixedBaseCommit, nil)
-	mockGit.On("Merge", "main").Return("", nil)
-	mockGit.On("MergeAbort").Return("", nil)
-	mockGit.On("Reset", "--hard", fixedBaseCommit).Return("", nil)
 	mockGit.On("MergeBase", "main", "fix-bug").Return("", assertError("none"))
+	// No RemoveWorktree / DeleteBranch / store.Delete expectations: abort keeps
+	// everything in place.
 
 	store.On("Get", "fix-bug").Return(sess, nil)
 
@@ -554,48 +539,17 @@ func TestHandleFinish_TestFailure(t *testing.T) {
 	store.AssertExpectations(t)
 }
 
-func TestHandleFinish_MergeConflict(t *testing.T) {
-	h, mockGit, mainGit, store := newHandlerWithStore(t)
-	sess := fixtureSession()
-
-	// Preview clean, dry-run merge clean. Real merge in main repo conflicts:
-	// the 3rd Status() call (after the real merge) reports a conflict.
-	mockGit.On("Status").Return(cleanStatus(), nil).Times(2)
-	mockGit.On("Head").Return(fixedBaseCommit, nil)
-	mockGit.On("Merge", "main").Return("", nil) // dry-run clean
-	mockGit.On("MergeAbort").Return("", nil)
-	mockGit.On("Reset", "--hard", fixedBaseCommit).Return("", nil)
-	mockGit.On("MergeBase", "main", "fix-bug").Return("", assertError("none"))
-	mainGit.On("Merge", "fix-bug").Return("", assertError("merge conflict"))
-	mainGit.On("Status").Return(conflictStatus(), nil).Once()
-	mainGit.On("MergeAbort").Return("", nil)
-
-	store.On("Get", "fix-bug").Return(sess, nil)
-
-	args := map[string]any{"command": "finish", "session_id": "fix-bug"}
-	res, err := h.HandleSession(context.Background(), sessionReq(args))
-	assert.NoError(t, err)
-	require.NotNil(t, res)
-	text := resultText(t, res)
-	assert.Contains(t, text, `"status":"conflict"`)
-	mockGit.AssertExpectations(t)
-	mainGit.AssertExpectations(t)
-	store.AssertExpectations(t)
-}
-
+// TestHandleFinish_CleanupFailure verifies that a worktree-removal failure is
+// reported as cleanup_failed, but the branch is STILL alive (no DeleteBranch is
+// called during cleanup) and the merge step was never attempted.
 func TestHandleFinish_CleanupFailure(t *testing.T) {
-	h, mockGit, mainGit, store := newHandlerWithStore(t)
+	h, mockGit, store := newHandlerWithStore(t)
 	sess := fixtureSession()
 
-	mockGit.On("Status").Return(cleanStatus(), nil).Times(2)
-	mockGit.On("Head").Return(fixedBaseCommit, nil)
-	mockGit.On("Merge", "main").Return("", nil)
-	mockGit.On("MergeAbort").Return("", nil)
-	mockGit.On("Reset", "--hard", fixedBaseCommit).Return("", nil)
+	mockGit.On("Status").Return(cleanStatus(), nil)
 	mockGit.On("MergeBase", "main", "fix-bug").Return("", assertError("none"))
-	mainGit.On("Merge", "fix-bug").Return("", nil)
 	mockGit.On("RemoveWorktree", "../git-courer-worktrees/fix-bug").Return(assertError("worktree busy"))
-	mockGit.On("DeleteBranch", "fix-bug", true).Return("", nil)
+	// DeleteBranch is NOT expected — cleanup only removes the worktree now.
 
 	store.On("Get", "fix-bug").Return(sess, nil)
 	store.On("Save", mock.MatchedBy(func(s *domain.Session) bool {
@@ -608,13 +562,15 @@ func TestHandleFinish_CleanupFailure(t *testing.T) {
 	require.NotNil(t, res)
 	text := resultText(t, res)
 	assert.Contains(t, text, `"status":"cleanup_failed"`)
+	// Even on cleanup failure, the branch is reported alive — the user can
+	// still integrate or discard it manually.
+	assert.Contains(t, text, `"branch_alive":true`)
 	mockGit.AssertExpectations(t)
-	mainGit.AssertExpectations(t)
 	store.AssertExpectations(t)
 }
 
 func TestHandleFinish_NotFound(t *testing.T) {
-	h, _, _, store := newHandlerWithStore(t)
+	h, _, store := newHandlerWithStore(t)
 	store.On("Get", "nope").Return((*domain.Session)(nil), assertError("session not found"))
 
 	args := map[string]any{"command": "finish", "session_id": "nope"}
@@ -627,7 +583,7 @@ func TestHandleFinish_NotFound(t *testing.T) {
 }
 
 func TestHandleStatus_ReturnsSessionState(t *testing.T) {
-	h, _, _, store := newHandlerWithStore(t)
+	h, _, store := newHandlerWithStore(t)
 	sess := fixtureSession()
 	store.On("Get", "fix-bug").Return(sess, nil)
 
@@ -645,7 +601,7 @@ func TestHandleStatus_ReturnsSessionState(t *testing.T) {
 }
 
 func TestHandleDiscard_RemovesWorktreeBranchMetadata(t *testing.T) {
-	h, mockGit, _, store := newHandlerWithStore(t)
+	h, mockGit, store := newHandlerWithStore(t)
 	sess := fixtureSession()
 
 	store.On("Get", "fix-bug").Return(sess, nil)
@@ -664,7 +620,7 @@ func TestHandleDiscard_RemovesWorktreeBranchMetadata(t *testing.T) {
 }
 
 func TestHandleDiscard_MissingConfirmedReturnsError(t *testing.T) {
-	h, _, _, _ := newHandlerWithStore(t)
+	h, _, _ := newHandlerWithStore(t)
 	args := map[string]any{"command": "discard", "session_id": "fix-bug"}
 	res, err := h.HandleSession(context.Background(), sessionReq(args))
 	assert.NoError(t, err)

--- a/internal/workflow/session_finish.go
+++ b/internal/workflow/session_finish.go
@@ -14,7 +14,6 @@ type FinishStatus string
 
 const (
 	FinishSuccess       FinishStatus = "success"
-	FinishConflict      FinishStatus = "conflict"
 	FinishPreviewFailed FinishStatus = "preview_failed"
 	FinishCleanupFailed FinishStatus = "cleanup_failed"
 	FinishNotFound      FinishStatus = "not_found"
@@ -22,30 +21,32 @@ const (
 
 // FinishResult is the structured result of SessionFinishWorkflow.Finish.
 type FinishResult struct {
-	Status  FinishStatus    `json:"status"`
-	Message string          `json:"message"`
-	Preview *PreviewResult  `json:"preview,omitempty"`
-	Session *domain.Session `json:"session,omitempty"`
+	Status      FinishStatus    `json:"status"`
+	Message     string          `json:"message"`
+	Preview     *PreviewResult  `json:"preview,omitempty"`
+	BranchAlive bool            `json:"branch_alive"`
+	Session     *domain.Session `json:"session,omitempty"`
 }
 
 // SessionFinishWorkflow orchestrates the finish lifecycle: load session,
-// preview-validate, merge into base, cleanup worktree+branch, persist state.
+// preview-validate (uncommitted-changes guard + diff stats only), cleanup the
+// worktree, and persist state. The session branch is left ALIVE for the user
+// to integrate manually (merge, PR, or discard). No merge is attempted and no
+// branch is deleted.
 type SessionFinishWorkflow struct {
 	git     ports.Git // worktree adapter (preview, cleanup)
-	mainGit ports.Git // main repo adapter (merge only)
 	store   ports.SessionStore
 	preview *PreviewEngine
 	workDir string
 }
 
-// NewSessionFinishWorkflow builds a finish workflow backed by git, mainGit,
-// store, and a PreviewEngine rooted at workDir. mainGit MUST point to the
-// main repository root (not the session worktree) so the merge runs where
-// the base branch is already checked out.
-func NewSessionFinishWorkflow(git, mainGit ports.Git, store ports.SessionStore, workDir string) *SessionFinishWorkflow {
+// NewSessionFinishWorkflow builds a finish workflow backed by git, store, and a
+// PreviewEngine rooted at workDir. The git port must address the session
+// worktree (or the main repo when no session is active) so the uncommitted
+// check and worktree removal land in the right place.
+func NewSessionFinishWorkflow(git ports.Git, store ports.SessionStore, workDir string) *SessionFinishWorkflow {
 	return &SessionFinishWorkflow{
 		git:     git,
-		mainGit: mainGit,
 		store:   store,
 		preview: NewPreviewEngine(git, workDir),
 		workDir: workDir,
@@ -56,16 +57,14 @@ func NewSessionFinishWorkflow(git, mainGit ports.Git, store ports.SessionStore, 
 //
 // Steps:
 //  1. Load the session from the store. Missing session -> not_found.
-//  2. Run the PreviewEngine against the session's base branch.
-//  3. If preview detects uncommitted changes, test failure, or a merge
-//     conflict, abort and keep the session active (preview_failed or conflict).
-//  4. Resolve the main repo root from GitCommonDir, switch to the base branch
-//     there, and merge the session branch.
-//  5. On merge conflict, abort the merge and return conflict status.
-//  6. On success, cleanup: RemoveWorktree + DeleteBranch.
-//  7. If cleanup fails, transition the session to cleanup_failed (the merge is
-//     NOT reverted) and persist it.
-//  8. If cleanup succeeds, delete the session metadata file.
+//  2. Run PreviewLight against the session's base branch: the only abort gate
+//     is uncommitted/untracked changes (data-loss guard). Test status and
+//     merge readiness are NOT checked — the user controls integration.
+//  3. Cleanup: RemoveWorktree only. The session branch is NOT deleted so the
+//     user can merge, open a PR, or `session discard` it later.
+//  4. If cleanup fails, transition the session to cleanup_failed and persist
+//     it. The branch is still alive; the user can retry cleanup or discard.
+//  5. If cleanup succeeds, delete the session metadata file.
 func (w *SessionFinishWorkflow) Finish(ctx context.Context, sessionID string) (*FinishResult, error) {
 	sess, err := w.store.Get(sessionID)
 	if err != nil {
@@ -77,8 +76,8 @@ func (w *SessionFinishWorkflow) Finish(ctx context.Context, sessionID string) (*
 		baseBranch = "main"
 	}
 
-	// 2. Preview validation.
-	preview, perr := w.preview.Preview(ctx, baseBranch)
+	// 2. Preview validation (light: uncommitted guard + diff stats only).
+	preview, perr := w.preview.PreviewLight(ctx, baseBranch)
 	if perr != nil {
 		return &FinishResult{
 			Status:  FinishPreviewFailed,
@@ -87,7 +86,7 @@ func (w *SessionFinishWorkflow) Finish(ctx context.Context, sessionID string) (*
 		}, nil
 	}
 
-	// 3. Abort on uncommitted changes, test failure, or conflict.
+	// 3. Abort ONLY on uncommitted/untracked changes (data-loss risk).
 	if preview.HasUncommitted {
 		return &FinishResult{
 			Status:  FinishPreviewFailed,
@@ -96,87 +95,41 @@ func (w *SessionFinishWorkflow) Finish(ctx context.Context, sessionID string) (*
 			Session: sess,
 		}, nil
 	}
-	if preview.TestResult != nil && (preview.TestResult.Status == "fail" || preview.TestResult.Status == "timeout") {
-		return &FinishResult{
-			Status:  FinishPreviewFailed,
-			Message: fmt.Sprintf("tests %s: %d failing", preview.TestResult.Status, preview.TestResult.Failed),
-			Preview: preview,
-			Session: sess,
-		}, nil
-	}
-	if preview.HasConflict {
-		return &FinishResult{
-			Status:  FinishConflict,
-			Message: "merge conflict detected during dry-run; resolve before finishing",
-			Preview: preview,
-			Session: sess,
-		}, nil
-	}
 
-	// 4. Merge the session branch into the base branch.
-	// The merge runs in the main repo (via mainGit) where the base branch
-	// is already checked out. We do NOT switch branches inside the worktree
-	// — git rejects that when the branch is active in the main worktree.
-	if _, merr := w.mainGit.Merge(sess.Branch); merr != nil {
-		// Detect conflict via status; abort merge regardless.
-		status, _ := w.mainGit.Status()
-		if status.Conflicted > 0 {
-			_, _ = w.mainGit.MergeAbort()
-			return &FinishResult{
-				Status:  FinishConflict,
-				Message: fmt.Sprintf("merge conflict while merging %q into %q", sess.Branch, baseBranch),
-				Preview: preview,
-				Session: sess,
-			}, nil
-		}
-		return &FinishResult{
-			Status:  FinishPreviewFailed,
-			Message: fmt.Sprintf("merge %q into %q: %v", sess.Branch, baseBranch, merr),
-			Preview: preview,
-			Session: sess,
-		}, nil
-	}
-
-	// 6. Cleanup: remove worktree then delete the session branch.
+	// 4. Cleanup: remove the worktree only. The branch stays alive.
 	cleanupErr := w.cleanup(sess)
 	if cleanupErr != nil {
-		// 7. Tolerant cleanup: do NOT revert the merge. Mark the session as
-		// cleanup_failed and persist so the caller can retry cleanup.
 		sess.Status = domain.SessionCleanupFailed
 		sess.FinishedAt = time.Now().UTC().Format(time.RFC3339)
 		_ = w.store.Save(sess)
 		return &FinishResult{
-			Status:  FinishCleanupFailed,
-			Message: fmt.Sprintf("merge succeeded but cleanup failed: %v", cleanupErr),
-			Preview: preview,
-			Session: sess,
+			Status:      FinishCleanupFailed,
+			Message:     fmt.Sprintf("cleanup failed: %v", cleanupErr),
+			Preview:     preview,
+			BranchAlive: true,
+			Session:     sess,
 		}, nil
 	}
 
-	// 8. Cleanup succeeded: delete the session metadata file.
+	// 5. Cleanup succeeded: delete the session metadata file.
 	_ = w.store.Delete(sess.ID)
 
 	return &FinishResult{
-		Status:  FinishSuccess,
-		Message: fmt.Sprintf("session %q merged into %q and cleaned up", sess.ID, baseBranch),
-		Preview: preview,
-		Session: sess,
+		Status:      FinishSuccess,
+		Message:     fmt.Sprintf("session %q finished: worktree removed, branch %q alive for manual integration", sess.ID, sess.Branch),
+		Preview:     preview,
+		BranchAlive: true,
+		Session:     sess,
 	}, nil
 }
 
-// cleanup removes the session worktree and deletes the session branch.
-// Worktree removal is attempted first; if it fails we still try to delete the
-// branch and report the first error.
+// cleanup removes the session worktree. The session branch is intentionally
+// NOT deleted — finish leaves the branch alive so the user can integrate
+// (merge, PR) or discard it explicitly via `session discard`.
 func (w *SessionFinishWorkflow) cleanup(sess *domain.Session) error {
-	var firstErr error
-	if sess.Worktree != "" {
-		if err := w.git.RemoveWorktree(sess.Worktree); err != nil {
-			firstErr = err
-		}
+	if sess.Worktree == "" {
+		return nil
 	}
-	if _, derr := w.git.DeleteBranch(sess.Branch, true); derr != nil && firstErr == nil {
-		firstErr = derr
-	}
-	return firstErr
+	return w.git.RemoveWorktree(sess.Worktree)
 }
 

--- a/internal/workflow/session_preview.go
+++ b/internal/workflow/session_preview.go
@@ -137,6 +137,39 @@ func (p *PreviewEngine) Preview(ctx context.Context, baseBranch string) (*Previe
 	return result, nil
 }
 
+// PreviewLight runs the minimal validation session finish needs: the
+// uncommitted-changes guard (data-loss protection) and the diff-stats
+// computation. It deliberately SKIPS the test command, the dry-run merge, the
+// pre-merge HEAD capture, MergeAbort, and the post-clean-merge Reset — finish
+// no longer merges or runs tests, so those are wasted work and potential
+// side-effects. The returned PreviewResult only populates HasUncommitted and
+// DiffStats; TestResult and HasConflict are always zero-valued.
+//
+// Use Preview (the heavy variant) when a caller needs the full pre-merge
+// picture (e.g. pr-review). Use PreviewLight for finish, where the branch is
+// left alive and integration is the user's decision.
+func (p *PreviewEngine) PreviewLight(ctx context.Context, baseBranch string) (*PreviewResult, error) {
+	_ = ctx
+	result := &PreviewResult{ConflictFiles: []string{}}
+
+	// 1. Uncommitted/untracked changes check — the ONLY abort gate for finish.
+	status, err := p.git.Status()
+	if err != nil {
+		return nil, fmt.Errorf("preview: status: %w", err)
+	}
+	if !status.IsClean {
+		result.HasUncommitted = true
+	}
+
+	// 2. Diff stats against the merge base (best-effort; never aborts).
+	mb, mbErr := p.git.MergeBase(baseBranch, currentBranchName(status))
+	if mbErr == nil && mb != "" {
+		result.DiffStats = buildPreviewDiffStats(p.git, mb, currentBranchName(status))
+	}
+
+	return result, nil
+}
+
 // isConflictStatus reports whether a porcelain status code indicates a conflict.
 func isConflictStatus(s string) bool {
 	switch s {

--- a/internal/workflow/session_preview_test.go
+++ b/internal/workflow/session_preview_test.go
@@ -1,0 +1,146 @@
+package workflow
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/blak0p/git-courer/internal/core/domain"
+	"github.com/blak0p/git-courer/internal/core/ports"
+)
+
+// fakeGit is a minimal ports.Git stub for PreviewEngine unit tests. It embeds
+// ports.Git (as a nil interface) so any method NOT explicitly overridden panics
+// with a nil-dereference — a loud failure proving PreviewLight stayed on the
+// light path. The methods PreviewLight touches are overridden to return canned
+// values; the heavy-path methods (Merge/MergeAbort/Head/Reset) set flags so we
+// can assert they were never called.
+type fakeGit struct {
+	ports.Git // nil: unimplemented methods panic loudly
+
+	status    domain.Status
+	statusErr error
+	mb        string
+	mbErr     error
+	diff      string
+	diffErr   error
+
+	calledMerge      bool
+	calledMergeAbort bool
+	calledHead       bool
+	calledReset      bool
+}
+
+func (f *fakeGit) Status() (domain.Status, error) { return f.status, f.statusErr }
+func (f *fakeGit) MergeBase(_, _ string) (string, error) { return f.mb, f.mbErr }
+func (f *fakeGit) DiffRange(_, _, _ string, _ ...string) (string, error) {
+	return f.diff, f.diffErr
+}
+
+// Mutator methods that PreviewLight MUST NOT call. Setting flags (instead of
+// panicking) lets the test report WHICH heavy method was hit before failing.
+func (f *fakeGit) Merge(_ string) (string, error) {
+	f.calledMerge = true
+	return "", errors.New("Merge must not be called by PreviewLight")
+}
+func (f *fakeGit) MergeAbort() (string, error) {
+	f.calledMergeAbort = true
+	return "", errors.New("MergeAbort must not be called by PreviewLight")
+}
+func (f *fakeGit) Head() (string, error) {
+	f.calledHead = true
+	return "", errors.New("Head must not be called by PreviewLight")
+}
+func (f *fakeGit) Reset(_, _ string) (string, error) {
+	f.calledReset = true
+	return "", errors.New("Reset must not be called by PreviewLight")
+}
+
+// TestPreviewLight_CleanStatus_NoUncommitted reports the status faithfully and
+// does not invoke any merge/head/reset plumbing.
+func TestPreviewLight_CleanStatus_NoUncommitted(t *testing.T) {
+	g := &fakeGit{
+		status: domain.Status{IsClean: true, Branch: "fix-bug", Files: []domain.FileStatus{}},
+		mb:     "mergebase-sha",
+		diff:   "diff --git a/x.go b/x.go\n+1\n",
+	}
+	eng := NewPreviewEngine(g, "")
+
+	res, err := eng.PreviewLight(context.Background(), "main")
+	if err != nil {
+		t.Fatalf("PreviewLight returned error: %v", err)
+	}
+	if res.HasUncommitted {
+		t.Errorf("HasUncommitted = true; want false for clean status")
+	}
+	if res.HasConflict {
+		t.Errorf("HasConflict = true; PreviewLight must never report conflicts")
+	}
+	if res.TestResult != nil {
+		t.Errorf("TestResult = %v; want nil — PreviewLight skips tests", res.TestResult)
+	}
+	if g.calledMerge || g.calledMergeAbort || g.calledHead || g.calledReset {
+		t.Errorf("PreviewLight invoked heavy path: merge=%v abort=%v head=%v reset=%v",
+			g.calledMerge, g.calledMergeAbort, g.calledHead, g.calledReset)
+	}
+	// DiffStats should be populated from the fake diff (one file, one addition).
+	if len(res.DiffStats.Files) != 1 {
+		t.Errorf("DiffStats.Files len = %d; want 1", len(res.DiffStats.Files))
+	}
+	if res.DiffStats.TotalAdditions != 1 {
+		t.Errorf("TotalAdditions = %d; want 1", res.DiffStats.TotalAdditions)
+	}
+}
+
+// TestPreviewLight_DirtyStatus_ReportsUncommitted triangulates the dirty path:
+// the only abort gate is uncommitted changes, and diff stats are still computed.
+func TestPreviewLight_DirtyStatus_ReportsUncommitted(t *testing.T) {
+	g := &fakeGit{
+		status: domain.Status{
+			IsClean: false,
+			Branch:  "fix-bug",
+			Files:   []domain.FileStatus{{Path: "x.go", Status: "M "}},
+		},
+		mb:   "mergebase-sha",
+		diff: "diff --git a/y.go b/y.go\n-1\n",
+	}
+	eng := NewPreviewEngine(g, "")
+
+	res, err := eng.PreviewLight(context.Background(), "main")
+	if err != nil {
+		t.Fatalf("PreviewLight returned error: %v", err)
+	}
+	if !res.HasUncommitted {
+		t.Errorf("HasUncommitted = false; want true for dirty status")
+	}
+	if res.HasConflict {
+		t.Errorf("HasConflict = true; PreviewLight must never report conflicts")
+	}
+	if res.TestResult != nil {
+		t.Errorf("TestResult = %v; want nil — PreviewLight skips tests", res.TestResult)
+	}
+	if g.calledMerge || g.calledMergeAbort || g.calledHead || g.calledReset {
+		t.Errorf("PreviewLight invoked heavy path: merge=%v abort=%v head=%v reset=%v",
+			g.calledMerge, g.calledMergeAbort, g.calledHead, g.calledReset)
+	}
+	// Dirty branch still gets diff stats (best-effort).
+	if len(res.DiffStats.Files) != 1 {
+		t.Errorf("DiffStats.Files len = %d; want 1 (diff stats still computed on dirty)", len(res.DiffStats.Files))
+	}
+	if res.DiffStats.TotalDeletions != 1 {
+		t.Errorf("TotalDeletions = %d; want 1", res.DiffStats.TotalDeletions)
+	}
+}
+
+// TestPreviewLight_StatusError_Propagates verifies that a Status() error
+// short-circuits PreviewLight with a wrapped error.
+func TestPreviewLight_StatusError_Propagates(t *testing.T) {
+	g := &fakeGit{
+		statusErr: errors.New("boom"),
+	}
+	eng := NewPreviewEngine(g, "")
+
+	if _, err := eng.PreviewLight(context.Background(), "main"); err == nil {
+		t.Fatalf("PreviewLight returned nil error; want wrapped status error")
+	}
+}


### PR DESCRIPTION
## Summary

`session finish` now only removes the worktree and clears session metadata. The session branch is **left alive** for manual integration (merge, PR, or `session discard`). No automatic merge, no branch deletion.

## What Changed

- **No merge**: Removed `mainGit.Merge` from the finish workflow. The merge decision is now the user's.
- **No branch deletion**: `cleanup()` only calls `RemoveWorktree`. The branch stays alive.
- **Optimized preview**: New `PreviewLight` method — only checks uncommitted changes and computes diff stats. Skips test execution and dry-run merge (faster finish).
- **Data-loss guard**: Uncommitted/untracked changes still abort finish with a clear error.
- **Informative output**: `FinishResult` now includes `branch_alive: true` so callers know the branch is still there.
- **Cleaner API**: `mainGit` removed from `Handler`, `NewHandlerWithStore`, and `NewSessionFinishWorkflow` — one git port for the worktree.

## Files Changed (8)

| File | Changes |
|------|---------|
| `internal/workflow/session_finish.go` | −90/+43 — removed merge, branch delete, gates; added `BranchAlive` |
| `internal/workflow/session_preview.go` | +33 — new `PreviewLight` method |
| `internal/workflow/session_preview_test.go` | +146 — 3 unit tests for `PreviewLight` |
| `internal/delivery/mcp/session/handler.go` | −5/+8 — removed `mainGit` field + constructor param |
| `internal/delivery/mcp/session/session.go` | −5/+7 — 3-param constructor call |
| `internal/delivery/mcp/handlers.go` | −1/+1 — dropped `mainGit` arg |
| `internal/delivery/mcp/session/session_test.go` | −84/+40 — rewritten finish tests |
| `internal/delivery/mcp/session/session_select_test.go` | −32/+23 — updated helpers |

## Testing

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — 39 packages PASS
- `go test -race -short ./internal/workflow/... ./internal/delivery/mcp/session/...` — PASS

## Migration

If you relied on `session finish` to auto-merge, use `git-courer integrate MERGE` or create a PR after finish. Use `git-courer branch DELETE` or `git branch -d` to clean up stale branches.