### PR TITLE
docs: simplify PR template to Closes/Summary/Changes/TestPlan format

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,27 +3,18 @@
   Please follow the conventional commit format and ensure tests pass.
 -->
 
-## Description
+Closes #
 
-<!-- Describe the change, why it's needed, and link to the related issue -->
+## Summary
 
-Fixes # | Updates #
+<!-- Describe what this PR does -->
 
-## Type of change
+## Changes
 
-- [ ] Bug fix (non-breaking)
-- [ ] New feature (non-breaking)
-- [ ] Breaking change (add `!` after type in commit, e.g. `feat!:`)
-- [ ] Documentation update
+| File | Change |
+|------|--------|
+|  |  |
 
-## Checklist
+## Test Plan
 
-- [ ] `go build ./...` compiles without errors
-- [ ] `go test ./...` passes
-- [ ] `go vet ./...` passes
-- [ ] I followed [conventional commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `perf:`, `test:`, `ci:`)
-- [ ] I updated relevant documentation (if applicable)
-
-## Additional context
-
-<!-- Add any other context about the PR here -->
+<!-- How did you verify this works? -->


### PR DESCRIPTION
Closes #

## Summary

Simplify PR template — remove verbose sections that duplicate info already in the linked issue. Match the concise format used in real PRs.

## Changes

| File | Change |
|------|--------|
| .github/PULL_REQUEST_TEMPLATE.md | Replace verbose template with Closes/Summary/Changes/TestPlan |

## Test Plan

No code changes — config only.