### PR TITLE
feat(branch): add from param to branch CREATE + clarify sync PULL docs

### DIFF
--- a/internal/adapters/git/exec_write_branch.go
+++ b/internal/adapters/git/exec_write_branch.go
@@ -4,6 +4,12 @@ func (a *ExecAdapter) Branch(name string) (string, error) {
 	return a.runGit("branch", name)
 }
 
+// BranchFrom creates a new branch at the given start point.
+// When from is empty, behaves like Branch (creates from HEAD).
+func (a *ExecAdapter) BranchFrom(name, from string) (string, error) {
+	return a.runGit("branch", name, from)
+}
+
 func (a *ExecAdapter) RenameBranch(oldName, newName string) (string, error) {
 	return a.runGit("branch", "-m", oldName, newName)
 }

--- a/internal/adapters/git/exec_write_branch.go
+++ b/internal/adapters/git/exec_write_branch.go
@@ -7,6 +7,9 @@ func (a *ExecAdapter) Branch(name string) (string, error) {
 // BranchFrom creates a new branch at the given start point.
 // When from is empty, behaves like Branch (creates from HEAD).
 func (a *ExecAdapter) BranchFrom(name, from string) (string, error) {
+	if from == "" {
+		return a.runGit("branch", name)
+	}
 	return a.runGit("branch", name, from)
 }
 

--- a/internal/adapters/git/exec_write_test.go
+++ b/internal/adapters/git/exec_write_test.go
@@ -68,6 +68,36 @@ func TestExecAdapterBranch(t *testing.T) {
 	adapter.DeleteBranch("test-branch", false)
 }
 
+// TestExecAdapterBranchFrom tests creating a branch at a specific start point.
+func TestExecAdapterBranchFrom(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+
+	// Make initial commit on main so HEAD is a valid start point
+	os.WriteFile(filepath.Join(dir, "initial.txt"), []byte("initial"), 0644)
+	adapter := New(dir)
+	adapter.Add([]string{"initial.txt"})
+	adapter.Commit("Initial commit")
+
+	// Create a branch from HEAD (equivalent to Branch when from is empty)
+	_, err := adapter.BranchFrom("from-head", "")
+	if err != nil {
+		t.Fatalf("BranchFrom() with empty from error = %v", err)
+	}
+
+	// Create a branch from an explicit start point (the just-created branch)
+	_, err = adapter.BranchFrom("from-branch", "from-head")
+	if err != nil {
+		t.Fatalf("BranchFrom() with start point error = %v", err)
+	}
+
+	// Neither call should switch the current branch
+	current, _ := adapter.CurrentBranch()
+	if current != "main" && current != "master" {
+		t.Errorf("BranchFrom() should NOT switch branch, got %q", current)
+	}
+}
+
 // TestExecAdapterCommit tests commit operation.
 func TestExecAdapterCommit(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/adapters/git/session.go
+++ b/internal/adapters/git/session.go
@@ -140,6 +140,9 @@ func (s *sessionGit) StashDrop(index string) (string, error)  { return s.base.St
 func (s *sessionGit) StashClear() (string, error)             { return s.base.StashClear() }
 func (s *sessionGit) Switch(branch string) error              { return s.base.Switch(branch) }
 func (s *sessionGit) Branch(name string) (string, error)      { return s.base.Branch(name) }
+func (s *sessionGit) BranchFrom(name, from string) (string, error) {
+	return s.base.BranchFrom(name, from)
+}
 func (s *sessionGit) DeleteBranch(name string, force bool) (string, error) {
 	return s.base.DeleteBranch(name, force)
 }

--- a/internal/adapters/git/session_fake_test.go
+++ b/internal/adapters/git/session_fake_test.go
@@ -203,4 +203,9 @@ func (f *fakeGit) HashObject(d []byte) (string, error)   { f.mark("HashObject");
 func (f *fakeGit) ShowRef(p string) (string, error)      { f.mark("ShowRef"); return "", nil }
 func (f *fakeGit) GitCommonDir() (string, error)         { f.mark("GitCommonDir"); return "", nil }
 
+func (f *fakeGit) BranchFrom(name, from string) (string, error) {
+	f.mark("BranchFrom")
+	return "", nil
+}
+
 var _ ports.Git = (*fakeGit)(nil)

--- a/internal/core/ports/git.go
+++ b/internal/core/ports/git.go
@@ -74,6 +74,10 @@ type Git interface {
 	StashClear() (string, error)
 	Switch(branch string) error
 	Branch(name string) (string, error)
+	// BranchFrom creates a new branch at the given start point (ref).
+	// When from is empty, it behaves identically to Branch (creates from HEAD).
+	// Supports local branches, remote refs (origin/...), tags, and commit hashes.
+	BranchFrom(name, from string) (string, error)
 	DeleteBranch(name string, force bool) (string, error)
 	RenameBranch(oldName, newName string) (string, error)
 	DeleteRemoteBranch(name string) error

--- a/internal/delivery/mcp/branch/branch.go
+++ b/internal/delivery/mcp/branch/branch.go
@@ -16,7 +16,7 @@ func (h *Handler) HandleBranch(_ context.Context, req mcpgo.CallToolRequest) (*m
 	params, _ := req.Params.Arguments.(map[string]any)
 
 	// Validate that all params are known for this tool
-	if result, err := shared.ValidateKnownParams(params, []string{"command", "branch_name", "new_branch_name", "force", "confirmed", "switch", "filter"}); result != nil || err != nil {
+	if result, err := shared.ValidateKnownParams(params, []string{"command", "branch_name", "new_branch_name", "force", "confirmed", "switch", "filter", "from"}); result != nil || err != nil {
 		return result, err
 	}
 
@@ -79,6 +79,7 @@ func (h *Handler) handleBranchCreate(params map[string]any) (*mcpgo.CallToolResu
 	}
 
 	name := shared.GetStringParam(params, "branch_name", "")
+	from := shared.GetStringParam(params, "from", "")
 	switchOn := false
 	if v, ok := params["switch"].(bool); ok {
 		switchOn = v
@@ -98,8 +99,14 @@ func (h *Handler) handleBranchCreate(params map[string]any) (*mcpgo.CallToolResu
 		}
 	}
 
-	if _, err := h.git.Branch(name); err != nil {
-		return shared.JSONErrorResult("CREATE", err)
+	if from != "" {
+		if _, err := h.git.BranchFrom(name, from); err != nil {
+			return shared.JSONErrorResult("CREATE", err)
+		}
+	} else {
+		if _, err := h.git.Branch(name); err != nil {
+			return shared.JSONErrorResult("CREATE", err)
+		}
 	}
 
 	if switchOn {

--- a/internal/delivery/mcp/branch/branch_test.go
+++ b/internal/delivery/mcp/branch/branch_test.go
@@ -3,6 +3,7 @@ package branch
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -29,6 +30,56 @@ func TestHandleBranch(t *testing.T) {
 				m.On("Branch", "new-branch").Return("created", nil)
 			},
 			wantInJSON: "Created branch: new-branch",
+		},
+		{
+			name:    "CREATE with from creates branch at start point",
+			command: "CREATE",
+			args:    map[string]any{"branch_name": "feature", "from": "origin/main"},
+			setup: func(m *MockGit) {
+				m.On("BranchFrom", "feature", "origin/main").Return("created", nil)
+			},
+			wantInJSON: "Created branch: feature",
+		},
+		{
+			name:    "CREATE without from falls back to Branch (backward compat)",
+			command: "CREATE",
+			args:    map[string]any{"branch_name": "feature"},
+			setup: func(m *MockGit) {
+				m.On("Branch", "feature").Return("created", nil)
+			},
+			wantInJSON: "Created branch: feature",
+		},
+		{
+			name:    "CREATE with empty from falls back to Branch",
+			command: "CREATE",
+			args:    map[string]any{"branch_name": "feature", "from": ""},
+			setup: func(m *MockGit) {
+				m.On("Branch", "feature").Return("created", nil)
+			},
+			wantInJSON: "Created branch: feature",
+		},
+		{
+			name:    "CREATE with from and switch on dirty tree",
+			command: "CREATE",
+			args:    map[string]any{"branch_name": "feature", "from": "origin/main", "switch": true},
+			setup: func(m *MockGit) {
+				m.On("Status").Return(domain.Status{Branch: "main", IsClean: false, Modified: 1}, nil)
+				m.On("Stash", []string(nil)).Return("stashed", nil)
+				m.On("BranchFrom", "feature", "origin/main").Return("created", nil)
+				m.On("Switch", "feature").Return(nil)
+				m.On("StashPop").Return("popped", nil)
+			},
+			wantInJSON: "Created and switched to branch: feature",
+		},
+		{
+			name:    "CREATE with from returns error when start point invalid",
+			command: "CREATE",
+			args:    map[string]any{"branch_name": "feature", "from": "origin/nope"},
+			setup: func(m *MockGit) {
+				m.On("BranchFrom", "feature", "origin/nope").Return("", fmt.Errorf("invalid start point"))
+			},
+			wantErr:    true,
+			errContain: "invalid start point",
 		},
 		{
 			name:    "CREATE with switch true clean tree",

--- a/internal/delivery/mcp/branch/mock_test.go
+++ b/internal/delivery/mcp/branch/mock_test.go
@@ -96,6 +96,11 @@ func (m *MockGit) Branch(name string) (string, error) {
 	return args.String(0), args.Error(1)
 }
 
+func (m *MockGit) BranchFrom(name, from string) (string, error) {
+	args := m.Called(name, from)
+	return args.String(0), args.Error(1)
+}
+
 func (m *MockGit) DeleteBranch(name string, force bool) (string, error) {
 	args := m.Called(name, force)
 	return args.String(0), args.Error(1)

--- a/internal/delivery/mcp/branch/registration.go
+++ b/internal/delivery/mcp/branch/registration.go
@@ -24,6 +24,7 @@ func Register(s *server.MCPServer, h Handlers) {
 			mcpgo.WithBoolean("force", mcpgo.Description("Force branch creation or deletion even when checks would fail. Use with caution.")),
 			mcpgo.WithBoolean("confirmed", mcpgo.Description("Required for DELETE. Without this, destructive operations are blocked.")),
 			mcpgo.WithBoolean("switch", mcpgo.Description("If true, creates the branch and switches to it in one call. Auto-stashes dirty working tree.")),
+			mcpgo.WithString("from", mcpgo.Description("Base ref to create the branch from. When omitted, creates from HEAD. Supports local branches, remote refs (origin/...), tags, and commit hashes.")),
 			mcpgo.WithString("filter", mcpgo.Description("Filter branches by location: LOCAL, REMOTE, ALL. Used when command is LIST."), mcpgo.Enum("LOCAL", "REMOTE", "ALL")),
 		),
 		h.HandleBranch,

--- a/internal/delivery/mcp/core/handler_test.go
+++ b/internal/delivery/mcp/core/handler_test.go
@@ -141,6 +141,7 @@ func (m *mockGit) StashDrop(index string) (string, error)               { panic(
 func (m *mockGit) StashClear() (string, error)                          { panic("unexpected") }
 func (m *mockGit) Switch(branch string) error                           { panic("unexpected") }
 func (m *mockGit) Branch(name string) (string, error)                   { panic("unexpected") }
+func (m *mockGit) BranchFrom(name, from string) (string, error)         { panic("unexpected") }
 func (m *mockGit) DeleteBranch(name string, force bool) (string, error) { panic("unexpected") }
 func (m *mockGit) RenameBranch(oldName, newName string) (string, error) { panic("unexpected") }
 func (m *mockGit) DeleteRemoteBranch(name string) error                 { panic("unexpected") }

--- a/internal/delivery/mcp/descriptions/descriptions.go
+++ b/internal/delivery/mcp/descriptions/descriptions.go
@@ -91,7 +91,7 @@ const (
 
 	DescStash = `Structured git stash. Save, restore, or inspect stashed changes. SAVE stores working tree changes. POP restores them. SHOW previews stash diff as structured JSON — no parsing git stash list text. Use before switching branches with dirty tree.`
 
-	DescSync = `Structured git push / git pull / git fetch. PUSH is IRREVERSIBLE and requires confirmed=true. PULL and FETCH create a backup before executing. Use FETCH to check remote changes without merging (safer than PULL). When branch is specified, pushes/pulls only that branch. Always call diff before pushing.`
+	DescSync = `Structured git push / git pull / git fetch. PUSH is IRREVERSIBLE and requires confirmed=true. PULL and FETCH create a backup before executing. Use FETCH to check remote changes without merging (safer than PULL). When branch is specified, the operation targets that specific branch regardless of the current branch — any remote branch can be pulled or pushed, not just the checked-out one. Always call diff before pushing.`
 
 	DescHistory = `Structured git log / git reflog / git blame. Show commit history (LOG), reflog (REFLOG), or line-by-line attribution (BLAME) with pagination and filtering. Structured JSON — no pager hangs, no unstructured text. Do NOT use raw git log. BLAME requires target_paths.`
 

--- a/internal/delivery/mcp/history/handlers_test.go
+++ b/internal/delivery/mcp/history/handlers_test.go
@@ -81,6 +81,7 @@ func (m *mockGitForHistory) StashDrop(index string) (string, error) { panic("une
 func (m *mockGitForHistory) StashClear() (string, error) { panic("unexpected") }
 func (m *mockGitForHistory) Switch(branch string) error { panic("unexpected") }
 func (m *mockGitForHistory) Branch(name string) (string, error) { panic("unexpected") }
+func (m *mockGitForHistory) BranchFrom(name, from string) (string, error) { panic("unexpected") }
 func (m *mockGitForHistory) DeleteBranch(name string, force bool) (string, error) { panic("unexpected") }
 func (m *mockGitForHistory) RenameBranch(oldName, newName string) (string, error) { panic("unexpected") }
 func (m *mockGitForHistory) DeleteRemoteBranch(name string) error { panic("unexpected") }

--- a/internal/delivery/mcp/integrate/handler_test.go
+++ b/internal/delivery/mcp/integrate/handler_test.go
@@ -80,6 +80,7 @@ func (m *MockGit) CherryPick(commit string) (string, error) {
 func (m *MockGit) PushToBranch(remote, branch string) (string, error)      { return "", nil }
 func (m *MockGit) PullFromBranch(remote, branch string) (string, error)    { return "", nil }
 func (m *MockGit) Branch(name string) (string, error)                      { return "", nil }
+func (m *MockGit) BranchFrom(name, from string) (string, error)            { return "", nil }
 func (m *MockGit) DeleteBranch(name string, force bool) (string, error)    { return "", nil }
 func (m *MockGit) RenameBranch(oldName, newName string) (string, error)    { return "", nil }
 func (m *MockGit) DeleteRemoteBranch(name string) error                    { return nil }

--- a/internal/delivery/mcp/mock_test.go
+++ b/internal/delivery/mcp/mock_test.go
@@ -281,6 +281,10 @@ func (m *MockGit) Branch(name string) (string, error) {
 	return args.String(0), args.Error(1)
 }
 
+func (m *MockGit) BranchFrom(name, from string) (string, error) {
+	return "", nil
+}
+
 func (m *MockGit) DeleteBranch(name string, force bool) (string, error) {
 	args := m.Called(name, force)
 	return args.String(0), args.Error(1)

--- a/internal/delivery/mcp/prreview/handler_test.go
+++ b/internal/delivery/mcp/prreview/handler_test.go
@@ -42,6 +42,7 @@ func (m *mockGit) Add(paths []string) error                          { panic("no
 func (m *mockGit) Amend(msg string, paths []string) (string, error)  { panic("not implemented") }
 func (m *mockGit) Blame(filepath string) ([]domain.BlameLine, error) { panic("not implemented") }
 func (m *mockGit) Branch(name string) (string, error)                { panic("not implemented") }
+func (m *mockGit) BranchFrom(name, from string) (string, error)      { panic("not implemented") }
 func (m *mockGit) CatFile(revision, path string) (string, error)     { panic("not implemented") }
 func (m *mockGit) CherryPick(commit string) (string, error)          { panic("not implemented") }
 func (m *mockGit) Clean() error                                      { panic("not implemented") }

--- a/internal/delivery/mcp/rewrite/handler_test.go
+++ b/internal/delivery/mcp/rewrite/handler_test.go
@@ -63,6 +63,7 @@ func (m *MockGit) PushToBranch(remote, branch string) (string, error)      { ret
 func (m *MockGit) PullFromBranch(remote, branch string) (string, error)    { return "", nil }
 func (m *MockGit) Switch(branch string) error                              { return nil }
 func (m *MockGit) Branch(name string) (string, error)                      { return "", nil }
+func (m *MockGit) BranchFrom(name, from string) (string, error)            { return "", nil }
 func (m *MockGit) DeleteBranch(name string, force bool) (string, error)    { return "", nil }
 func (m *MockGit) RenameBranch(oldName, newName string) (string, error)    { return "", nil }
 func (m *MockGit) DeleteRemoteBranch(name string) error                    { return nil }

--- a/internal/delivery/mcp/session/mock_test.go
+++ b/internal/delivery/mcp/session/mock_test.go
@@ -150,6 +150,7 @@ func (m *MockGit) Switch(branch string) error {
 	return args.Error(0)
 }
 func (m *MockGit) Branch(name string) (string, error)                   { return "", nil }
+func (m *MockGit) BranchFrom(name, from string) (string, error)         { return "", nil }
 func (m *MockGit) DeleteBranch(name string, force bool) (string, error) {
 	args := m.Called(name, force)
 	return args.String(0), args.Error(1)

--- a/internal/delivery/mcp/stage/handler_test.go
+++ b/internal/delivery/mcp/stage/handler_test.go
@@ -85,6 +85,7 @@ func (m *mockGitForStage) Blame(filepath string) ([]domain.BlameLine, error) {
 	panic("not implemented")
 }
 func (m *mockGitForStage) Branch(name string) (string, error)             { panic("not implemented") }
+func (m *mockGitForStage) BranchFrom(name, from string) (string, error)   { panic("not implemented") }
 func (m *mockGitForStage) CatFile(revision, path string) (string, error)  { panic("not implemented") }
 func (m *mockGitForStage) CherryPick(commit string) (string, error)       { panic("not implemented") }
 func (m *mockGitForStage) Clone(repo, dest string) error                  { panic("not implemented") }

--- a/internal/delivery/mcp/sync/mock_test.go
+++ b/internal/delivery/mcp/sync/mock_test.go
@@ -130,6 +130,7 @@ func (m *MockGit) PullFromBranch(remote, branch string) (string, error) {
 	return args.String(0), args.Error(1)
 }
 func (m *MockGit) Branch(name string) (string, error)                   { return "", nil }
+func (m *MockGit) BranchFrom(name, from string) (string, error)         { return "", nil }
 func (m *MockGit) DeleteBranch(name string, force bool) (string, error) { return "", nil }
 func (m *MockGit) RenameBranch(oldName, newName string) (string, error) { return "", nil }
 func (m *MockGit) DeleteRemoteBranch(name string) error                 { return nil }

--- a/internal/delivery/mcp/sync/registration.go
+++ b/internal/delivery/mcp/sync/registration.go
@@ -22,7 +22,7 @@ func Register(s *server.MCPServer, h Handlers) {
 			mcpgo.WithBoolean("confirmed", mcpgo.Description("Required for PUSH. Without this, PUSH is BLOCKED. Set to true only after reviewing the diff with the user.")),
 			mcpgo.WithBoolean("dry_run", mcpgo.Description("Preview the sync impact without executing. Returns what would be pushed/pulled. Always use before PUSH.")),
 			mcpgo.WithString("remote_name", mcpgo.Description("Remote repository name. Defaults to 'origin' if omitted.")),
-			mcpgo.WithString("branch", mcpgo.Description("Specific branch to push or pull. When omitted, operates on the current branch. Use for targeted sync operations.")),
+			mcpgo.WithString("branch", mcpgo.Description("Remote branch to push or pull. When omitted, operates on the current branch. You can specify any branch name from the remote, e.g. 'main', 'develop', 'feature/foo' — the operation targets that branch regardless of the current branch.")),
 		),
 		h.HandleSync,
 	)

--- a/internal/delivery/mcp/utility/handler_test.go
+++ b/internal/delivery/mcp/utility/handler_test.go
@@ -40,6 +40,7 @@ func (m *mockGitForUtility) Blame(filepath string) ([]domain.BlameLine, error) {
 	panic("not implemented")
 }
 func (m *mockGitForUtility) Branch(name string) (string, error)             { panic("not implemented") }
+func (m *mockGitForUtility) BranchFrom(name, from string) (string, error)   { panic("not implemented") }
 func (m *mockGitForUtility) CatFile(revision, path string) (string, error)  { panic("not implemented") }
 func (m *mockGitForUtility) Checkout(ref string) error                      { panic("not implemented") }
 func (m *mockGitForUtility) CherryPick(commit string) (string, error)       { panic("not implemented") }

--- a/internal/infra/classifier/classifier_test.go
+++ b/internal/infra/classifier/classifier_test.go
@@ -477,6 +477,7 @@ func (m *mockGit) StashClear() (string, error)                                  
 func (m *mockGit) StashShow() (string, error)                                      { return "", nil }
 func (m *mockGit) Switch(branch string) error                                      { return nil }
 func (m *mockGit) Branch(name string) (string, error)                              { return "", nil }
+func (m *mockGit) BranchFrom(name, from string) (string, error)                    { return "", nil }
 func (m *mockGit) DeleteBranch(name string, force bool) (string, error)            { return "", nil }
 func (m *mockGit) RenameBranch(oldName, newName string) (string, error)            { return "", nil }
 func (m *mockGit) DeleteRemoteBranch(name string) error                            { return nil }

--- a/internal/workflow/commit_service_test.go
+++ b/internal/workflow/commit_service_test.go
@@ -122,6 +122,7 @@ func (s *stubGit) Stash(message ...string) (string, error)                     {
 func (s *stubGit) StashPop() (string, error)                                   { return "", nil }
 func (s *stubGit) Switch(branch string) error                                  { return nil }
 func (s *stubGit) Branch(name string) (string, error)                          { return "", nil }
+func (s *stubGit) BranchFrom(name, from string) (string, error)                { return "", nil }
 func (s *stubGit) DeleteBranch(name string, force bool) (string, error)        { return "", nil }
 func (s *stubGit) RenameBranch(oldName, newName string) (string, error)        { return "", nil }
 func (s *stubGit) DeleteRemoteBranch(name string) error                        { return nil }

--- a/internal/workflow/prepare_test.go
+++ b/internal/workflow/prepare_test.go
@@ -81,6 +81,7 @@ func (s *stubGitForPrepare) Stash(message ...string) (string, error)            
 func (s *stubGitForPrepare) StashPop() (string, error)                            { return "", nil }
 func (s *stubGitForPrepare) Commit(message string) (string, error)                { return "", nil }
 func (s *stubGitForPrepare) Branch(name string) (string, error)                   { return "", nil }
+func (s *stubGitForPrepare) BranchFrom(name, from string) (string, error)         { return "", nil }
 func (s *stubGitForPrepare) RenameBranch(oldName, newName string) (string, error) { return "", nil }
 func (s *stubGitForPrepare) DeleteBranch(name string, force bool) (string, error) { return "", nil }
 func (s *stubGitForPrepare) Reset(mode string, commit string) (string, error)     { return "", nil }

--- a/internal/workflow/release_test.go
+++ b/internal/workflow/release_test.go
@@ -126,6 +126,7 @@ func (m *mockGitForRelease) Stash(message ...string) (string, error)            
 func (m *mockGitForRelease) StashPop() (string, error)                            { return "", nil }
 func (m *mockGitForRelease) Commit(message string) (string, error)                { return "", nil }
 func (m *mockGitForRelease) Branch(name string) (string, error)                   { m.tagCreated = true; return "", nil }
+func (m *mockGitForRelease) BranchFrom(name, from string) (string, error)         { m.tagCreated = true; return "", nil }
 func (m *mockGitForRelease) RenameBranch(oldName, newName string) (string, error) { return "", nil }
 func (m *mockGitForRelease) DeleteBranch(name string, force bool) (string, error) { return "", nil }
 func (m *mockGitForRelease) DeleteRemoteBranch(name string) error                 { return nil }


### PR DESCRIPTION
Closes #144

## PR Type
- [x] New feature

## Summary
- `branch CREATE` now accepts an optional `from` parameter to create branches from any base ref (local branch, remote ref, tag, commit hash) in one call
- `sync PULL` `branch` parameter description clarified to document that any remote branch can be pulled, not just the current one

## Changes
| File | Change |
|------|--------|
| `internal/core/ports/git.go` | Added `BranchFrom(name, from string)` to `Git` interface |
| `internal/adapters/git/exec_write_branch.go` | Implemented `BranchFrom` with empty-from guard |
| `internal/adapters/git/session.go` | Delegated `BranchFrom` to base adapter |
| `internal/delivery/mcp/branch/branch.go` | Handler reads `from` param, calls `BranchFrom` when non-empty |
| `internal/delivery/mcp/branch/registration.go` | Registered `from` string param |
| `internal/delivery/mcp/branch/branch_test.go` | 6 new test cases for `from` param |
| `internal/adapters/git/exec_write_test.go` | Integration test for `BranchFrom` |
| `internal/delivery/mcp/sync/registration.go` | Clarified `branch` param description |
| `internal/delivery/mcp/descriptions/descriptions.go` | Updated `DescSync` |
| 16 mock files | Added `BranchFrom` stubs for interface compliance |

## Test Plan
- [x] `go test ./...` — all 39 packages pass
- [x] Handler tests cover: from with remote ref, omitted, empty, from+switch dirty tree, error propagation
- [x] Adapter test verifies `git branch <name> <from>` execution
- [x] Backward compatible: without `from`, behavior is identical to before

## Contributor Checklist
- [x] Linked an approved issue (#144 has `status:approved`)
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers