### PR TITLE
docs: Phase 1 — fix architecture.md, config.md, commands.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ If you're new to the project, look for issues labeled [`good first issue`](https
 
 ## Setup
 
-**Requirements:** Go 1.25+ · Git · Ollama (optional, for integration tests)
+**Requirements:** Go 1.26+ · Git · Ollama (optional, for integration tests)
 
 ```bash
 git clone https://github.com/blak0p/git-courer.git
@@ -91,6 +91,7 @@ Integration tests use real Ollama with `qwen3.5:latest`. They create isolated gi
 ```
 git-courer/
 ├── cmd/main.go                   # Entry point
+├── ffi/                          # Foreign-function interface bindings (tree-sitter)
 ├── internal/
 │   ├── adapters/                 # Implementations of ports
 │   │   ├── commitstore/          # Per-branch file-based commit plans
@@ -100,24 +101,33 @@ git-courer/
 │   │   ├── llm/                  # Unified OpenAI standard client
 │   │   └── sessionstore/         # JSON session database
 │   ├── classifier/               # Command-based Git change classification
+│   │   └── gitcmd/               # Shell-command classifier (hook-check)
 │   ├── config/                   # Config loading and defaults
 │   ├── core/
 │   │   ├── domain/               # Core logic (no external dependencies)
 │   │   └── ports/                # Interfaces (Git, LLM, Confirm, Security)
 │   ├── data/                     # Embedded language definitions
-│   ├── delivery/mcp/             # MCP server and modular tool handlers
+│   ├── delivery/
+│   │   ├── cli/                  # CLI subcommand adapters (doctor, hook-check, release)
+│   │   └── mcp/                  # MCP server and modular tool handlers
+│   │       ├── descriptions/     # Per-tool MCP descriptions
+│   │       └── shared/           # Shared MCP helpers (diff, formatters, progress)
 │   ├── infra/
 │   │   ├── chunkers/             # Diff and log chunkers
 │   │   ├── classifier/           # AST-based classification via tree-sitter
 │   │   ├── filters/              # Path filtering
-│   │   └── secrets/              # Secret patterns and magic bytes
+│   │   └── secrets/              # Secret patterns, blacklist, magic bytes
 │   ├── installer/                # Install, setup, and client configs
 │   ├── models/                   # Local LLM capability detector
 │   ├── security/                 # Multi-layer security service orchestrator
+│   │   └── model.go              # Model-size gating (ParseModelSize) for LLM scan eligibility
 │   ├── shared/prompts/           # Prompt templates
 │   │   └── md/                   # Markdown prompt files
 │   └── workflow/                 # Commit and release service workflows
 ├── tui/                          # Interactive terminal UI (Bubbletea)
+│   ├── screens/                  # TUI screens
+│   ├── components/               # Reusable TUI components
+│   └── styles/                   # TUI styling
 ├── test/                         # E2E test suites
 │   ├── pipeline/                 # Commit E2E pipeline tests
 │   └── release/                  # Release E2E tests

--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ git-courer mcp setup     # auto-configures your agent (OpenCode, Claude Code, Co
 
 Restart your agent, then ask it to run `status` on any repo. If it comes back with structured JSON instead of raw `git status` output, you're connected.
 
+### Diagnostics & lifecycle
+
+```bash
+git-courer doctor              # read-only health report for every detected MCP client
+git-courer hook-check "git status"   # classify a shell command (agent hook; never denies)
+git-courer init                # TUI wizard to create/update project config
+git-courer version --predict   # predict next release tag from conventional commits
+git-courer remove              # remove project-level config (keeps the binary)
+git-courer update              # self-update to the latest release + reconfigure MCP
+```
+
+`doctor` reports per client: config path, MCP configured, prompt block injected, hooks installed (`yes`/`no`/`partial`), and Claude inline hooks (Claude Code only).
+
 ---
 
 ## How an agent works with git-courer
@@ -240,6 +253,31 @@ Full reference with examples: [docs/commands.md](docs/commands.md).
 | Antigravity | ✓ |
 
 `git-courer mcp setup` configures all at once. Manual setup and config formats: [docs/mcp-clients.md](docs/mcp-clients.md).
+
+---
+
+## Hooks & golden rules
+
+`mcp setup` does more than register the MCP server — it also injects guardrails so agents route git operations through git-courer instead of raw Bash.
+
+**Golden rules injection.** A `<!-- git-courer start -->` / `<!-- git-courer end -->` block is injected (and kept up to date) in each client's instructions file (`AGENTS.md` for OpenCode, `CLAUDE.md` for Claude Code, `GEMINI.md` for Antigravity). The block encodes the golden rules: check `status` before mutating, run `diff` + `review` before a PR, always `session start` first.
+
+**Hooks.** Clients that support shell hooks get entries wired to git-courer subcommands:
+
+| Event | Matcher | Command | Fires when |
+|-------|---------|---------|------------|
+| PreToolUse | `git *` | `git-courer hook-check` | Before any Bash `git ...` run |
+| SessionStart | — | `git-courer session-start-hook` | Agent session opens |
+| SubagentStart | — | `git-courer subagent-start-hook` | A sub-agent starts |
+| PreInvocation | — | `git-courer pre-invocation-hook` | Before each model call (Antigravity) |
+
+`hook-check` classifies the command and emits `additionalContext` suggesting the matching git-courer MCP tool — it **never denies**. The session/subagent/pre-invocation hooks inject the golden rules as `additionalContext`. Claude Code uses inline `settings.json` hooks (`UserPromptSubmit` instead of PreInvocation); Codex uses a separate `hooks.json`; Antigravity uses a separate `hooks.json` with a `run_command` matcher and only 2 events. Full reference: [docs/hooks.md](docs/hooks.md).
+
+**OpenCode policy.** For OpenCode (which has no shell hooks), `mcp setup` merges into `opencode.json`:
+- `permission.bash["git *"] = "ask"` — OpenCode prompts the user before any `git` Bash command, so the agent is nudged toward the MCP tool.
+- `instructions` array includes the `AGENTS.md` path (legacy `GIT_COURER.md` entries are removed). The merge is idempotent; a `.bak` backup is written before any change.
+
+Run `git-courer doctor` to verify all of the above per client.
 
 ---
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -13,10 +13,20 @@ llm:
   model: gemma4:26b                         # mandatory — model name/identifier
   base_url: http://localhost:11434/v1        # API endpoint (include /v1 for OpenAI-compatible)
   num_parallel: 1                           # Max concurrent LLM calls (default: 1 = serial)
-  context_window: 8192                      # Context window size. Automatically resolved at install.
+  context_window: 0                         # Auto-resolved at install (8192 fallback). 0 = resolve from model/API, >0 = use this value.
 
 # ---------------------------------------------------------------------------
 # Release behavior settings
 # ---------------------------------------------------------------------------
 release:
   type: tag                                 # tag (annotated git tag) | github (GitHub Release via gh CLI)
+
+# ---------------------------------------------------------------------------
+# Per-project settings (stored in .git/git-courer/config.json, not this file)
+# ---------------------------------------------------------------------------
+# The per-project config overrides the global config for this repo. Fields:
+#   user_name     # Commit author name override for this repo
+#   user_email    # Commit author email override for this repo
+#   signing_key   # GPG signing key id for this repo
+# Use `git-courer init` (TUI wizard) to set them; they are not part of the
+# global ~/.config/git-courer/config.yaml.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,31 +7,39 @@ High-level overview of git-courer's codebase for contributors.
 - **Language**: Go 1.26+
 - **MCP Server**: Custom implementation using `mark3labs/mcp-go` under `internal/delivery/mcp`
 - **LLM Integration**: Unified OpenAI-compatible backend adapter (supporting Ollama, LM Studio, vLLM, LocalAI, OpenAI, etc.).
