### PR TITLE
fix: deleted files produce `delete:` commit type instead of `refactor:`

### DIFF
--- a/internal/core/domain/commit_type.go
+++ b/internal/core/domain/commit_type.go
@@ -22,6 +22,8 @@ func CommitTypeWeight(commitType string) int {
 		return 8
 	case "refactor":
 		return 7
+	case "delete":
+		return 7
 	case "chore", "ci", "docs":
 		return 6
 	case "test":
@@ -60,7 +62,7 @@ func InferCommitType(chunk DiffChunk) string {
 
 	// Priority 3: Deleted file detection
 	if strings.Contains(chunk.Diff, "deleted file mode") {
-		return "refactor"
+		return "delete"
 	}
 
 	// Priority 4b: Path-type detection via DefaultPathTypes

--- a/internal/core/domain/commit_type_test.go
+++ b/internal/core/domain/commit_type_test.go
@@ -58,14 +58,14 @@ func TestInferCommitType_NewFileDetected(t *testing.T) {
 	}
 }
 
-// TestInferCommitType_DeletedFile verifies deleted file → "refactor".
+// TestInferCommitType_DeletedFile verifies deleted file → "delete".
 func TestInferCommitType_DeletedFile(t *testing.T) {
 	t.Parallel()
 
 	chunk := DiffChunk{Diff: "deleted file mode 100644\n--- a/old.go\n+++ /dev/null\n"}
 	got := InferCommitType(chunk)
-	if got != "refactor" {
-		t.Errorf("InferCommitType for deleted file = %q, want %q", got, "refactor")
+	if got != "delete" {
+		t.Errorf("InferCommitType for deleted file = %q, want %q", got, "delete")
 	}
 }
 

--- a/internal/infra/classifier/classifier.go
+++ b/internal/infra/classifier/classifier.go
@@ -369,7 +369,7 @@ func LabelWeight(labelType string) (commitType string, weight int) {
 	case "MOD_BODY_CALL":
 		return "", 6
 	case "DELETED_FUNC", "DELETED_TYPE":
-		return "refactor", 7
+		return "delete", 7
 	case "MOD_SIG":
 		return "fix", 8
 	case "MOD_TYPE":

--- a/internal/infra/classifier/classifier_test.go
+++ b/internal/infra/classifier/classifier_test.go
@@ -301,8 +301,8 @@ func TestClassify_DELETED(t *testing.T) {
 
 	commitType, confidence := c.Classify(chunk)
 
-	if commitType != "refactor" {
-		t.Errorf("CommitType = %q, want refactor for DELETED_FUNC", commitType)
+	if commitType != "delete" {
+		t.Errorf("CommitType = %q, want delete for DELETED_FUNC", commitType)
 	}
 	if confidence < 0.85 {
 		t.Errorf("Confidence = %f, want >= 0.85", confidence)
@@ -323,10 +323,10 @@ func TestClassify_DELETED_FUNC_breaking(t *testing.T) {
 		commitType, confidence := c.Classify(chunk)
 
 		if !strings.HasSuffix(commitType, "!") {
-			t.Errorf("CommitType = %q, want refactor! or feat! for DELETED_FUNC BREAKING", commitType)
+			t.Errorf("CommitType = %q, want delete! or feat! for DELETED_FUNC BREAKING", commitType)
 		}
-		if !strings.HasPrefix(commitType, "refactor") && !strings.HasPrefix(commitType, "feat") {
-			t.Errorf("CommitType = %q, want refactor! or feat! prefix for DELETED_FUNC BREAKING", commitType)
+		if !strings.HasPrefix(commitType, "delete") && !strings.HasPrefix(commitType, "feat") {
+			t.Errorf("CommitType = %q, want delete! or feat! prefix for DELETED_FUNC BREAKING", commitType)
 		}
 		if confidence < 0.90 {
 			t.Errorf("Confidence = %f, want >= 0.90 for single DELETED_FUNC BREAKING", confidence)
@@ -363,7 +363,7 @@ func TestClassify_DELETED_TYPE_breaking(t *testing.T) {
 		commitType, confidence := c.Classify(chunk)
 
 		if !strings.HasSuffix(commitType, "!") {
-			t.Errorf("CommitType = %q, want refactor! or feat! for DELETED_TYPE BREAKING", commitType)
+			t.Errorf("CommitType = %q, want delete! or feat! for DELETED_TYPE BREAKING", commitType)
 		}
 		if confidence < 0.90 {
 			t.Errorf("Confidence = %f, want >= 0.90 for DELETED_TYPE BREAKING", confidence)
@@ -1049,8 +1049,8 @@ func TestLabelWeight(t *testing.T) {
 		{name: "MOD_SIG_maps_to_fix_8", labelType: "MOD_SIG", wantType: "fix", wantWeight: 8},
 		// Fuerza 7: refactor
 		{name: "MOD_BODY_REORDER_maps_to_refactor_7", labelType: "MOD_BODY_REORDER", wantType: "refactor", wantWeight: 7},
-		{name: "DELETED_FUNC_maps_to_refactor_7", labelType: "DELETED_FUNC", wantType: "refactor", wantWeight: 7},
-		{name: "DELETED_TYPE_maps_to_refactor_7", labelType: "DELETED_TYPE", wantType: "refactor", wantWeight: 7},
+		{name: "DELETED_FUNC_maps_to_delete_7", labelType: "DELETED_FUNC", wantType: "delete", wantWeight: 7},
+		{name: "DELETED_TYPE_maps_to_delete_7", labelType: "DELETED_TYPE", wantType: "delete", wantWeight: 7},
 		{name: "MOD_TYPE_maps_to_refactor_7", labelType: "MOD_TYPE", wantType: "refactor", wantWeight: 7},
 		// Fuerza 6: chore / ci / docs
 		{name: "CONFIG_maps_to_chore_6", labelType: "CONFIG", wantType: "chore", wantWeight: 6},
@@ -1405,12 +1405,12 @@ func TestInferCommitType(t *testing.T) {
 			wantType: "docs",
 		},
 		{
-			name: "deleted_file_returns_refactor",
+			name: "deleted_file_returns_delete",
 			chunk: domain.DiffChunk{
 				Files: []string{"internal/legacy/deprecated.go"},
 				Diff:  "diff --git a/internal/legacy/deprecated.go b/internal/legacy/deprecated.go\ndeleted file mode 100644\n--- a/internal/legacy/deprecated.go\n+++ /dev/null\n@@ -1,10 +0,0 @@\n-package legacy\n",
 			},
-			wantType: "refactor",
+			wantType: "delete",
 		},
 		{
 			name: "non_empty_commit_type_returns_existing",


### PR DESCRIPTION
Closes #51

## Summary

- `DELETED_FUNC` and `DELETED_TYPE` labels now return `delete` instead of `refactor`
- `InferCommitType()` fallback for `deleted file mode` now returns `delete`
- `CommitTypeWeight()` recognizes `delete` with weight 7
- All tests updated and passing

## Changes

| File | Change |
|------|--------|
| `internal/infra/classifier/classifier.go` | `LabelWeight()` — `refactor` → `delete` for DELETED_* |
| `internal/core/domain/commit_type.go` | `InferCommitType()` + `CommitTypeWeight()` — add `delete` support |
| `internal/infra/classifier/classifier_test.go` | Update expected values in DELETED tests |
| `internal/core/domain/commit_type_test.go` | Update expected value for deleted file test |

## Test Plan

- [x] `go test ./internal/infra/classifier/...` — passes
- [x] `go test ./internal/core/domain/...` — passes
- [x] `LabelWeight("DELETED_FUNC")` returns `"delete", 7`
- [x] `LabelWeight("DELETED_TYPE")` returns `"delete", 7`
- [x] `InferCommitType()` with `deleted file mode` returns `"delete"`
- [x] `CommitTypeWeight("delete")` returns `7`