### PR TITLE
feat(backup): rewrite PruneBackups to reachability+age and add auto-prune gate

### DIFF
--- a/internal/adapters/git/backup_test.go
+++ b/internal/adapters/git/backup_test.go
@@ -1,9 +1,13 @@
 package git
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/blak0p/git-courer/internal/core/domain"
 )
@@ -64,4 +68,298 @@ func TestCreateBackup(t *testing.T) {
 	}
 
 	adapter.DeleteBackup(backup2)
+}
+
+// --- PruneBackups reachability tests (table-driven) ---
+
+// gitRun runs a git command in dir and fails the test on error.
+func gitRun(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %s\n%s", args, dir, err, out)
+	}
+	return string(out)
+}
+
+// commitFile creates a commit adding a file with the given content. Returns the
+// new HEAD commit OID. Uses the real adapter so it goes through the same git
+// plumbing as production.
+func commitFile(t *testing.T, a *ExecAdapter, dir, name, content string) string {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	if err := a.Add([]string{name}); err != nil {
+		t.Fatalf("add %s: %v", name, err)
+	}
+	if _, err := a.Commit(name); err != nil {
+		t.Fatalf("commit %s: %v", name, err)
+	}
+	return strings.TrimSpace(gitRun(t, dir, "rev-parse", "HEAD"))
+}
+
+// createBackupRefAt creates a backup ref pointing at the given commit OID with
+// an encoded timestamp so ListBackups can parse CreatedAt.
+func createBackupRefAt(t *testing.T, dir, op string, ts time.Time, commit string) string {
+	t.Helper()
+	ref := fmt.Sprintf("refs/git-courer/backup/%s_%s", ts.Format("20060102150405"), op)
+	gitRun(t, dir, "update-ref", ref, commit)
+	return ref
+}
+
+// backupRefs returns the set of backup ref names currently present.
+func backupRefs(t *testing.T, a *ExecAdapter) map[string]bool {
+	t.Helper()
+	backups, err := a.ListBackups()
+	if err != nil {
+		t.Fatalf("ListBackups: %v", err)
+	}
+	set := make(map[string]bool, len(backups))
+	for _, b := range backups {
+		set[b.Ref] = true
+	}
+	return set
+}
+
+func TestPruneBackups_Reachability(t *testing.T) {
+	cases := []struct {
+		name      string
+		setup     func(t *testing.T, a *ExecAdapter, dir string) (keep, del map[string]bool)
+		olderThan time.Duration
+	}{
+		{
+			name: "unreachable backup deleted regardless of age",
+			setup: func(t *testing.T, a *ExecAdapter, dir string) (map[string]bool, map[string]bool) {
+				base := commitFile(t, a, dir, "base.txt", "base")
+				// Branch off base, then advance main so the branch commit becomes unreachable from HEAD.
+				branchCommit := createCommitOnNewBranch(t, a, dir, "topic", "topic.txt", "topic")
+				// Move HEAD forward on main, past the branch point.
+				gitRun(t, dir, "checkout", "master")
+				mainCommit := commitFile(t, a, dir, "main2.txt", "main2")
+				_ = base
+				_ = mainCommit
+				// Backup pointing at the topic branch tip — reachable from refs/heads/topic.
+				keepRef := createBackupRefAt(t, dir, "KEEP", time.Now(), branchCommit)
+				// Backup pointing at a commit that is NOT an ancestor of HEAD or any branch.
+				// Create a dangling commit (no ref points at it) then a backup at it.
+				dangling := gitRun(t, dir, "commit-tree", "-m", "dangling",
+					"-p", base, fmt.Sprintf("%s^{tree}", base))
+				dangling = strings.TrimSpace(dangling)
+				delRef := createBackupRefAt(t, dir, "DEL", time.Now(), dangling)
+				return map[string]bool{keepRef: true}, map[string]bool{delRef: true}
+			},
+			olderThan: 30 * 24 * time.Hour,
+		},
+		{
+			name: "reachable and older than window is deleted",
+			setup: func(t *testing.T, a *ExecAdapter, dir string) (map[string]bool, map[string]bool) {
+				commitFile(t, a, dir, "base.txt", "base")
+				old := time.Now().Add(-45 * 24 * time.Hour)
+				// Backup pointing at HEAD but created 45 days ago → reachable + old → delete.
+				head := strings.TrimSpace(gitRun(t, dir, "rev-parse", "HEAD"))
+				delRef := createBackupRefAt(t, dir, "OLD", old, head)
+				return map[string]bool{}, map[string]bool{delRef: true}
+			},
+			olderThan: 30 * 24 * time.Hour,
+		},
+		{
+			name: "reachable and recent is kept",
+			setup: func(t *testing.T, a *ExecAdapter, dir string) (map[string]bool, map[string]bool) {
+				commitFile(t, a, dir, "base.txt", "base")
+				head := strings.TrimSpace(gitRun(t, dir, "rev-parse", "HEAD"))
+				keepRef := createBackupRefAt(t, dir, "RECENT", time.Now().Add(-5*24*time.Hour), head)
+				return map[string]bool{keepRef: true}, map[string]bool{}
+			},
+			olderThan: 30 * 24 * time.Hour,
+		},
+		{
+			name: "reachable from one of many branches is kept",
+			setup: func(t *testing.T, a *ExecAdapter, dir string) (map[string]bool, map[string]bool) {
+				commitFile(t, a, dir, "base.txt", "base")
+				// Create 12 branches, each with its own commit.
+				var lastBranchCommit string
+				for i := 0; i < 12; i++ {
+					name := fmt.Sprintf("b%d", i)
+					lastBranchCommit = createCommitOnNewBranch(t, a, dir, name, name+".txt", name)
+					gitRun(t, dir, "checkout", "master")
+				}
+				// Backup at the 7th branch tip — reachable only from refs/heads/b6.
+				keepRef := createBackupRefAt(t, dir, "ONE", time.Now(), lastBranchCommit)
+				return map[string]bool{keepRef: true}, map[string]bool{}
+			},
+			olderThan: 30 * 24 * time.Hour,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			initGitRepo(t, dir)
+			// Ensure a default branch name exists (git init may use "master" or "main").
+			gitRun(t, dir, "symbolic-ref", "HEAD", "refs/heads/master")
+			a := New(dir)
+
+			keep, del := tc.setup(t, a, dir)
+
+			if err := a.PruneBackups(tc.olderThan); err != nil {
+				t.Fatalf("PruneBackups: %v", err)
+			}
+
+			surviving := backupRefs(t, a)
+			for ref := range keep {
+				if !surviving[ref] {
+					t.Errorf("expected %s to survive, but it was pruned", ref)
+				}
+			}
+			for ref := range del {
+				if surviving[ref] {
+					t.Errorf("expected %s to be pruned, but it survived", ref)
+				}
+			}
+		})
+	}
+}
+
+// createCommitOnNewBranch creates a new branch at HEAD, checks it out, makes a
+// commit, and returns the new commit OID. HEAD is left on the new branch.
+func createCommitOnNewBranch(t *testing.T, a *ExecAdapter, dir, branch, file, content string) string {
+	t.Helper()
+	gitRun(t, dir, "checkout", "-b", branch)
+	return commitFile(t, a, dir, file, content)
+}
+
+func TestPruneBackups_CorruptRefRecovery(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+	gitRun(t, dir, "symbolic-ref", "HEAD", "refs/heads/master")
+	a := New(dir)
+	commitFile(t, a, dir, "base.txt", "base")
+
+	// A valid 40-hex OID that does not exist in this repo's object store. We
+	// cannot use `git update-ref` because it validates the target object, so we
+	// write the ref file directly to simulate a ref left dangling after a
+	// gc/prune of its target object.
+	phantom := "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	ts := time.Now().Format("20060102150405")
+	badRef := fmt.Sprintf("refs/git-courer/backup/%s_CORRUPT", ts)
+	refPath := filepath.Join(dir, ".git", badRef)
+	if err := os.MkdirAll(filepath.Dir(refPath), 0755); err != nil {
+		t.Fatalf("mkdir ref dir: %v", err)
+	}
+	if err := os.WriteFile(refPath, []byte(phantom+"\n"), 0644); err != nil {
+		t.Fatalf("write corrupt ref: %v", err)
+	}
+
+	// Also create a valid reachable recent backup to confirm the loop continues.
+	head := strings.TrimSpace(gitRun(t, dir, "rev-parse", "HEAD"))
+	goodRef := createBackupRefAt(t, dir, "GOOD", time.Now(), head)
+
+	if err := a.PruneBackups(30 * 24 * time.Hour); err != nil {
+		t.Fatalf("PruneBackups should recover from corrupt ref, got: %v", err)
+	}
+
+	surviving := backupRefs(t, a)
+	if surviving[badRef] {
+		t.Errorf("corrupt ref %s should have been deleted", badRef)
+	}
+	if !surviving[goodRef] {
+		t.Errorf("valid ref %s should have survived", goodRef)
+	}
+}
+
+// --- Auto-prune gate tests ---
+
+func TestCreateBackup_AutoPruneGate_BelowThreshold(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+	gitRun(t, dir, "symbolic-ref", "HEAD", "refs/heads/master")
+	a := New(dir)
+	commitFile(t, a, dir, "base.txt", "base")
+
+	// Create 19 backups — below the maxBackups=20 threshold. The 20th
+	// CreateBackup call must NOT prune (all 19 survive + the new one).
+	for i := 0; i < 19; i++ {
+		ref := fmt.Sprintf("refs/git-courer/backup/202501010000%02d_PRE", i)
+		gitRun(t, dir, "update-ref", ref, "HEAD")
+	}
+
+	before := len(backupRefs(t, a))
+	if before != 19 {
+		t.Fatalf("setup: expected 19 backups, got %d", before)
+	}
+
+	if _, err := a.CreateBackup("NEW", domain.StashNone); err != nil {
+		t.Fatalf("CreateBackup: %v", err)
+	}
+
+	after := backupRefs(t, a)
+	if len(after) != 20 {
+		t.Errorf("expected 20 backups after create (no prune), got %d", len(after))
+	}
+}
+
+func TestCreateBackup_AutoPruneGate_AtThreshold(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+	gitRun(t, dir, "symbolic-ref", "HEAD", "refs/heads/master")
+	a := New(dir)
+	commitFile(t, a, dir, "base.txt", "base")
+
+	// Create 20 old reachable backups — at the threshold. They are all old
+	// enough (45d) and reachable from HEAD, so the auto-prune inside the next
+	// CreateBackup will delete them, then create the new ref.
+	old := time.Now().Add(-45 * 24 * time.Hour)
+	for i := 0; i < 20; i++ {
+		ts := old.Add(time.Duration(i) * time.Second)
+		ref := fmt.Sprintf("refs/git-courer/backup/%s_OLD%02d", ts.Format("20060102150405"), i)
+		gitRun(t, dir, "update-ref", ref, "HEAD")
+	}
+	if got := len(backupRefs(t, a)); got != 20 {
+		t.Fatalf("setup: expected 20 backups, got %d", got)
+	}
+
+	// This call hits the gate (count >= maxBackups) → auto-prune deletes the 20
+	// old backups, then creates the new ref.
+	if _, err := a.CreateBackup("NEW", domain.StashNone); err != nil {
+		t.Fatalf("CreateBackup: %v", err)
+	}
+
+	surviving := backupRefs(t, a)
+	// The 20 old backups are pruned; only the new one remains.
+	if len(surviving) != 1 {
+		t.Errorf("expected 1 backup after auto-prune+create, got %d (%v)", len(surviving), surviving)
+	}
+}
+
+// TestCreateBackup_AutoPruneGate_PruneErrorDoesNotBlock verifies that even when
+// PruneBackups cannot reduce the count (all backups recent+reachable), a new
+// CreateBackup still succeeds and creates its ref.
+func TestCreateBackup_AutoPruneGate_PruneErrorDoesNotBlock(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+	gitRun(t, dir, "symbolic-ref", "HEAD", "refs/heads/master")
+	a := New(dir)
+	commitFile(t, a, dir, "base.txt", "base")
+
+	// 20 recent reachable backups — auto-prune will run but keep all of them.
+	for i := 0; i < 20; i++ {
+		ref := fmt.Sprintf("refs/git-courer/backup/%s_RC%02d",
+			time.Now().Add(time.Duration(-i)*time.Second).Format("20060102150405"), i)
+		gitRun(t, dir, "update-ref", ref, "HEAD")
+	}
+
+	backup, err := a.CreateBackup("NEW", domain.StashNone)
+	if err != nil {
+		t.Fatalf("CreateBackup must succeed even if prune cannot reduce count: %v", err)
+	}
+	if backup.Ref == "" {
+		t.Fatal("CreateBackup returned empty ref")
+	}
+	surviving := backupRefs(t, a)
+	if !surviving[backup.Ref] {
+		t.Errorf("new backup ref %s was not created", backup.Ref)
+	}
 }