-- **AI Toggle**: Non-AI execution mode when `llm.enabled` is `false` to run offline without LLM requirements.
+- **AI Toggle**: Offline mode when `llm.enabled` is `false` — runs without an LLM (commit pipeline accepts a manual message instead of `why`).
 - **Architecture**: Hexagonal / Clean Architecture
 
 ## Directory Structure
 
 ```
 git-courer/
-├── cmd/                    # CLI entry point (main.go)
+├── cmd/                    # CLI entry point (main.go: dispatches doctor, hook-check, release, MCP server)
+├── ffi/                    # Pre-built native shared libraries (libgit2 bindings) per platform
+│   ├── darwin_amd64/       # macOS Intel
+│   ├── darwin_arm64/       # macOS Apple Silicon
+│   ├── linux_amd64/        # Linux x86_64
+│   ├── windows_amd64/      # Windows x86_64
+│   └── include/            # C headers for libgit2
 ├── internal/
 │   ├── adapters/           # Interface implementations (Ports)
 │   │   ├── commitstore/    # Per-branch file-based commit plan database
 │   │   ├── confirm/        # In-memory session confirm/safety locks
 │   │   ├── git/            # Exec-based Git adapter & Session redirect wrapper
-│   │   ├── github/         # API client for PR integration (optional)
+│   │   ├── github/         # API client for PR integration (optional, via `gh` CLI)
 │   │   ├── llm/            # OpenAI-standard chat completion client
 │   │   │   ├── ollama/     # Ollama-specific client lifecycle manager
 │   │   │   └── openai_standard/ # Core OpenAI standard adapter
 │   │   └── sessionstore/   # JSON-based session database
-│   ├── classifier/         # Command-based Git change classification
+│   ├── classifier/         # Command classification (shell-command → MCP tool routing)
+│   │   └── gitcmd/         # Classifies git shell commands to redirect to MCP tools (used by hook-check)
 │   ├── config/             # Config loaders (global ~/.config/git-courer/config.yaml)
 │   ├── core/
 │   │   ├── domain/         # Pure domain models (Session, ProjectConfig, Backup, etc.)
 │   │   └── ports/          # Central interfaces driven by adapters
-│   ├── data/               # Static/embedded data (languages.json)
+│   ├── data/               # Embedded static data (languages.json for chunker language detection)
 │   ├── delivery/
+│   │   ├── cli/            # CLI subcommands (doctor.go, hook_check.go, release.go)
 │   │   └── mcp/            # MCP server & modular command handlers
 │   │       ├── branch/     # branch tool handler
 │   │       ├── core/       # status, diff, and commit tool handlers
@@ -41,23 +49,31 @@ git-courer/
 │   │       ├── prreview/   # pr-review tool handler
 │   │       ├── rewrite/    # rewrite tool handler
 │   │       ├── session/    # session tool handler
+│   │       ├── shared/     # Shared MCP helpers (param validation, progress, token sanitizer, diff formatters)
 │   │       ├── stage/      # stage & stash tool handlers
 │   │       ├── sync/       # sync tool handler
 │   │       └── utility/    # backup tool handler
 │   ├── infra/              # Low-level utilities
 │   │   ├── chunkers/       # Diff & log chunking for context windows
 │   │   ├── classifier/     # AST-based commit classification via tree-sitter
-│   │   ├── filters/        # Path/file filtering
-│   │   └── secrets/        # Regex & magic bytes secret matching rules
-│   ├── installer/          # CLI installer & client configuration setup
+│   │   ├── filters/        # Diff noise filtering (whitespace/renames/no-op removal)
+│   │   └── secrets/        # Secret matching rules
+│   │       ├── blacklist.go     # Folder & filename blacklists
+│   │       ├── detector.go      # Regex-based secret detection in files and diff content
+│   │       └── magic_bytes.go   # Binary file detection via magic bytes
+│   ├── installer/          # CLI installer & client configuration setup (hooks, prompt blocks, policies)
 │   ├── models/             # Local LLM detection utilities
 │   ├── security/           # Multi-layer paranoid security service orchestrator
+│   │   └── model.go        # Model-size gating (ParseModelSize) for LLM scan eligibility
 │   ├── shared/             # Common helper packages
 │   │   ├── prompts/        # Chat completion markdown prompt templates
 │   │   │   └── md/         # Core markdown template files
 │   │   └── testutil/       # Shared test utilities
-│   └── workflow/           # Main business workflows (CommitService, ReleaseService)
+│   └── workflow/           # Main business workflows (CommitService, ReleaseService, SessionFinishWorkflow)
 ├── tui/                    # Interactive configuration TUI (Bubbletea + Lipgloss)
+│   ├── screens/            # TUI screens (init, install, mcp_setup)
+│   ├── components/         # Reusable TUI components (checkbox, dynamic_form, form)
+│   └── styles/             # Lipgloss theme & shared styles
 ├── test/                   # E2E test suites
 │   ├── pipeline/           # Commit pipeline E2E tests
 │   └── release/            # Release & changelog E2E tests
@@ -107,14 +123,14 @@ The CLI configurator runs as an interactive terminal UI built with [Bubbletea](h
 
 ## 6-Layer Proactive Security (`internal/security/`)
 
-Before staging or committing any changes, the security orchestrator checks the working tree and staged diffs in memory using 6 cumulative defense layers:
+Before staging or committing any changes, the security orchestrator checks the working tree and staged diffs in memory using 6 cumulative defense layers, executed in this order (matches `internal/security/security.go`):
 
-1. **Binary File Block**: Magic bytes check (`IsBinary`) on files + AI-powered file noise analysis (`AuditBinaryContent`) to detect obfuscated payloads disguised as plain text.
-2. **Folder Blacklist**: Rejects tracking in sensitive directories (e.g. `vendor/`, `.git/`, `.github/`, `test/`).
-3. **Name Blacklist**: Blocks known sensitive files (e.g. `.env`, `id_rsa`, `credentials.json`, `auth.key`).
-4. **Static Analysis**: Runs external detectors like `trufflehog` or `gosec` on files if they are installed on the system.
-5. **Regex Search**: Matches files and staged diff lines against a library of regular expressions targeting common secret formats (e.g. Stripe keys, AWS credentials).
-6. **LLM Verification**: A paranoid AI auditor agent (`VerifySecrets`) parses the diff to filter false positives. If the LLM validates that the match is not a secret, it can override low-confidence regex flags.
+1. **Binary File Block**: Magic bytes check (`secrets.IsBinary`) on files, plus AI-powered content audit (`AuditBinaryContent`) to detect obfuscated payloads disguised as plain text. Go test files (`_test.go`) skip the AI audit.
+2. **Folder Blacklist**: Rejects tracking in sensitive directories (e.g. `vendor/`, `.git/`, `.github/`, `test/`). Hard stop.
+3. **Name Blacklist**: Blocks known sensitive files (e.g. `.env`, `id_rsa`, `credentials.json`, `auth.key`). Hard stop. Legitimate Go test files (`_test.go`) are exempted here and skip the remaining layers.
+4. **Static Analysis**: Runs external detectors (`trufflehog` or `gosec`) on the file list if installed. 30s timeout. Hard stop on findings.
+5. **Regex Search**: Matches file content and staged diff lines against a library of regular expressions targeting common secret formats (e.g. Stripe keys, AWS credentials). Test files (`_test.go`, `test/...`) are filtered out before findings are merged.
+6. **LLM Verification**: A paranoid AI auditor (`VerifySecrets`) parses a filtered diff (test files and prompts removed via `filterDiff`) to confirm or override regex findings. If the LLM validates that a low-confidence regex match is not a secret, it can clear the block to avoid false positives.
 
 ## Testing
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,6 +1,6 @@
 # Commands Reference
 
-Complete reference for all git-courer MCP tools and their arguments.
+Complete reference for all git-courer MCP tools and CLI subcommands.
 
 ## Overview
 
@@ -10,7 +10,7 @@ git-courer exposes **13 MCP tools** for AI assistants. Every tool returns struct
 |------|----------|---------|
 | `status` | Unique / Read | Complete repository state in one call |
 | `diff` | Unique / Read | AST-labeled diffs with semantic tags |
-| `commit` | Unique / Write | 3-phase (AI) or 2-phase (Non-AI) commit pipeline |
+| `commit` | Unique / Write | LLM-powered 3-phase commit pipeline (PREVIEW → APPLY → STATUS) |
 | `pr-review` | Unique / Read | Pre-PR gate: runs tests, checks conflicts and divergence |
 | `backup` | Unique / Utility | Manage backups and undo mutations |
 | `session` | Unique / Write | Manage isolated sessions (git worktrees) for parallel agents |
@@ -21,6 +21,8 @@ git-courer exposes **13 MCP tools** for AI assistants. Every tool returns struct
 | `rewrite` | Replacement / Write | Amend, revert, soft reset, and hard reset |
 | `integrate` | Replacement / Write | Merge, rebase, cherry-pick, and abort/continue |
 | `sync` | Replacement / Write | Push, pull, and fetch remote changes |
+
+In addition to the MCP tools above, git-courer ships CLI subcommands that support the MCP workflow but are not themselves MCP tools: `doctor`, `hook-check` (and its `session-start-hook` / `subagent-start-hook` / `pre-invocation-hook` variants), and `release`. See [CLI Subcommands](#cli-subcommands) at the end of this document.
 
 ---
 
@@ -55,25 +57,27 @@ Returns AST-labeled diffs. Hunks are semantically annotated (e.g., `[NEW_FUNC]`,
 | `include_untracked` | boolean | No | Include untracked files in the diff output |
 
 ### commit
-Handles the multi-phase commit pipeline. Supports both AI mode (uses a local/remote LLM to generate description and message) and Non-AI mode (offline mode with manual messages).
+Handles the multi-phase commit pipeline. In the default (LLM-enabled) mode it uses a local/remote LLM to analyze the diff and generate the commit message. When `llm.enabled: false`, the pipeline runs offline and the commit message is supplied manually via the `message` parameter.
 
-* **AI Mode Workflow**: 
-  1. `command="PREVIEW"` + `why="..."` -> generates plan.
-  2. Review plan with user.
-  3. `command="APPLY"` + `job_id="..."` -> applies plan.
-* **Non-AI Mode Workflow**: 
-  1. `command="PREVIEW"` + `message="..."` -> prepares plan.
-  2. `command="APPLY"` -> executes commit.
+**Workflow (PREVIEW → APPLY):**
+1. `command="PREVIEW"` + `why="..."` → analyze the staged diff and generate a commit plan. Fast path (<45s) returns the plan directly; slow path returns a `job_id` to poll via `STATUS`.
+2. Review the plan with the user.
+3. `command="APPLY"` → execute the plan. With `job_id`, uses git plumbing (`commit-tree` + `update-ref`) to create an atomic commit from the PREVIEW tree snapshot. Without `job_id`, executes the pending plan from the ConfirmStore.
+4. (Optional) `command="STATUS"` + `job_id="..."` → poll a slow PREVIEW job.
+
+> **`why` is required for PREVIEW.** Describe the *why* — the real problem, symptom, or limitation that motivated the change — NOT what the code does (the LLM reads the diff to derive the *what*).
+
+**Offline mode** (`llm.enabled: false`): PREVIEW accepts `message` instead of `why` and infers the conventional-commit type prefix from the staged files when one is missing.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `command` | string | **Yes** | `PREVIEW`, `APPLY`, or `STATUS` (poll job state) |
-| `why` | string | **Yes** (AI mode) | The business/technical reason for this change. Describe the *why*, not what the code does. |
-| `message` | string | **Yes** (Non-AI mode) | Manual commit message to use. |
-| `target_paths` | string | No | Space-separated paths to stage before preview (use `.` for all) |
+| `why` | string | **Yes** (PREVIEW, LLM mode) | The REAL reason for this change — the problem/symptom/limitation that motivated it. Do NOT describe what the code does. |
+| `message` | string | **Yes** (PREVIEW, offline mode) | Manual commit message (only when `llm.enabled: false`). |
+| `target_paths` | string | No | Space-separated paths to stage before preview (use `.` for all). PREVIEW only. |
 | `job_id` | string | No | Job ID for STATUS polling or plumbing-based APPLY execution |
 | `push_after` | boolean | No | Auto-push commits after successful APPLY |
-| `type` | string | No | Commit type prefix override (e.g., `feat`, `fix`, `chore`) |
+| `type` | string | No | Commit type prefix override (e.g., `feat`, `fix`, `chore`). APPLY only. Valid: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`, `style`. |
 
 ### pr-review
 A pre-PR validation gate that runs the project's `test_command`, detects merge conflicts with the target branch, shows diff stats, and checks branch divergence.
@@ -95,7 +99,8 @@ Manages automated git state backups. Every write operation automatically creates
 ### session
 Manages isolated git worktrees and branches to allow agents to work in parallel on the same repository without conflicts.
 
-* **Workflow**: `start` (creates worktree) -> `select` (redirects all MCP tools) -> work -> `finish` (cleans up worktree, leaves branch alive).
+* **Workflow**: `start` (creates worktree + branch) → `select` (redirects all MCP tools to the session's worktree) → work → `finish` (removes the worktree, **leaves the branch alive** for manual integration).
+* **`finish` behavior**: `finish` runs a light preview-validation (aborts only on uncommitted/untracked changes — a data-loss guard) and then removes the worktree. The session branch is intentionally **NOT deleted** so you can merge it, open a PR, or `discard` it later. No merge is attempted by `finish`.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
@@ -209,7 +214,45 @@ When a safety check blocks an operation, one of the following codes is returned:
 | Code | Trigger | Solution |
 |------|---------|----------|
 | `SECRET_DETECTED` | Credentials or keys found in the diff | Remove secrets before staging or committing |
-| `INTEGRITY ALERT` | Workspace files changed during review | Start the commit process again |
+| `INTEGRITY ALERT` | Workspace files changed between PREVIEW and APPLY | Start the commit process again (PREVIEW → APPLY) |
 | `plan expired` | The PREVIEW commit plan timed out | Run `commit command="PREVIEW"` again |
-| `confirmed required` | Mutating operation without confirmation | Pass `confirmed=true` after explaining to the user |
-| `blocked` | Safety constraint failed | Review the hint in the JSON response |
+
+Mutating operations that require confirmation return a `blocked` status in the JSON response rather than a dedicated error code — read the `message`/hint field and pass `confirmed=true` after explaining the impact to the user.
+
+---
+
+## CLI Subcommands
+
+These subcommands are invoked from the shell (`git-courer <subcommand>`), not over MCP. They support the MCP workflow (diagnostics, hooks, releases).
+
+### doctor
+
+```bash
+git-courer doctor
+```
+
+Runs read-only diagnostics on every MCP client detected on the system and prints a human-readable health report: config path, whether the MCP server is configured, whether the prompt block is injected, and the hooks installation status (per client). All diagnostic logic lives in the `installer` package; `doctor` is a thin CLI adapter.
+
+Use it when something feels off with a client's git-courer integration — it surfaces exactly which piece (config, prompt block, or hooks) is missing or misconfigured.
+
+### hook-check
+
+```bash
+git-courer hook-check <shell-command>
+# or, in Codex hook mode: reads Codex hook JSON from stdin
+```
+
+Classifies a shell command the agent is about to run and emits a JSON `Result` indicating whether a git-courer MCP tool should be used instead of raw git. Two modes:
+
+- **Argument mode**: `git-courer hook-check "git commit -m foo"` → prints `{command, decision, mcp_tool, reason}` JSON. `decision` is `"allow"` (non-git, safe to run) or `"ask"` (git mutation/read that should use the MCP tool named in `mcp_tool`).
+- **Stdin mode** (Codex hooks): when stdin is a pipe and no args are given, reads Codex `PreToolUse` hook JSON, extracts the command, classifies it, and emits Codex hook output with `additionalContext` suggesting the MCP tool. Non-git commands exit cleanly with no output.
+
+The classifier is a pure function (`internal/classifier/gitcmd`) — it inspects the command string only and never executes anything. Related hook subcommands: `session-start-hook`, `subagent-start-hook`, and `pre-invocation-hook` emit golden-rules context for Codex/Antigravity lifecycle hooks.
+
+### release
+
+```bash
+git-courer release [bump]
+```
+
+Runs the release workflow (tag or GitHub Release) via the `workflow.ReleaseService`. Not an MCP tool — it is a CLI-only command driven by the commit store and the configured `release.type`.

--- a/docs/config.md
+++ b/docs/config.md
@@ -18,7 +18,7 @@ llm:
   model: gemma4:26b
   base_url: http://localhost:11434/v1
   num_parallel: 1
-  context_window: 8192
+  context_window: 0          # 0 = auto-resolved at install (8192 fallback)
 
 release:
   type: tag
@@ -51,11 +51,14 @@ This file is **committable** and **shared by your team**. It lives in your repos
 {
   "description": "Payment service API",
   "path_types": {
-    "test": ["test/", "internal/testing/"],
+    "test": ["test/"],
     "ci": [".github/workflows/"]
   },
   "test_command": "go test ./...",
   "base_branch": "main",
+  "user_name": "Alice",
+  "user_email": "alice@example.com",
+  "signing_key": "~/.ssh/id_ed25519",
   "excluded": ["*.pb.go", "vendor/", "*.gen.go"]
 }
 ```
@@ -63,16 +66,19 @@ This file is **committable** and **shared by your team**. It lives in your repos
 | Field | Type | Description |
 |-------|------|-------------|
 | `description` | string | Short project description for LLM context. Used to scope commit messages. |
-| `path_types` | object | Maps commit types (like `test`, `ci`, `docs`) to file path prefixes. If all changed files match the prefixes under a type, that type is automatically assigned to the commit. |
+| `path_types` | object | Maps commit types (like `test`, `ci`, `docs`) to file path prefixes. If all changed files match the prefixes under a type, that type is automatically assigned to the commit. Defaults (when unset): `test` → `["test/"]`, `ci` → `[".github/workflows/", "ci/"]`, `docs` → `["docs/"]`. |
 | `test_command` | string | Command for pre-PR validation (used by `pr-review` and `git-courer release`). |
 | `base_branch` | string | Base branch used for PR validation and comparison (e.g., `main` or `develop`). |
+| `user_name` | string | Per-project commit author name. Overrides the global `user.name` for commits made through git-courer. |
+| `user_email` | string | Per-project commit author email. Overrides the global `user.email` for commits made through git-courer. |
+| `signing_key` | string | Path to a GPG/SSH signing key used to sign commits made through git-courer. |
 | `excluded` | array | Path prefixes to exclude from diff analysis and commit classification. |
 
 ### Best Practices
 
-- **Trailing Slash Rule**: All prefixes in `path_types` and `excluded` **must end with a trailing slash (`/`)** to prevent partial matches (e.g., `"docs/"` ensures it won't match `"docsify/"`).
+- **Trailing Slash Rule**: All prefixes in `path_types` and `excluded` **must end with a trailing slash (`/`)** to prevent partial matches (e.g., `"docs/"` ensures it won't match `"docsify/"`). Missing trailing slashes are normalized at load time.
 - **Define Custom Path Types**: By default, path types are mapped for `test` (`test/`), `ci` (`.github/workflows/`, `ci/`), and `docs` (`docs/`). Define custom `path_types` in `config.json` to override or extend this mapping.
-- **Set Test Command**: Set `test_command` to the fastest command that proves correctness (e.g., `go test ./...`, `make test-ci`, `npm test`).
+- **Set Test Command**: Set `test_command` to the fastest command that proves correctness (e.g., `go test ./...`, `npm test`).
 - **Use Excluded**: Use `excluded` for generated files, vendored code, and lockfiles you never want in commit analysis.
 
 ---
@@ -120,7 +126,7 @@ llm:
     "storage": ["internal/storage/"],
     "deploy": ["deploy/"]
   },
-  "test_command": "make test-ci",
+  "test_command": "make test-unit",
   "excluded": ["*.pb.go", "vendor/"]
 }
 ```

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,227 @@
+# Hooks Reference
+
+git-courer installs **lifecycle hooks** into MCP clients so agents always see the git-courer Golden Rules and are nudged toward the git-courer MCP tools instead of raw git.
+
+This is the dedicated hooks reference. For the per-client setup overview, see [mcp-clients.md](./mcp-clients.md).
+
+---
+
+## Event Types
+
+git-courer uses four hook events. Each event has a matcher (which agent actions it fires on), a command (which git-courer subcommand is invoked), and a purpose.
+
+| Event | Matcher | Command | Fires When | Purpose |
+|-------|---------|---------|------------|---------|
+| `PreToolUse` | `Bash` (Claude Code, Codex) / `run_command` (Antigravity) | `git-courer hook-check` | The agent is about to run a shell command | Classify the command; if it's a git command, emit `additionalContext` suggesting the git-courer MCP tool. **Never denies** — only suggests. |
+| `SessionStart` | `startup\|resume` | `git-courer session-start-hook` | A new agent session starts (or resumes) | Inject the Golden Rules into the agent's context so the workflow is known from the first turn. |
+| `SubagentStart` | `general-purpose\|Explore\|Plan` | `git-courer subagent-start-hook` | A subagent is spawned | Inject the Golden Rules into the subagent's context, so subagents also follow `session start` → `status` → `diff`/`review` → `pr-review`. |
+| `PreInvocation` | *(empty matcher)* | `git-courer pre-invocation-hook` | Before every model call (Antigravity only) | Inject the Golden Rules before each model invocation. Compensates for clients that have no `SessionStart`/`SubagentStart` events. |
+
+### What each hook emits
+
+Every hook subcommand emits a JSON object on stdout shaped for the Codex hook contract:
+
+```json
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "additionalContext": "..."
+  }
+}
+```
+
+- `hookEventName` echoes the event (`PreToolUse`, `SessionStart`, `SubagentStart`, `PreInvocation`).
+- `additionalContext` is the Golden Rules markdown for the three context-injection hooks. For `PreToolUse` it is a short suggestion like `Use git-courer/<tool> instead of bash <command>` when the command is a git command; for non-git commands, `hook-check` exits cleanly with **no output** (no decision is emitted, no command is denied).
+- `permissionDecision` / `permissionDecisionReason` are **never set** by git-courer — it never denies a command. The agent (and the user, via the client's own permission prompt) always retains the final say.
+
+---
+
+## Per-Client Differences
+
+Clients store hooks differently and support different event subsets. git-courer adapts to each.
+
+### Claude Code — inline hooks in `settings.json`
+
+- **Storage**: hooks are stored **inline** in `~/.claude/settings.json` under the top-level `hooks` object, keyed by event name. There is no separate hooks file.
+- **Form**: Claude Code uses the exec form — `type: "command"` with separate `command` and `args` fields, plus an optional `timeout` (seconds). git-courer sets `timeout: 10` on `SessionStart`, `SubagentStart`, and `UserPromptSubmit`.
+- **Event names**: Claude Code calls the `PreInvocation` event **`UserPromptSubmit`**. git-courer installs it under that name.
+- **Events installed**: `PreToolUse` (matcher `Bash`), `SessionStart` (`startup|resume`), `SubagentStart` (`general-purpose|Explore|Plan`), `UserPromptSubmit` (empty matcher).
+- **Merge**: existing non-git-courer hooks and every other top-level settings key (`permissions`, `model`, `theme`, …) are preserved. Matching is by `(matcher, command containing "git-courer")` — same matcher + git-courer command is updated in place (handles binary path changes); same matcher + no git-courer command appends git-courer alongside the existing hook.
+- **Write**: atomic (temp file + rename).
+- **Backup**: `~/.claude/settings.json` → `~/.claude/settings.json.bak`.
+
+### Codex — separate `hooks.json`
+
+- **Storage**: hooks are stored in a **separate** `~/.codex/hooks.json` file (not inside `config.toml`).
+- **Form**: simple `{ "type": "command", "command": "..." }` entries, no timeout field.
+- **Events installed**: all four — `PreToolUse` (matcher `Bash`), `SessionStart` (`startup|resume`), `SubagentStart` (`general-purpose|Explore|Plan`), `PreInvocation` (empty matcher).
+- **Stdin mode**: when `git-courer hook-check` is invoked with no args and stdin is a pipe, it reads Codex hook JSON from stdin (`event.input.command`), classifies it, and emits a Codex-shaped `hookSpecificOutput`.
+- **Backup**: `hooks.json` → `hooks.json.bak`.
+
+### Antigravity — separate `hooks.json` + declarative permissions
+
+- **Storage**: hooks in `~/.gemini/antigravity-cli/hooks.json` AND declarative permissions in `~/.gemini/antigravity-cli/settings.json` (two separate files).
+- **Matcher difference**: Antigravity uses the **`run_command`** matcher (not `Bash`) for `PreToolUse`.
+- **Events installed**: only two — `PreToolUse` (`run_command`) and `PreInvocation` (empty matcher). Antigravity has no `SessionStart`/`SubagentStart` events, so `PreInvocation` runs before every model call to inject the Golden Rules.
+- **Permissions** (`settings.json`): three entries are merged into the existing `permissions` object:
+  - `permissions.allow` gains `"mcp(git-courer/*)"` — allow all git-courer MCP tools without prompting.
+  - `permissions.ask` gains `"command(git *)"` — prompt before raw git commands.
+  - `permissions.ask` gains `"command(*)"` — prompt before any other shell command.
+- **Backup**: `hooks.json` → `hooks.json.bak`; `settings.json` → `settings.json.gc.bak` (distinct suffix to avoid colliding with any Antigravity-native backup scheme).
+
+### OpenCode — no hooks (policy + prompt block instead)
+
+- **No hooks**: OpenCode does not support lifecycle hooks. git-courer instead injects:
+  - `permission.bash["git *"] = "ask"` into `opencode.json` — OpenCode asks before raw git commands.
+  - The `AGENTS.md` path into the `instructions` array — so OpenCode reads the Golden Rules from the prompt block it already loads.
+- See [mcp-clients.md § OpenCode Policy Injection](./mcp-clients.md#5-opencode-policy-injection).
+
+### Cursor
+
+- Cursor is **not** auto-configured by `git-courer mcp setup`. If you use Cursor, add the MCP server manually using the standard JSON format (see [mcp-clients.md § Config Formats](./mcp-clients.md#config-formats)). Cursor does not expose a lifecycle hook system git-courer can target, so no hooks or prompt block are installed for it.
+
+---
+
+## Lifecycle
+
+### Install
+
+`git-courer mcp setup` (or `mcp setup <client>`) installs hooks for every detected client that supports them:
+
+1. **Backup** any existing hooks/settings file before the first mutation.
+2. **Merge** git-courer hook entries into the existing hooks object, preserving every non-git-courer hook.
+3. **Write** the merged file atomically where the client supports it (Claude Code, Antigravity).
+
+Install is **idempotent** — running it twice produces byte-identical output. The backup is not overwritten on re-run.
+
+### Status
+
+`git-courer doctor` reports the hook status per client:
+
+- **`installed`** — all git-courer hook events are present with a git-courer command for the expected matcher.
+- **`not_installed`** — none of the git-courer hook events are present.
+- **`partial`** (Claude Code only) — some but not all git-courer hook events are present. Re-run `git-courer mcp setup <client>` to complete the install.
+
+### Remove
+
+`git-courer remove` cleans up hooks for every known client (even clients whose binary is no longer on `PATH`):
+
+1. If a `.bak` (or `.gc.bak`) exists, it is **restored** over the live file and the backup is removed.
+2. Otherwise, git-courer strips only the git-courer-owned entries in place, preserving non-git-courer hooks and every other settings key.
+
+Remove is idempotent — running it twice does not error and does not touch user content.
+
+---
+
+## Configuration Examples
+
+### Claude Code (`~/.claude/settings.json`)
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "/usr/local/bin/git-courer hook-check", "args": [] }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          { "type": "command", "command": "/usr/local/bin/git-courer session-start-hook", "args": [], "timeout": 10 }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "matcher": "general-purpose|Explore|Plan",
+        "hooks": [
+          { "type": "command", "command": "/usr/local/bin/git-courer subagent-start-hook", "args": [], "timeout": 10 }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          { "type": "command", "command": "/usr/local/bin/git-courer pre-invocation-hook", "args": [], "timeout": 10 }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Codex (`~/.codex/hooks.json`)
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Bash", "hooks": [{ "type": "command", "command": "/usr/local/bin/git-courer hook-check" }] }
+    ],
+    "SessionStart": [
+      { "matcher": "startup|resume", "hooks": [{ "type": "command", "command": "/usr/local/bin/git-courer session-start-hook" }] }
+    ],
+    "SubagentStart": [
+      { "matcher": "general-purpose|Explore|Plan", "hooks": [{ "type": "command", "command": "/usr/local/bin/git-courer subagent-start-hook" }] }
+    ],
+    "PreInvocation": [
+      { "matcher": "", "hooks": [{ "type": "command", "command": "/usr/local/bin/git-courer pre-invocation-hook" }] }
+    ]
+  }
+}
+```
+
+### Antigravity
+
+`~/.gemini/antigravity-cli/hooks.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "run_command", "hooks": [{ "type": "command", "command": "/usr/local/bin/git-courer hook-check" }] }
+    ],
+    "PreInvocation": [
+      { "matcher": "", "hooks": [{ "type": "command", "command": "/usr/local/bin/git-courer pre-invocation-hook" }] }
+    ]
+  }
+}
+```
+
+`~/.gemini/antigravity-cli/settings.json`:
+
+```json
+{
+  "permissions": {
+    "allow": ["mcp(git-courer/*)"],
+    "ask": ["command(git *)", "command(*)"]
+  }
+}
+```
+
+---
+
+## Verifying Your Installation
+
+```bash
+git-courer doctor
+```
+
+Check the `Hooks installed` and `Claude hooks` rows in the report. If either shows `not_installed` or `partial` for a client you use, re-run:
+
+```bash
+git-courer mcp setup <client>
+```
+
+To manually verify a hook is wired, run the subcommand directly — it should emit JSON on stdout:
+
+```bash
+/usr/local/bin/git-courer hook-check "git status"
+/usr/local/bin/git-courer session-start-hook < /dev/null
+```

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -1,6 +1,6 @@
 # MCP Clients
 
-git-courer supports **5 MCP clients** and automatically configures all detected tools, security policies, and prompt hooks with a single command.
+git-courer supports **5 MCP clients** and automatically configures all detected tools, security policies, prompt blocks, and lifecycle hooks with a single command.
 
 ---
 
@@ -8,11 +8,11 @@ git-courer supports **5 MCP clients** and automatically configures all detected 
 
 | Client | Status | Platform | Config Format | Auto-configured Files |
 |--------|--------|----------|---------------|-----------------------|
-| **OpenCode** | ✓ | Linux, macOS, Windows | JSON | `~/.config/opencode/opencode.json` (Includes custom security policies) |
-| **Claude Code** | ✓ | Linux, macOS, Windows | JSON | `~/.claude.json` (Includes lifecycle hook injection) |
-| **Codex** | ✓ | Linux, macOS, Windows | TOML | `~/.codex/config.toml` (Includes `hooks.json` hooks configuration) |
-| **pi** | ✓ | Linux, macOS, Windows | JSON | `~/.pi/agent/mcp.json` |
-| **Antigravity** | ✓ | Linux, macOS, Windows | JSON | `~/.gemini/antigravity-cli/mcp_config.json` |
+| **OpenCode** | ✓ | Linux, macOS, Windows | JSON | `~/.config/opencode/opencode.json` (MCP + policy), `~/.config/opencode/AGENTS.md` (prompt block) |
+| **Claude Code** | ✓ | Linux, macOS, Windows | JSON | `~/.claude.json` (MCP), `~/.claude/settings.json` (inline hooks), `~/.claude/CLAUDE.md` (prompt block) |
+| **Codex** | ✓ | Linux, macOS, Windows | TOML | `~/.codex/config.toml` (MCP), `~/.codex/hooks.json` (hooks), `~/.codex/AGENTS.md` (prompt block) |
+| **pi** | ✓ | Linux, macOS, Windows | JSON | `~/.pi/agent/mcp.json`, `~/.pi/agent/AGENTS.md` (prompt block) |
+| **Antigravity** | ✓ | Linux, macOS, Windows | JSON | `~/.gemini/antigravity-cli/mcp_config.json` (MCP), `~/.gemini/antigravity-cli/hooks.json` (hooks), `~/.gemini/antigravity-cli/settings.json` (permissions), `~/.gemini/GEMINI.md` (prompt block) |
 
 ---
 
@@ -30,7 +30,22 @@ To configure a single specific client:
 git-courer mcp setup opencode
 git-courer mcp setup codex
 git-courer mcp setup claude-code
+git-courer mcp setup antigravity
+git-courer mcp setup pi
 ```