--- a/internal/adapters/git/exec_backup.go
+++ b/internal/adapters/git/exec_backup.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"fmt"
+	"log"
 	"path/filepath"
 	"strings"
 	"time"
@@ -9,9 +10,26 @@ import (
 	"github.com/blak0p/git-courer/internal/core/domain"
 )
 
+// maxBackups is the auto-prune threshold: when the existing backup count
+// reaches this value, CreateBackup fires PruneBackups(30d) before creating a
+// new ref. Prune failure is logged but never blocks backup creation.
+const maxBackups = 20
+
 func (a *ExecAdapter) CreateBackup(operation string, mode domain.StashMode) (domain.Backup, error) {
 	timestamp := time.Now().Format("20060102150405")
 	ref := fmt.Sprintf("refs/git-courer/backup/%s_%s", timestamp, operation)
+
+	// Auto-prune gate: prune before creating a new ref when the backup count
+	// has reached the threshold. Prune failure MUST NOT block the backup.
+	if backups, lErr := a.ListBackups(); lErr != nil {
+		log.Printf("[WARN] backup: failed to list backups before auto-prune: %v", lErr)
+	} else if len(backups) >= maxBackups {
+		if pErr := a.PruneBackups(30 * 24 * time.Hour); pErr != nil {
+			// Prune failure is logged (preserving the wrapped cause in the
+			// message) but MUST NOT block the backup — the ref still gets created.
+			log.Printf("[WARN] backup: auto-prune before %s failed: %v", operation, pErr)
+		}
+	}
 
 	_, err := a.runGit("update-ref", "-m", fmt.Sprintf("git-courer backup: %s", operation), ref, "HEAD")
 	if err != nil {
@@ -116,15 +134,144 @@ func (a *ExecAdapter) ListBackups() ([]domain.Backup, error) {
 func (a *ExecAdapter) PruneBackups(olderThan time.Duration) error {
 	backups, err := a.ListBackups()
 	if err != nil {
-		return err
+		// ListBackups uses %(contents) which fails when a ref points at a
+		// missing object. Recover by listing refnames only — the commit is
+		// resolved per-ref below, and corrupt refs are deleted there. This
+		// keeps ListBackups' behavior unchanged while letting PruneBackups
+		// honor its corrupt-ref recovery contract.
+		log.Printf("[WARN] backup: ListBackups failed during prune, falling back to refname-only listing: %v", err)
+		backups, err = a.listBackupRefs()
+		if err != nil {
+			return fmt.Errorf("listing backup refs for prune: %w", err)
+		}
 	}
+
+	// Collect tips: HEAD + every local branch tip from refs/heads/.
+	tips, err := a.collectReachabilityTips()
+	if err != nil {
+		return fmt.Errorf("collecting reachability tips: %w", err)
+	}
+
 	now := time.Now()
 	for _, b := range backups {
-		if now.Sub(b.CreatedAt) > olderThan {
-			a.DeleteBackup(b)
+		// Resolve the backup's target commit. A ref that cannot be resolved is
+		// corrupt/dangling — recover by deleting it and continuing the loop.
+		commit, err := a.resolveBackupCommit(b.Ref)
+		if err != nil {
+			log.Printf("[WARN] backup: cannot resolve commit for %s, deleting: %v", b.Ref, err)
+			if dErr := a.DeleteBackup(b); dErr != nil {
+				log.Printf("[WARN] backup: failed to delete corrupt ref %s: %v", b.Ref, dErr)
+			}
+			continue
+		}
+
+		// Reachability: a backup is reachable if its commit is an ancestor of
+		// HEAD or any local branch tip. Short-circuit on the first match.
+		reachable := a.isReachable(commit, tips)
+
+		switch {
+		case !reachable:
+			// Unreachable from all tips — delete regardless of age.
+			if dErr := a.DeleteBackup(b); dErr != nil {
+				log.Printf("[WARN] backup: failed to delete unreachable ref %s: %v", b.Ref, dErr)
+			}
+		case now.Sub(b.CreatedAt) > olderThan:
+			// Reachable AND older than the window — delete.
+			if dErr := a.DeleteBackup(b); dErr != nil {
+				log.Printf("[WARN] backup: failed to delete stale ref %s: %v", b.Ref, dErr)
+			}
+		default:
+			// Reachable and recent — keep.
 		}
 	}
 	return nil
+}
+
+// listBackupRefs lists backup refs by refname only (without resolving the
+// target object), used as a fallback when ListBackups fails due to a corrupt
+// ref. The returned Backup entries carry Ref/Operation/CreatedAt; the target
+// commit is resolved later per-ref by resolveBackupCommit.
+func (a *ExecAdapter) listBackupRefs() ([]domain.Backup, error) {
+	out, err := a.runGit("for-each-ref", "refs/git-courer/backup/", "--format=%(refname)")
+	if err != nil {
+		return nil, err
+	}
+	var backups []domain.Backup
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		ref := strings.TrimSpace(line)
+		if ref == "" {
+			continue
+		}
+		name := filepath.Base(ref)
+		nameParts := strings.SplitN(name, "_", 2)
+		if len(nameParts) < 2 {
+			continue
+		}
+		t, _ := time.Parse("20060102150405", nameParts[0])
+		backups = append(backups, domain.Backup{
+			Ref:       ref,
+			Operation: nameParts[1],
+			CreatedAt: t,
+		})
+	}
+	return backups, nil
+}
+
+// collectReachabilityTips returns the commit OIDs for HEAD and every local
+// branch tip under refs/heads/. HEAD is always first.
+func (a *ExecAdapter) collectReachabilityTips() ([]string, error) {
+	var tips []string
+
+	head, err := a.runGit("rev-parse", "HEAD")
+	if err != nil {
+		return nil, fmt.Errorf("resolving HEAD: %w", err)
+	}
+	if h := strings.TrimSpace(head); h != "" {
+		tips = append(tips, h)
+	}
+
+	// Local branch tips: one OID per line.
+	out, err := a.runGit("for-each-ref", "refs/heads/", "--format=%(objectname)")
+	if err != nil {
+		return nil, fmt.Errorf("listing local branch tips: %w", err)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if oid := strings.TrimSpace(line); oid != "" {
+			tips = append(tips, oid)
+		}
+	}
+	return tips, nil
+}
+
+// resolveBackupCommit resolves a backup ref to its target commit OID via
+// `git rev-parse {ref}^{commit}`. Returns an error if the ref is corrupt or
+// points at an object that cannot be peeled to a commit.
+func (a *ExecAdapter) resolveBackupCommit(ref string) (string, error) {
+	out, err := a.runGit("rev-parse", fmt.Sprintf("%s^{commit}", ref))
+	if err != nil {
+		return "", fmt.Errorf("rev-parse %s^{commit}: %w", ref, err)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// isReachable reports whether commit is an ancestor of ANY of the given tips.
+// It short-circuits on the first reachable tip. A tip identical to commit is
+// also considered reachable (merge-base --is-ancestor is reflexive for equal
+// commits).
+func (a *ExecAdapter) isReachable(commit string, tips []string) bool {
+	for _, tip := range tips {
+		if tip == "" {
+			continue
+		}
+		// git merge-base --is-ancestor exits 0 when commit is an ancestor of
+		// tip (inclusive), non-zero otherwise. runGit returns an error on
+		// non-zero exit, so a non-nil error here means "not an ancestor of
+		// this tip" — try the next one.
+		if _, err := a.runGit("merge-base", "--is-ancestor", commit, tip); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 func (a *ExecAdapter) hasUnstaged() (bool, error) {

--- a/internal/delivery/mcp/branch/branch.go
+++ b/internal/delivery/mcp/branch/branch.go
@@ -34,14 +34,17 @@ func (h *Handler) HandleBranch(_ context.Context, req mcpgo.CallToolRequest) (*m
 	validBranchCommands := []string{"CREATE", "DELETE", "RENAME", "SWITCH", "LIST"}
 
 	switch command {
-	case "CREATE", "DELETE", "RENAME", "SWITCH":
+	case "CREATE":
+		// CREATE is non-destructive — no backup.
+	case "DELETE":
 		// Safety gate for destructive branch commands
-		if command == "DELETE" {
-			if result, err := shared.CheckSafetyGate("branch_delete", false, confirmed); result != nil || err != nil {
-				return result, err
-			}
+		if result, err := shared.CheckSafetyGate("branch_delete", false, confirmed); result != nil || err != nil {
+			return result, err
 		}
-		// All branch commands modify state — create backup
+		// DELETE is destructive — back up for undo safety.
+		_, _ = h.git.CreateBackup(command, domain.StashNone)
+	case "RENAME", "SWITCH":
+		// RENAME/SWITCH can move the ref HEAD points at — back up for undo.
 		_, _ = h.git.CreateBackup(command, domain.StashNone)
 	case "LIST":
 		// read-only bypasses safety checks and backup creation

--- a/internal/delivery/mcp/branch/branch_test.go
+++ b/internal/delivery/mcp/branch/branch_test.go
@@ -26,7 +26,6 @@ func TestHandleBranch(t *testing.T) {
 			command: "CREATE",
 			args:    map[string]any{"branch_name": "new-branch"},
 			setup: func(m *MockGit) {
-				m.On("CreateBackup", "CREATE", domain.StashNone).Return(domain.Backup{}, nil)
 				m.On("Branch", "new-branch").Return("created", nil)
 			},
 			wantInJSON: "Created branch: new-branch",
@@ -36,7 +35,6 @@ func TestHandleBranch(t *testing.T) {
 			command: "CREATE",
 			args:    map[string]any{"branch_name": "feature", "switch": true},
 			setup: func(m *MockGit) {
-				m.On("CreateBackup", "CREATE", domain.StashNone).Return(domain.Backup{}, nil)
 				m.On("Status").Return(domain.Status{Branch: "main", IsClean: true}, nil)
 				m.On("Branch", "feature").Return("created", nil)
 				m.On("Switch", "feature").Return(nil)
@@ -48,7 +46,6 @@ func TestHandleBranch(t *testing.T) {
 			command: "CREATE",
 			args:    map[string]any{"branch_name": "feature", "switch": true},
 			setup: func(m *MockGit) {
-				m.On("CreateBackup", "CREATE", domain.StashNone).Return(domain.Backup{}, nil)
 				m.On("Status").Return(domain.Status{Branch: "main", IsClean: false, Modified: 1}, nil)
 				m.On("Stash", []string(nil)).Return("stashed", nil)
 				m.On("Branch", "feature").Return("created", nil)
@@ -101,7 +98,7 @@ func TestHandleBranch(t *testing.T) {
 			name:       "CREATE missing branch_name returns error",
 			command:    "CREATE",
 			args:       map[string]any{},
-			setup:      func(m *MockGit) { m.On("CreateBackup", "CREATE", domain.StashNone).Return(domain.Backup{}, nil) },
+			setup:      func(m *MockGit) {},
 			wantErr:    true,
 			errContain: "branch_name is required for CREATE",
 		},
@@ -220,7 +217,6 @@ func TestHandleBranch_ValidJSON(t *testing.T) {
 		mockGit := new(MockGit)
 		handler := NewHandler(mockGit)
 
-		mockGit.On("CreateBackup", "CREATE", domain.StashNone).Return(domain.Backup{}, nil)
 		mockGit.On("Branch", "feature").Return("created", nil)
 
 		req := mcpgo.CallToolRequest{

--- a/internal/delivery/mcp/handlers_safety_test.go
+++ b/internal/delivery/mcp/handlers_safety_test.go
@@ -398,7 +398,6 @@ func TestHandleSync_PushWithConfirmed(t *testing.T) {
 	mockGit := new(MockGit)
 	handler := mcpsync.NewHandler(mockGit)
 
-	mockGit.On("CreateBackup", "PUSH", domain.StashNone).Return(domain.Backup{}, nil)
 	mockGit.On("PushTo", "origin").Return("pushed", nil)
 
 	req := mcpgo.CallToolRequest{

--- a/internal/delivery/mcp/stage/handler_test.go
+++ b/internal/delivery/mcp/stage/handler_test.go
@@ -227,7 +227,6 @@ func TestHandler_HandleStage(t *testing.T) {
 			command: "RM",
 			args:    map[string]any{"target_paths": "old.go"},
 			setup: func(m *mockGitForStage) {
-				m.On("CreateBackup", "RM", domain.StashNone).Return(domain.Backup{}, nil)
 				m.On("Remove", []string{"old.go"}).Return(nil)
 			},
 			expected: "1 files removed",
@@ -237,7 +236,6 @@ func TestHandler_HandleStage(t *testing.T) {
 			command: "RESTORE",
 			args:    map[string]any{"target_paths": "file.go"},
 			setup: func(m *mockGitForStage) {
-				m.On("CreateBackup", "RESTORE", domain.StashNone).Return(domain.Backup{}, nil)
 				m.On("Restore", []string{"file.go"}).Return(nil)
 			},
 			expected: "1 files restored",
@@ -411,7 +409,6 @@ func TestHandler_HandleStage_CleanDryRun(t *testing.T) {
 
 func TestHandler_HandleStash_Save(t *testing.T) {
 	git := new(mockGitForStage)
-	git.On("CreateBackup", "SAVE", domain.StashNone).Return(domain.Backup{}, nil)
 	git.On("Stash", []string(nil)).Return("stashed", nil)
 
 	h := NewHandler(git, nil)
@@ -436,7 +433,6 @@ func TestHandler_HandleStash_Save(t *testing.T) {
 
 func TestHandler_HandleStash_SaveWithMessage(t *testing.T) {
 	git := new(mockGitForStage)
-	git.On("CreateBackup", "SAVE", domain.StashNone).Return(domain.Backup{}, nil)
 	git.On("Stash", []string{"my msg"}).Return("saved", nil)
 
 	h := NewHandler(git, nil)
@@ -456,7 +452,6 @@ func TestHandler_HandleStash_SaveWithMessage(t *testing.T) {
 
 func TestHandler_HandleStash_Pop(t *testing.T) {
 	git := new(mockGitForStage)
-	git.On("CreateBackup", "POP", domain.StashNone).Return(domain.Backup{}, nil)
 	git.On("StashPop").Return("restored", nil)
 
 	h := NewHandler(git, nil)
@@ -527,7 +522,6 @@ func TestHandler_HandleStash_UnknownCommand(t *testing.T) {
 
 func TestHandler_HandleStash_PopWithStashIndex(t *testing.T) {
 	git := new(mockGitForStage)
-	git.On("CreateBackup", "POP", domain.StashNone).Return(domain.Backup{}, nil)
 	git.On("StashApply", "2").Return("applied", nil)
 
 	h := NewHandler(git, nil)
@@ -552,7 +546,6 @@ func TestHandler_HandleStash_PopWithStashIndex(t *testing.T) {
 
 func TestHandler_HandleStash_PopWithoutStashIndex(t *testing.T) {
 	git := new(mockGitForStage)
-	git.On("CreateBackup", "POP", domain.StashNone).Return(domain.Backup{}, nil)
 	git.On("StashPop").Return("restored", nil)
 
 	h := NewHandler(git, nil)

--- a/internal/delivery/mcp/stage/handlers.go
+++ b/internal/delivery/mcp/stage/handlers.go
@@ -78,9 +78,6 @@ func (h *Handler) HandleStage(_ context.Context, req mcpgo.CallToolRequest) (*mc
 
 	paths := shared.GetStringParam(params, "target_paths", "")
 
-	// Auto-create backup before destructive stage operations for undo safety
-	_, _ = h.git.CreateBackup(command, domain.StashNone)
-
 	var err error
 	var result string
 
@@ -94,6 +91,8 @@ func (h *Handler) HandleStage(_ context.Context, req mcpgo.CallToolRequest) (*mc
 		err = h.git.Restore(pathList)
 		result = shared.WriteHintedResultJSON("RESTORE", err == nil, fmt.Sprintf("%d files restored", len(pathList)), "consider calling status to verify working tree")
 	case "CLEAN":
+		// CLEAN irrevocably removes untracked files — back up for undo safety.
+		_, _ = h.git.CreateBackup(command, domain.StashNone)
 		err = h.git.Clean()
 		result = shared.WriteResultJSON("CLEAN", err == nil, "Untracked files cleaned")
 	}
@@ -122,12 +121,8 @@ func (h *Handler) HandleStash(_ context.Context, req mcpgo.CallToolRequest) (*mc
 
 	switch command {
 	case "SAVE":
-		// Auto-create backup before stash save for undo safety
-		_, _ = h.git.CreateBackup(command, domain.StashNone)
 		return h.handleStashSave(params)
 	case "POP":
-		// Auto-create backup before stash pop for undo safety
-		_, _ = h.git.CreateBackup(command, domain.StashNone)
 		return h.handleStashPop(params)
 	case "SHOW":
 		return h.handleStashShow(params)

--- a/internal/delivery/mcp/sync/sync.go
+++ b/internal/delivery/mcp/sync/sync.go
@@ -59,14 +59,13 @@ func (h *Handler) HandleSync(_ context.Context, req mcpgo.CallToolRequest) (*mcp
 	var err error
 	var result string
 
-	// FETCH, PULL, PUSH don't stash by default, but CreateBackup writes to log
-	_, _ = h.git.CreateBackup(command, domain.StashNone)
-
 	switch command {
 	case "FETCH":
 		_, err = h.git.Fetch()
 		result = shared.WriteResultJSON("FETCH", err == nil, "Fetched from remote")
 	case "PULL":
+		// PULL mutates HEAD via merge/rebase — back up for undo safety.
+		_, _ = h.git.CreateBackup(command, domain.StashNone)
 		if branch != "" {
 			_, err = h.git.PullFromBranch(remote, branch)
 		} else {
@@ -95,6 +94,8 @@ func (h *Handler) HandleSync(_ context.Context, req mcpgo.CallToolRequest) (*mcp
 		result = shared.WriteResultJSON("PUSH", err == nil, "Pushed to "+remote+" — changes are now on remote. Remember: call pr-review before creating a PR.")
 		// branch=="" means no ref push sidecar; do not call CurrentBranch
 	case "AUTO":
+		// AUTO runs Pull then Push — Pull mutates HEAD, so back up for undo.
+		_, _ = h.git.CreateBackup(command, domain.StashNone)
 		var outputs []string
 		// 1. Fetch
 		if fOut, fErr := h.git.Fetch(); fErr != nil {

--- a/internal/delivery/mcp/sync/sync_test.go
+++ b/internal/delivery/mcp/sync/sync_test.go
@@ -63,8 +63,6 @@ func TestHandleSync_PullWithoutBranch(t *testing.T) {
 
 func TestHandleSync_PushWithBranch(t *testing.T) {
 	gitMock := new(MockGit)
-	backup := domain.Backup{Ref: "ref", Operation: "PUSH"}
-	gitMock.On("CreateBackup", "PUSH", domain.StashNone).Return(backup, nil)
 	gitMock.On("PushToBranch", "origin", "feature").Return("pushed feature to origin", nil).Once()
 	gitMock.On("PushToBranch", "origin", "refs/courer/feature").Return("pushed ref", nil)
 
@@ -91,8 +89,6 @@ func TestHandleSync_PushWithBranch(t *testing.T) {
 
 func TestHandleSync_PushWithoutBranch(t *testing.T) {
 	gitMock := new(MockGit)
-	backup := domain.Backup{Ref: "ref", Operation: "PUSH"}
-	gitMock.On("CreateBackup", "PUSH", domain.StashNone).Return(backup, nil)
 	gitMock.On("PushTo", "origin").Return("pushed", nil)
 
 	h := NewHandler(gitMock)


### PR DESCRIPTION
Closes #180

## Summary
- Rewrite `PruneBackups` from time-based to reachability (HEAD + local branches) + 30-day age
- Add auto-prune gate in `CreateBackup`: fires `PruneBackups(30d)` when >= 20 backups exist
- Stop creating backups for 7 useless operations (PUSH, FETCH, branch CREATE, stage RM/RESTORE, stash SAVE/POP)
- Handle corrupt refs gracefully: delete and continue

## Changes
| File | Change |
|------|--------|
| `internal/adapters/git/exec_backup.go` | Rewrite PruneBackups, add auto-prune gate, reachability helpers |
| `internal/adapters/git/backup_test.go` | Tests for reachability, corrupt refs, auto-prune threshold |
| `internal/delivery/mcp/sync/sync.go` | Backup only on PULL/AUTO |
| `internal/delivery/mcp/branch/branch.go` | Backup only on DELETE/RENAME/SWITCH |
| `internal/delivery/mcp/stage/handlers.go` | Backup only on CLEAN |
| `internal/delivery/mcp/sync/sync_test.go` | Updated mock expectations |
| `internal/delivery/mcp/branch/branch_test.go` | Updated mock expectations |
| `internal/delivery/mcp/stage/handler_test.go` | Updated mock expectations |
| `internal/delivery/mcp/handlers_safety_test.go` | Updated mock expectations |

## Test Plan
- [x] `go test ./...` — 44 packages green
- [x] `go vet ./...` — clean
- [x] 13 acceptance criteria verified against spec