+
+Setup is **idempotent** — re-running it never duplicates entries and never overwrites user content that is not owned by git-courer. Running setup twice produces byte-identical output.
+
+### Backup and Restore During Setup
+
+Before mutating any existing config file, git-courer backs it up alongside the original:
+
+- `opencode.json` → `opencode.json.bak`
+- `.claude.json` / `~/.claude/settings.json` → `.bak` sibling
+- `~/.codex/hooks.json` → `hooks.json.bak`
+- `~/.gemini/antigravity-cli/settings.json` → `settings.json.gc.bak`
+
+On uninstall (`git-courer remove`), the `.bak` is restored over the live file and the backup is removed. If no backup exists, git-courer strips only the git-courer-owned entries in place (preserving everything else). The Antigravity settings backup uses a distinct `.gc.bak` suffix to avoid clashing with any Antigravity-native backup scheme.
 
 ---
 
@@ -75,16 +90,183 @@ args = ["mcp"]
 
 ## Advanced Integration Features
 
-When you run `git-courer mcp setup`, git-courer installs advanced integrations to ensure that agents follow the correct workflows:
+When you run `git-courer mcp setup`, git-courer installs advanced integrations to ensure that agents follow the correct workflows. Each integration is targeted at the client that needs it — no client receives an integration it cannot use.
 
-### 1. Automatic Hook Injection (Claude Code, Codex, Antigravity)
-git-courer registers hooks on events like `SessionStart` and `SubagentStart`. 
-- **What it does**: These hooks intercept agent startup and dynamically inject git-courer's workflow rules (e.g. mandatory `session start` usage before modifying files) directly into the agent's system prompt context.
-- **Why it matters**: This ensures that agents always know the git-courer rules, even in fresh terminal windows or subagents, without polluting your code repositories with rule files.
+### 1. Hooks System (Claude Code, Codex, Antigravity)
 
-### 2. OpenCode Policy Injection
-OpenCode requires explicit permission definitions for executing commands on the host machine.
-- **What it does**: git-courer merges custom policy rules into `opencode.json`, automatically granting access to git commands and git-courer hooks to prevent annoying permission authorization prompts during code generation.
+git-courer registers **lifecycle hooks** so the agent always knows the git-courer workflow, even in a fresh terminal window or a subagent.
 
-### 3. Prompt Block Injection
-During setup or when running the `doctor` command, git-courer injects custom instruction prompt blocks directly into client-native instruction files such as `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` to guide agents correctly.
+Four hook events are used:
+
+| Event | Matcher | Command | Purpose |
+|-------|---------|---------|---------|
+| `PreToolUse` | `Bash` (Claude Code, Codex) / `run_command` (Antigravity) | `git-courer hook-check` | Classify the shell command the agent is about to run; suggest the git-courer MCP tool for git commands. Never denies — only suggests. |
+| `SessionStart` | `startup\|resume` | `git-courer session-start-hook` | Inject the Golden Rules into the agent's context at session start. |
+| `SubagentStart` | `general-purpose\|Explore\|Plan` | `git-courer subagent-start-hook` | Inject the Golden Rules when a subagent starts, so subagents also follow the rules. |
+| `PreInvocation` | *(empty matcher)* | `git-courer pre-invocation-hook` | Inject the Golden Rules before every model call (Antigravity only — it has no SessionStart/SubagentStart). |
+
+**Why it matters**: agents always see the `session start` → `status` → `diff`/`review` → `pr-review` workflow, without you having to repeat it in every repo or every subagent.
+
+See [hooks.md](./hooks.md) for the full event reference, per-client differences, lifecycle, and configuration examples.
+
+### 2. Claude Code Inline Hooks
+
+Claude Code stores hooks **inline** in `~/.claude/settings.json` (under the top-level `hooks` object, keyed by event name) — not in a separate hooks file. git-courer merges its entries into that object and preserves every non-git-courer hook and every other top-level settings key (`permissions`, `model`, `theme`, etc.).
+
+Claude Code uses the exec form: `type: "command"` with separate `command` and `args` fields, and supports an optional `timeout` (seconds). git-courer sets a 10-second timeout on `SessionStart`, `SubagentStart`, and `UserPromptSubmit` (Claude Code's name for the `PreInvocation` event).
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{ "type": "command", "command": "/usr/local/bin/git-courer hook-check", "args": [] }]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [{ "type": "command", "command": "/usr/local/bin/git-courer session-start-hook", "args": [], "timeout": 10 }]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "matcher": "general-purpose|Explore|Plan",
+        "hooks": [{ "type": "command", "command": "/usr/local/bin/git-courer subagent-start-hook", "args": [], "timeout": 10 }]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [{ "type": "command", "command": "/usr/local/bin/git-courer pre-invocation-hook", "args": [], "timeout": 10 }]
+      }
+    ]
+  }
+}
+```
+
+The merged file is written **atomically** (temp file + rename) so a crash mid-write never corrupts the real settings file.
+
+### 3. Codex Hooks (Separate File)
+
+Codex stores hooks in a separate `~/.codex/hooks.json` file. git-courer backs up the existing file to `hooks.json.bak` before the first mutation, then merges its entries. The structure is `hooks.<Event>[].matcher` + `hooks.<Event>[].hooks[].{type,command}`.
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Bash", "hooks": [{ "type": "command", "command": "/usr/local/bin/git-courer hook-check" }] }
+    ],
+    "SessionStart": [
+      { "matcher": "startup|resume", "hooks": [{ "type": "command", "command": "/usr/local/bin/git-courer session-start-hook" }] }
+    ],
+    "SubagentStart": [
+      { "matcher": "general-purpose|Explore|Plan", "hooks": [{ "type": "command", "command": "/usr/local/bin/git-courer subagent-start-hook" }] }
+    ],
+    "PreInvocation": [
+      { "matcher": "", "hooks": [{ "type": "command", "command": "/usr/local/bin/git-courer pre-invocation-hook" }] }
+    ]
+  }
+}
+```
+
+### 4. Antigravity Hooks + Permissions
+
+Antigravity uses a **separate** `hooks.json` (with the `run_command` matcher instead of `Bash`) AND a separate `settings.json` for **declarative permissions**. git-courer installs both.
+
+**Hooks** (`~/.gemini/antigravity-cli/hooks.json`) — only `PreToolUse` and `PreInvocation` (Antigravity has no SessionStart/SubagentStart events; `PreInvocation` runs before every model call to compensate):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "run_command", "hooks": [{ "type": "command", "command": "/usr/local/bin/git-courer hook-check" }] }
+    ],
+    "PreInvocation": [
+      { "matcher": "", "hooks": [{ "type": "command", "command": "/usr/local/bin/git-courer pre-invocation-hook" }] }
+    ]
+  }
+}
+```
+
+**Permissions** (`~/.gemini/antigravity-cli/settings.json`) — three entries are merged into the existing `permissions` object:
+
+- `permissions.allow` gains `"mcp(git-courer/*)"` — allow all git-courer MCP tools without prompting.
+- `permissions.ask` gains `"command(git *)"` — prompt before raw git commands (so the agent is nudged toward the git-courer equivalent).
+- `permissions.ask` gains `"command(*)"` — prompt before any other shell command.
+
+Non-git-courer permission entries and every other top-level settings key are preserved. The backup uses `.gc.bak` so it does not collide with any Antigravity-native backup.
+
+### 5. OpenCode Policy Injection
+
+OpenCode requires explicit permission definitions for executing commands on the host machine. git-courer merges two policy entries into `opencode.json`:
+
+- **`permission.bash["git *"] = "ask"`** — OpenCode asks the user before running raw git commands, which nudges the agent toward the git-courer MCP tool instead. Existing `permission.bash` keys are preserved; Go's alphabetical map sort on `json.MarshalIndent` naturally places `"git *"` after `"*"`, so last-match-wins applies.
+- **`instructions`** array includes the path to `AGENTS.md` in the same directory as `opencode.json` (deduplicated; a string `instructions` value is converted to an array preserving the original entry). The legacy `GIT_COURER.md` path is removed if present.
+
+If `opencode.json` does not exist, a fresh config with the policy is written. If it exists but is unparseable JSON, it is backed up and a fresh config with the policy is written. The merge is idempotent — running twice produces byte-identical output.
+
+### 6. Prompt Block Injection
+
+During setup (and when running `doctor`), git-courer injects a **prompt block** directly into the client-native instructions file so agents see the Golden Rules as part of their standing context:
+
+- **OpenCode** → `~/.config/opencode/AGENTS.md`
+- **Claude Code** → `~/.claude/CLAUDE.md`
+- **Codex** → `~/.codex/AGENTS.md`
+- **pi** → `~/.pi/agent/AGENTS.md`
+- **Antigravity** → `~/.gemini/GEMINI.md`
+
+The block is delimited by marker comments so git-courer can find and update it without touching anything else in the file:
+
+```markdown
+<!-- git-courer start -->
+# git-courer — Golden Rules
+
+git-courer is NOT a wrapper around git. Some tools do things raw git CANNOT.
+Others are structured replacements that return JSON instead of human text.
+
+## Golden Rules — save tokens and prevent mistakes
+
+0. On session start (MANDATORY) → ALWAYS run `session start` to create an isolated worktree before starting any task.
+1. Before any mutation → ALWAYS check `status` to know the repository state and identify active changes.
+2. Before push or PR (or when verifying changes) → ALWAYS check `diff` + `review` to verify active diff checks.
+3. Before PR → ALWAYS run `pr-review` to run all checks and verify changes in a single call.
+<!-- git-courer end -->
+```
+
+If the file does not exist, git-courer creates it with just the wrapped block. If it exists, the block is inserted (or updated in place if a previous block is found between the markers). Anything outside the markers is left untouched. `git-courer remove` strips the block and leaves the rest of the file intact.
+
+> The old physical `GIT_COURER.md` file is removed on setup if present — the prompt block now carries the same content in the instructions file the client already reads.
+
+---
+
+## Diagnostics: `doctor` and `hook-check`
+
+### `doctor` (CLI / MCP)
+
+```bash
+git-courer doctor
+```
+
+Runs **read-only diagnostics** on every detected MCP client and prints a human-readable report. Per client it checks:
+
+- **Config path** — the resolved config file.
+- **MCP configured** — whether the config file exists and contains `git-courer`.
+- **Prompt block injected** — whether the instructions file contains both `<!-- git-courer start -->` and `<!-- git-courer end -->`.
+- **Hooks installed** — the Codex-style hook status (`installed` / `not_installed`) for clients with a `HooksPath`.
+- **Claude hooks** — the Claude Code inline hook status (`installed` / `not_installed` / `partial`) for clients with a `SettingsPath`. Omitted for clients that do not use inline Claude hooks.
+
+The MCP tool form returns the same diagnostic envelope as structured JSON (engram-doctor-style: a per-client list with each field). It is safe to run at any time — it never mutates anything.
+
+### `hook-check` (CLI / hook entry point)
+
+```bash
+git-courer hook-check "<shell command>"
+```
+
+This is the command the `PreToolUse` hooks invoke. It classifies a shell command via the gitcmd classifier and emits the result as JSON on stdout. For git commands it includes `additionalContext` suggesting the git-courer MCP tool instead of bash — it **never denies** a command, it only nudges.
+
+When invoked with no args and stdin is a pipe (Codex hook mode), it reads the Codex hook JSON from stdin, extracts the command, classifies it, and emits a Codex-shaped `hookSpecificOutput` with `additionalContext`. Non-git commands exit cleanly with no output.
+
+The companion subcommands `session-start-hook`, `subagent-start-hook`, and `pre-invocation-hook` read stdin (ignored) and emit the Golden Rules as `additionalContext` for the `SessionStart`, `SubagentStart`, and `PreInvocation` events respectively.

--- a/docs/models.md
+++ b/docs/models.md
@@ -15,25 +15,40 @@ A core architectural principle of git-courer is that **the commit type (e.g., `f
 
 ---
 
+## `llm.enabled: false` — Operating Without an LLM
+
+Setting `llm.enabled: false` disables all AI features. In this mode:
+
+- **Commit type detection still works** — it is Go AST-based, not LLM-based.
+- **Commit message bodies are not generated** — the agent/user writes them manually.
+- **Changelog generation is unavailable** — releases fall back to a tag-only flow.
+- **Security audit falls back to the non-LLM layers** — binary, blacklist, static analysis, and regex still run, but there is no AI override of regex false positives (see `docs/security-architecture.md`).
+- **`Validate()` skips mandatory-field checks** — when `enabled` is false, `provider` and `model` are not required.
+
+This is useful for air-gapped environments or when you want the deterministic guarantees of the Go classifier without an LLM dependency.
+
+---
+
 ## Context Window Resolution (3-Tier Cascade)
 
 At startup or install time, git-courer dynamically resolves the target model's context window size to ensure prompt payloads fit within the LLM limits. It follows a 3-tier cascade strategy:
 
 1. **Ollama Lookup**: If using Ollama, git-courer calls the `/api/show` endpoint to dynamically read `<architecture>.context_length` or `context_length` from the active local model.
-2. **User Config Override**: If the Ollama lookup fails or a remote provider is used, it reads the `llm.context_window` setting from `~/.config/git-courer/config.yaml`.
+2. **User Config Override**: If the Ollama lookup fails or a remote provider is used, it reads the `llm.context_window` setting from `~/.config/git-courer/config.yaml`. A value of `0` (the default) means "resolve automatically"; any value `> 0` is used verbatim.
 3. **Default Fallback**: Falls back to a safe default of `8192` tokens if no other context size is resolved.
 
 ---
 
-## Model Recommendations
+## Choosing a Model
 
-While git-courer prompts are optimized to work on any model size, performance and description quality scale with model capability:
+git-courer's prompts are tuned to work across model sizes, but quality scales with model capability. **There is no single recommended model** — performance depends on your hardware, quantization, and the kind of changes you commit. Instead of trusting a generic table, **benchmark on your own setup**:
 
-| Model | Recommended Use Case | Commit Description Quality | Security Auditor Capability |
-|-------|----------------------|---------------------------|----------------------------|
-| **gemma4:26b** (or similar) | High-performance workstation | Elite (Excellent context & details) | Highly Paranoid |
-| **qwen3.5:latest** (7b) | Standard Developer Laptop | Very Good (Accurate, concise) | Reliable |
-| **qwen3.5:0.8b** (or similar) | Modest laptops / No GPU | Basic (Requires offline toggle verification) | Limited (Fallback to regex is safer) |
+1. Pull a candidate model (`ollama pull <model>`).
+2. Run `make test-e2e` against it.
+3. Inspect the generated commit messages and changelog entries for accuracy.
+4. Compare against another model on the same diff.
+
+Smaller models (`< 7B`) tend to need the strict-classification prompt path and may produce terser messages; larger models (`14B+`) handle deeper semantic context. The security auditor's `ParseModelSize` uses these same thresholds to select its prompt strategy (see `docs/security-architecture.md`).
 
 ---
 
@@ -45,8 +60,9 @@ Ollama is auto-discovered and managed by git-courer.
 llm:
   enabled: true
   provider: ollama
-  model: qwen3.5:latest
+  model: llama3.2:latest
   base_url: http://localhost:11434/v1
+  num_parallel: 1
 ```
 
 ### 2. LM Studio
@@ -58,6 +74,7 @@ llm:
   provider: lmstudio
   base_url: http://localhost:1234/v1
   model: my-model
+  num_parallel: 1
 ```
 
 ### 3. vLLM
@@ -71,6 +88,7 @@ llm:
   provider: vllm
   base_url: http://localhost:8000/v1
   model: my-model
+  num_parallel: 1
 ```
 
 ### 4. LocalAI
@@ -81,6 +99,7 @@ llm:
   provider: localai
   base_url: http://localhost:8080/v1
   model: my-model
+  num_parallel: 1
 ```
 
 ### 5. Standard OpenAI-Compatible Server
@@ -93,3 +112,19 @@ llm:
   api_key: sk-proj-...  # Optional API key if required by your endpoint
   num_parallel: 1
 ```
+
+---
+
+## Field Reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `llm.enabled` | bool | `true` | Master switch for all AI features. `false` disables LLM generation, changelog, and the AI security auditor (deterministic Go classification still works). |
+| `llm.provider` | string | *(mandatory)* | Provider key: `ollama`, `lmstudio`, `vllm`, `localai`, `openai`, or any OpenAI-compatible key. |
+| `llm.model` | string | *(mandatory)* | Model name as the provider expects it (e.g. `llama3.2:latest`, `gpt-4o-mini`). Parsed by `ParseModelSize` for prompt-strategy selection. |
+| `llm.base_url` | string | `http://localhost:11434/v1` | OpenAI-compatible completions endpoint. Required for non-Ollama providers. |
+| `llm.context_window` | int | `0` | `0` = resolve automatically (Ollama API → fallback `8192`). `>0` = use this value verbatim. |
+| `llm.num_parallel` | int | `1` | Number of concurrent LLM requests the adapter may issue (e.g. for parallel commit-message generation). Raise this on providers that accept higher concurrency; `1` is the safe default for local single-model setups. |
+| `llm.api_key` | string | *(none)* | **Adapter-level, not a config struct field.** Shown in the OpenAI example above for convenience; it is passed at adapter creation (`FactoryConfig.APIKey`), not read from `LLMConfig`. Omit for local providers that do not require auth. |
+
+> **`api_key` note**: `LLMConfig` does not have an `api_key` YAML field. The key is supplied at adapter-creation time via `FactoryConfig.APIKey`. The `api_key:` line in the OpenAI example above is consumed during setup wiring, not parsed from the global config file.

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -13,9 +13,9 @@ The security service (`internal/security/security.go`) audits all staged files a
 | **Layer 1** | Binary | Magic Bytes + AI Audit | Checks file headers for executables (ELF, PE, Mach-O) using `IsBinary` and runs an LLM binary noise check (`AuditBinaryContent`) for suspicious text files. |
 | **Layer 2** | Metadata | Folder Blacklist | Blocks staging changes in system directories (`.git/`, `.github/`, `vendor/`, `test/`). |
 | **Layer 3** | Metadata | Filename Blacklist | Prevents tracking of credential files (`.env`, `credentials.json`, `id_rsa`, `auth.key`). |
-| **Layer 4** | Static | External Static Analyzers | Runs local security tools (like `trufflehog` or `gosec`) on the staged files if they are installed and available in the system path. |
+| **Layer 4** | Static | External Static Analyzers | Runs local security tools (`trufflehog` or `gosec`) on the staged files if they are installed and available in `PATH`. Wrapped in a **30-second timeout** (`context.WithTimeout`) so a hung analyzer cannot block the commit indefinitely. |
 | **Layer 5** | Static | Content Regex Scan | Performs regex pattern matching on filenames and staged diff content to identify potential AWS, Stripe, Google Cloud, and generic token matches. |
-| **Layer 6** | AI | LLM Auditor Verification | Sends the cleaned diff to a paranoid security agent (`VerifySecrets`). If the LLM validates the diff as safe, it can override low-confidence regex matches to prevent false positives. |
+| **Layer 6** | AI | LLM Auditor Verification | Sends the **filtered** diff (see `filterDiff` below) to a paranoid security agent (`VerifySecrets`). If the LLM validates the diff as safe, it can **override low-confidence regex matches** to prevent false positives (see AI Override below). |
 
 ---
 
@@ -24,13 +24,47 @@ The security service (`internal/security/security.go`) audits all staged files a
 ### 🛡️ Memory-First Scanning
 The security service operates on the **Git Diff in memory** instead of reading files blindly from disk. This ensures that uncommitted edits or temporary files cannot bypass the check.
 
-### 🚫 Test File Exceptions
-Go test files (`*_test.go`) and files under the `test/` directory are explicitly exempted from regex secret blocks. This allows developers to commit mock keys, fake certificates, or structural tests without trigger blocks.
+### 🧹 filterDiff — Cleaning the Diff Before the LLM Sees It
 
-### 🧠 Model-Agnostic prompts
-Refined "accuracy-first" system instructions ensure that the paranoid AI auditor works reliably across different model sizes:
-- **Large Models (26B+)**: Perform a deep semantic analysis of the code context to determine if a matched string is a real credential or structural code.
-- **Small Models (<1B)**: Adhere strictly to classification instructions and output format validations.
+Before the diff is sent to the LLM auditor (Layer 6), `filterDiff()` (`internal/security/security.go`) strips out chunks that would cause false positives or leak prompt scaffolding:
+
+- **Go test files** (`*_test.go`) — mock keys and fake credentials are expected there.
+- **Files under `test/`** — E2E and pipeline fixtures.
+- **Files under `internal/shared/prompts/txt/`** — the prompt templates themselves contain token-like strings that regex would flag.
+
+The function splits the diff on the `diff --git ` boundary, inspects each chunk's header, and keeps only the non-excluded chunks. The LLM therefore only audits real production changes.
+
+### 🚫 Test File Exceptions
+
+Go test files (`*_test.go`) receive a **double exemption** — they are skipped in *both* the binary audit and the regex scan:
+
+1. **Binary AI audit (Layer 1)**: the `ShouldUseLLMScan() && !_test.go` guard means `AuditBinaryContent` is never called on test files, so a test fixture containing binary-looking bytes does not trigger a false block.
+2. **Regex scan (Layer 5)**: findings whose file ends in `_test.go` or lives under `test/` are filtered out of `filteredFindings` before they can become a block.
+
+This lets developers commit mock keys, fake certificates, and structural tests without being blocked.
+
+### 🤖 AI Override of Low-Confidence Regex Matches
+
+When the LLM auditor (Layer 6) is active and the regex scan (Layer 5) produced findings, the LLM's verdict is used as the tiebreaker:
+
+- **LLM says real secret** → the commit is blocked (`ai_auditor` result).
+- **LLM says not a secret** → all regex findings are **cleared** and the commit is unblocked. This is the override: the paranoid AI vouches that the regex matches were false positives, so the low-confidence regex block is discarded rather than left as a warning.
+
+When the LLM is **not** active (`llm.enabled: false` or no LLM configured), any regex finding blocks the commit — there is no override path.
+
+### 🧠 Model Size Gating — `ParseModelSize`
+
+`ParseModelSize()` (`internal/security/model.go`) parses the model name to extract its parameter count and classify it into a size category:
+
+| Parameter count in name | Classification | Example |
+|--------------------------|-----------------|---------|
+| `>= 14b` | `ModelSizeLarge` | `qwen3.5:14b`, `gemma:26b` |
+| `>= 7b` and `< 14b` | `ModelSizeMedium` | `qwen3.5:7b` |
+| `< 7b` (or unparseable) | `ModelSizeSmall` | `qwen3.5:0.8b`, `tinyllama` |
+
+The size is stored on the `Service` struct (`modelSize`) and is used to select prompt strategies: larger models get deep-semantic-analysis prompts, while smaller models get strict classification-and-format prompts to stay reliable within their capacity.
+
+> **Note on `ShouldUseLLMScan()`**: this method is currently hardcoded to `return true` ("auto" mode) — all models are sent to the LLM auditor regardless of size. The `modelSize` field still influences which prompt the auditor receives. If a future change gates the LLM scan on `ModelSizeLarge` (the 14B+ threshold), this method is the single switch point.
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,21 +4,68 @@ git-courer utilizes a comprehensive testing strategy combining unit tests and E2
 
 ---
 
-## Test Targets
+## Build Requirement: `CGO_ENABLED=1`
 
-All tests are configured in the [Makefile](file:///git-courer/git-courer/Makefile).
+git-courer uses cgo bindings, so the binary and all tests **must** be built with `CGO_ENABLED=1`. The Makefile sets this for you on every target; if you invoke `go build` or `go test` directly, export it yourself:
 
-### 1. Unit Tests (`make test-unit` or `make test`)
+```bash
+CGO_ENABLED=1 go build -o git-courer ./cmd/main.go
+CGO_ENABLED=1 go test ./...
+```
+
+---
+
+## Make Targets
+
+All targets are defined in the [Makefile](file:///git-courer/git-courer/Makefile):
+
+| Target | Purpose |
+|--------|---------|
+| `make build` | Build the self-contained `git-courer` binary (`CGO_ENABLED=1 go build`). |
+| `make test-unit` (alias: `make test`) | Run `go vet` then unit tests with the `-short` flag. No external services needed. |
+| `make test-e2e` | Run E2E pipeline tests with `-tags e2e`. Requires a live LLM service. |
+| `make lint` | `go vet ./...`. |
+| `make clean` | Remove the built binary and clear the Go build cache. |
+| `make help` | Print the target list. |
+
+---
+
+## `gotestsum` (Optional)
+
+The Makefile auto-detects [gotestsum](https://github.com/gotestyourself/gotestsum) on your `PATH` (or at `~/go/bin/gotestsum`). If found, tests are run through `gotestsum` with the `pkgname-and-test-fails` format for readable output; otherwise it falls back to plain `go test`. No configuration is needed — install gotestsum to get the nicer output:
+
+```bash
+go install gotest.tools/gotestsum@latest
+```
+
+---
+
+## Test Suite
+
+### 1. Unit Tests (`make test-unit`)
+
 Isolated, fast-running tests that verify core logic, config parsing, AST path type resolutions, and security rule matchers.
+
 - **Location**: `internal/**/*_test.go`
+- **Flag**: `-short` — skips long-running or integration-style tests, keeping the unit run fast.
 - **Focus**: Chunker parsing, classification logic, magic byte detection, config validation, and helpers.
 - **Requirement**: No external dependencies or running LLM services required.
 
 ### 2. Pipeline E2E Tests (`make test-e2e`)
+
 Runs the full commit pipeline (PREVIEW and APPLY) and release flows using a real LLM instance.
+
 - **Location**: `test/pipeline/` and `test/release/`
+- **Flag**: `-tags e2e` — the build tag that enables E2E test files.
 - **Focus**: Committing changes, generating changelogs, staging files, and verifying AST annotations with live model feedback.
 - **Prerequisite**: An active local Ollama instance (recommended model: `qwen3.5:latest`) or an OpenAI-compatible API endpoint configured via the environment variables `LLM_BASE_URL` and `LLM_MODEL`.
+
+#### Test Directory Structure
+
+| Directory | Contents |
+|-----------|---------|
+| `test/pipeline/` | End-to-end commit pipeline tests (PREVIEW → APPLY, AST annotations, security blocks). |
+| `test/release/` | Release-flow tests (changelog generation, version bumping, tagging). |
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -113,10 +113,12 @@ chmod +x ~/.local/bin/git-courer
 
 ## Secrets detected in commit
 
-git-courer has 6 security layers that block commits with:
+git-courer has 6 cumulative security layers that block commits with:
 - API keys (OpenAI, Stripe, AWS, etc.)
 - Passwords
 - Private tokens
+
+The layers run in this order (matches `internal/security/security.go`): binary audit → folder blacklist → name blacklist → static analysis → regex → LLM verification. Legitimate Go test files (`*_test.go`) are exempted from the binary audit and regex layers.
 
 **If it's a false positive:**
 ```bash
@@ -125,6 +127,130 @@ git commit --no-verify
 ```
 
 **Fix:** Move secrets to `.env` and add it to `.gitignore`.
+
+## Diagnostics with `doctor`
+
+Run a read-only health check across every detected MCP client:
+
+```bash
+git-courer doctor
+```
+
+For each client it prints:
+- **Config path** — where the client config file lives.
+- **MCP configured** — whether the `git-courer` MCP entry is present.
+- **Prompt block injected** — whether the `<!-- git-courer start -->` golden-rules block is present in the client's instructions file.
+- **Hooks installed** — `yes` / `no` / `partial` (clients that support hook files).
+- **Claude hooks** — only shown for Claude Code (inline `settings.json` hooks).
+
+If `doctor` reports `MCP configured: no` but you already ran `mcp setup`, the client's config path moved or was rewritten by another tool. Re-run `git-courer mcp setup`. If `Hooks installed: partial`, at least one expected hook entry is missing — re-run `mcp setup` (it is idempotent and only writes missing entries).
+
+## `hook-check` troubleshooting
+
+`hook-check` classifies a shell command and emits JSON; it **never denies** a command — it only adds `additionalContext` suggesting the git-courer MCP tool for git commands.
+
+```bash
+# Direct invocation
+git-courer hook-check "git status"
+
+# Codex stdin mode (no args; reads Codex hook JSON from stdin)
+echo '{"event":{"input":{"command":"git push"}}}' | git-courer hook-check
+```
+
+- **No output for a non-git command** — expected. `hook-check` only emits JSON when the command classifies as a git command (`Decision == "ask"`).
+- **`usage: git-courer hook-check <command>`** — you passed no argument and stdin is not a pipe. Either pass a command as the first arg or pipe Codex hook JSON via stdin.
+- **No output in stdin mode** — the input wasn't valid Codex hook JSON. `hook-check` exits cleanly as a safe fallback (it never blocks the agent).
+- Companion hooks (`session-start-hook`, `subagent-start-hook`, `pre-invocation-hook`) emit golden-rules `additionalContext` and never set `permissionDecision`.
+
+## Session issues
+
+### Worktree conflicts on `session finish`
+
+`session finish` removes the session worktree but **leaves the branch alive** for manual integration (no merge is attempted). If finish fails with `cleanup_failed`, the worktree may still be locked:
+
+```bash
+# List worktrees to find stale ones
+git worktree list
+
+# Remove a stale worktree manually
+git worktree remove --force /path/to/worktree
+git worktree prune
+```
+
+After a `cleanup_failed` finish, the session metadata is preserved with `status: cleanup_failed`. Retry `session finish`, or discard the session with `session discard` (requires `confirmed: true`).
+
+### Stale sessions
+
+Sessions whose worktree was deleted out-of-band (manually, disk cleanup, reboot) become stale. Recover with:
+
+```bash
+git-courer session status   # via the MCP tool — lists all sessions
+git-courer session discard  # removes session metadata without touching the branch
+```
+
+`session finish` will not delete the session branch — if you want it gone, delete it explicitly with `branch DELETE`.
+
+### Uncommitted changes block finish
+
+`session finish` runs a light preview whose only abort gate is uncommitted/untracked changes (data-loss guard). Commit or stash your work first:
+
+```bash
+# Via the MCP tools
+git-courer commit APPLY     # or
+git-courer stash SAVE
+```
+
+## `init`, `version --predict`, `remove` commands
+
+### `git-courer init`
+
+Launches the TUI init wizard to create or update project configuration (per-project `.git/git-courer/config.json`, including `user_name` / `user_email` / `signing_key`).
+
+```bash
+git-courer init
+```
+
+### `git-courer version --predict`
+
+Predicts the next release tag from conventional commits since the latest tag — no LLM required, pure Go:
+
+```bash
+git-courer version --predict
+# Current: v2.8.0
+# Bump:    minor
+# Next:    v2.9.0
+```
+
+Requires a git repo with at least one tag. With no new commits since the latest tag, it prints the current tag and exits.
+
+### `git-courer remove`
+
+Cleans project-level git-courer artifacts (the per-project config). It does **not** uninstall the binary — use `git-courer uninstall` for that.
+
+## Self-update asset matching
+
+`git-courer update` queries the latest GitHub release and matches a release asset to your `GOOS`/`GOARCH`:
+
+1. Goreleaser archive pattern first (`git-courer_<version>_<os>_<arch>.tar.gz` / `.zip`).
+2. Raw binary pattern as fallback (`git-courer_<version>_<os>_<arch>`).
+
+If no asset matches, it fails with `no compatible asset found for <GOOS>/<GOARCH>`. Workarounds:
+
+- Build from source: `go install github.com/blak0p/git-courer@latest` (requires Go 1.26+, `CGO_ENABLED=1`).
+- `git-courer update --force` re-runs the check and reconfigures MCP clients afterward.
+
+## OpenCode policy issues
+
+`mcp setup` merges the git-courer policy into `~/.config/opencode/opencode.json`:
+
+- `permission.bash["git *"] = "ask"` (preserving any existing keys; Go's map ordering is non-deterministic so existing keys are kept).
+- `instructions` array includes the `AGENTS.md` path (legacy `GIT_COURER.md` entries are removed).
+
+If `opencode.json` is unparseable JSON, `mcp setup` backs it up to `opencode.json.bak` and writes a fresh config with the policy. If your OpenCode agent isn't prompting for permission on `git *` commands:
+
+1. Run `git-courer doctor` — confirm `MCP configured: yes` and `Prompt block injected: yes`.
+2. Check the backup: `ls ~/.config/opencode/*.bak` — restore manually if a third-party tool overwrote your config.
+3. Re-run `git-courer mcp setup` (idempotent; only writes missing keys).
 
 ## "Near-zero tokens" but my AI still uses tokens
 


### PR DESCRIPTION
## Chain Context

| Field | Value |
|-------|-------|
| Chain | docs-rewrite |
| Tracker PR | [#191](https://github.com/blak0p/git-courer/pull/191) |
| Position | 1 of 4 |
| Base | `feat/docs-rewrite` |
| Depends on | None |
| Follow-up | PR #2 — mcp-clients.md + hooks.md |
| Review budget | ~145 / 400 |
| Starts at | main |
| Ends with | architecture.md, config.md, commands.md fixed |

### Chain Overview

```text
main
 └── #191 Tracker PR (draft)
      └── 📍 #NNN This PR
           └── #NNN PR #2 — mcp-clients + hooks
                └── #NNN PR #3 — polish
                     └── #NNN PR #4 — detail docs
```

### Scope
- **Includes**: Fix directory tree in architecture.md (add 12+ missing packages, fix security layer order), fix config.md defaults (context_window, path_types, user fields), fix commands.md (remove Non-AI mode, fix session finish, add doctor/hook-check)
- **Excludes**: Hooks docs, mcp-clients, README, CONTRIBUTING, troubleshooting, security/testing/models docs

### Autonomy
- [ ] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit

---

## Summary

Phase 1 of the documentation rewrite. Fixes the 3 most misleading docs:

- **architecture.md**: Corrected directory tree (removed 3 non-existent dirs, added 12+ missing packages), fixed security layer order to match code
- **config.md**: Fixed `context_window` default (0→auto-resolved), `path_types` example, added `user_name`/`user_email`/`signing_key` per-project fields
- **commands.md**: Removed "Non-AI Mode" references, documented PREVIEW/APPLY pipeline, fixed `session finish` behavior, added `doctor`/`hook-check` CLI subcommands