### PR TITLE
docs: Phase 4 — detail docs (security, testing, models)

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -15,25 +15,40 @@ A core architectural principle of git-courer is that **the commit type (e.g., `f
 
 ---
 
+## `llm.enabled: false` — Operating Without an LLM
+
+Setting `llm.enabled: false` disables all AI features. In this mode:
+
+- **Commit type detection still works** — it is Go AST-based, not LLM-based.
+- **Commit message bodies are not generated** — the agent/user writes them manually.
+- **Changelog generation is unavailable** — releases fall back to a tag-only flow.
+- **Security audit falls back to the non-LLM layers** — binary, blacklist, static analysis, and regex still run, but there is no AI override of regex false positives (see `docs/security-architecture.md`).
+- **`Validate()` skips mandatory-field checks** — when `enabled` is false, `provider` and `model` are not required.
+
+This is useful for air-gapped environments or when you want the deterministic guarantees of the Go classifier without an LLM dependency.
+
+---
+
 ## Context Window Resolution (3-Tier Cascade)
 
 At startup or install time, git-courer dynamically resolves the target model's context window size to ensure prompt payloads fit within the LLM limits. It follows a 3-tier cascade strategy:
 
 1. **Ollama Lookup**: If using Ollama, git-courer calls the `/api/show` endpoint to dynamically read `<architecture>.context_length` or `context_length` from the active local model.
-2. **User Config Override**: If the Ollama lookup fails or a remote provider is used, it reads the `llm.context_window` setting from `~/.config/git-courer/config.yaml`.
+2. **User Config Override**: If the Ollama lookup fails or a remote provider is used, it reads the `llm.context_window` setting from `~/.config/git-courer/config.yaml`. A value of `0` (the default) means "resolve automatically"; any value `> 0` is used verbatim.
 3. **Default Fallback**: Falls back to a safe default of `8192` tokens if no other context size is resolved.
 
 ---
 
-## Model Recommendations
+## Choosing a Model
 
-While git-courer prompts are optimized to work on any model size, performance and description quality scale with model capability:
+git-courer's prompts are tuned to work across model sizes, but quality scales with model capability. **There is no single recommended model** — performance depends on your hardware, quantization, and the kind of changes you commit. Instead of trusting a generic table, **benchmark on your own setup**:
 
-| Model | Recommended Use Case | Commit Description Quality | Security Auditor Capability |
-|-------|----------------------|---------------------------|----------------------------|
-| **gemma4:26b** (or similar) | High-performance workstation | Elite (Excellent context & details) | Highly Paranoid |
-| **qwen3.5:latest** (7b) | Standard Developer Laptop | Very Good (Accurate, concise) | Reliable |
-| **qwen3.5:0.8b** (or similar) | Modest laptops / No GPU | Basic (Requires offline toggle verification) | Limited (Fallback to regex is safer) |
+1. Pull a candidate model (`ollama pull <model>`).
+2. Run `make test-e2e` against it.
+3. Inspect the generated commit messages and changelog entries for accuracy.
+4. Compare against another model on the same diff.
+
+Smaller models (`< 7B`) tend to need the strict-classification prompt path and may produce terser messages; larger models (`14B+`) handle deeper semantic context. The security auditor's `ParseModelSize` uses these same thresholds to select its prompt strategy (see `docs/security-architecture.md`).
 
 ---
 
@@ -45,8 +60,9 @@ Ollama is auto-discovered and managed by git-courer.
 llm:
   enabled: true
   provider: ollama
-  model: qwen3.5:latest
+  model: llama3.2:latest
   base_url: http://localhost:11434/v1
+  num_parallel: 1
 ```
 
 ### 2. LM Studio
@@ -58,6 +74,7 @@ llm:
   provider: lmstudio
   base_url: http://localhost:1234/v1
   model: my-model
+  num_parallel: 1
 ```
 
 ### 3. vLLM
@@ -71,6 +88,7 @@ llm:
   provider: vllm
   base_url: http://localhost:8000/v1
   model: my-model
+  num_parallel: 1
 ```
 
 ### 4. LocalAI
@@ -81,6 +99,7 @@ llm:
   provider: localai
   base_url: http://localhost:8080/v1
   model: my-model
+  num_parallel: 1
 ```
 
 ### 5. Standard OpenAI-Compatible Server
@@ -93,3 +112,19 @@ llm:
   api_key: sk-proj-...  # Optional API key if required by your endpoint
   num_parallel: 1
 ```
+
+---
+
+## Field Reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `llm.enabled` | bool | `true` | Master switch for all AI features. `false` disables LLM generation, changelog, and the AI security auditor (deterministic Go classification still works). |
+| `llm.provider` | string | *(mandatory)* | Provider key: `ollama`, `lmstudio`, `vllm`, `localai`, `openai`, or any OpenAI-compatible key. |
+| `llm.model` | string | *(mandatory)* | Model name as the provider expects it (e.g. `llama3.2:latest`, `gpt-4o-mini`). Parsed by `ParseModelSize` for prompt-strategy selection. |
+| `llm.base_url` | string | `http://localhost:11434/v1` | OpenAI-compatible completions endpoint. Required for non-Ollama providers. |
+| `llm.context_window` | int | `0` | `0` = resolve automatically (Ollama API → fallback `8192`). `>0` = use this value verbatim. |
+| `llm.num_parallel` | int | `1` | Number of concurrent LLM requests the adapter may issue (e.g. for parallel commit-message generation). Raise this on providers that accept higher concurrency; `1` is the safe default for local single-model setups. |
+| `llm.api_key` | string | *(none)* | **Adapter-level, not a config struct field.** Shown in the OpenAI example above for convenience; it is passed at adapter creation (`FactoryConfig.APIKey`), not read from `LLMConfig`. Omit for local providers that do not require auth. |
+
+> **`api_key` note**: `LLMConfig` does not have an `api_key` YAML field. The key is supplied at adapter-creation time via `FactoryConfig.APIKey`. The `api_key:` line in the OpenAI example above is consumed during setup wiring, not parsed from the global config file.

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -13,9 +13,9 @@ The security service (`internal/security/security.go`) audits all staged files a
 | **Layer 1** | Binary | Magic Bytes + AI Audit | Checks file headers for executables (ELF, PE, Mach-O) using `IsBinary` and runs an LLM binary noise check (`AuditBinaryContent`) for suspicious text files. |
 | **Layer 2** | Metadata | Folder Blacklist | Blocks staging changes in system directories (`.git/`, `.github/`, `vendor/`, `test/`). |
 | **Layer 3** | Metadata | Filename Blacklist | Prevents tracking of credential files (`.env`, `credentials.json`, `id_rsa`, `auth.key`). |
-| **Layer 4** | Static | External Static Analyzers | Runs local security tools (like `trufflehog` or `gosec`) on the staged files if they are installed and available in the system path. |
+| **Layer 4** | Static | External Static Analyzers | Runs local security tools (`trufflehog` or `gosec`) on the staged files if they are installed and available in `PATH`. Wrapped in a **30-second timeout** (`context.WithTimeout`) so a hung analyzer cannot block the commit indefinitely. |
 | **Layer 5** | Static | Content Regex Scan | Performs regex pattern matching on filenames and staged diff content to identify potential AWS, Stripe, Google Cloud, and generic token matches. |
-| **Layer 6** | AI | LLM Auditor Verification | Sends the cleaned diff to a paranoid security agent (`VerifySecrets`). If the LLM validates the diff as safe, it can override low-confidence regex matches to prevent false positives. |
+| **Layer 6** | AI | LLM Auditor Verification | Sends the **filtered** diff (see `filterDiff` below) to a paranoid security agent (`VerifySecrets`). If the LLM validates the diff as safe, it can **override low-confidence regex matches** to prevent false positives (see AI Override below). |
 
 ---
 
@@ -24,13 +24,47 @@ The security service (`internal/security/security.go`) audits all staged files a
 ### 🛡️ Memory-First Scanning
 The security service operates on the **Git Diff in memory** instead of reading files blindly from disk. This ensures that uncommitted edits or temporary files cannot bypass the check.
 
-### 🚫 Test File Exceptions
-Go test files (`*_test.go`) and files under the `test/` directory are explicitly exempted from regex secret blocks. This allows developers to commit mock keys, fake certificates, or structural tests without trigger blocks.
+### 🧹 filterDiff — Cleaning the Diff Before the LLM Sees It
 
-### 🧠 Model-Agnostic prompts
-Refined "accuracy-first" system instructions ensure that the paranoid AI auditor works reliably across different model sizes:
-- **Large Models (26B+)**: Perform a deep semantic analysis of the code context to determine if a matched string is a real credential or structural code.
-- **Small Models (<1B)**: Adhere strictly to classification instructions and output format validations.
+Before the diff is sent to the LLM auditor (Layer 6), `filterDiff()` (`internal/security/security.go`) strips out chunks that would cause false positives or leak prompt scaffolding:
+
+- **Go test files** (`*_test.go`) — mock keys and fake credentials are expected there.
+- **Files under `test/`** — E2E and pipeline fixtures.
+- **Files under `internal/shared/prompts/txt/`** — the prompt templates themselves contain token-like strings that regex would flag.
+
+The function splits the diff on the `diff --git ` boundary, inspects each chunk's header, and keeps only the non-excluded chunks. The LLM therefore only audits real production changes.
+
+### 🚫 Test File Exceptions
+
+Go test files (`*_test.go`) receive a **double exemption** — they are skipped in *both* the binary audit and the regex scan:
+
+1. **Binary AI audit (Layer 1)**: the `ShouldUseLLMScan() && !_test.go` guard means `AuditBinaryContent` is never called on test files, so a test fixture containing binary-looking bytes does not trigger a false block.
+2. **Regex scan (Layer 5)**: findings whose file ends in `_test.go` or lives under `test/` are filtered out of `filteredFindings` before they can become a block.
+
+This lets developers commit mock keys, fake certificates, and structural tests without being blocked.
+
+### 🤖 AI Override of Low-Confidence Regex Matches
+
+When the LLM auditor (Layer 6) is active and the regex scan (Layer 5) produced findings, the LLM's verdict is used as the tiebreaker:
+
+- **LLM says real secret** → the commit is blocked (`ai_auditor` result).
+- **LLM says not a secret** → all regex findings are **cleared** and the commit is unblocked. This is the override: the paranoid AI vouches that the regex matches were false positives, so the low-confidence regex block is discarded rather than left as a warning.
+
+When the LLM is **not** active (`llm.enabled: false` or no LLM configured), any regex finding blocks the commit — there is no override path.
+
+### 🧠 Model Size Gating — `ParseModelSize`
+
+`ParseModelSize()` (`internal/security/model.go`) parses the model name to extract its parameter count and classify it into a size category:
+
+| Parameter count in name | Classification | Example |
+|--------------------------|-----------------|---------|
+| `>= 14b` | `ModelSizeLarge` | `qwen3.5:14b`, `gemma:26b` |
+| `>= 7b` and `< 14b` | `ModelSizeMedium` | `qwen3.5:7b` |
+| `< 7b` (or unparseable) | `ModelSizeSmall` | `qwen3.5:0.8b`, `tinyllama` |
+
+The size is stored on the `Service` struct (`modelSize`) and is used to select prompt strategies: larger models get deep-semantic-analysis prompts, while smaller models get strict classification-and-format prompts to stay reliable within their capacity.
+
+> **Note on `ShouldUseLLMScan()`**: this method is currently hardcoded to `return true` ("auto" mode) — all models are sent to the LLM auditor regardless of size. The `modelSize` field still influences which prompt the auditor receives. If a future change gates the LLM scan on `ModelSizeLarge` (the 14B+ threshold), this method is the single switch point.
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,21 +4,68 @@ git-courer utilizes a comprehensive testing strategy combining unit tests and E2
 
 ---
 
-## Test Targets
+## Build Requirement: `CGO_ENABLED=1`
 
-All tests are configured in the [Makefile](file:///git-courer/git-courer/Makefile).
+git-courer uses cgo bindings, so the binary and all tests **must** be built with `CGO_ENABLED=1`. The Makefile sets this for you on every target; if you invoke `go build` or `go test` directly, export it yourself:
 
-### 1. Unit Tests (`make test-unit` or `make test`)
+```bash
+CGO_ENABLED=1 go build -o git-courer ./cmd/main.go
+CGO_ENABLED=1 go test ./...
+```
+
+---
+
+## Make Targets
+
+All targets are defined in the [Makefile](file:///git-courer/git-courer/Makefile):
+
+| Target | Purpose |
+|--------|---------|
+| `make build` | Build the self-contained `git-courer` binary (`CGO_ENABLED=1 go build`). |
+| `make test-unit` (alias: `make test`) | Run `go vet` then unit tests with the `-short` flag. No external services needed. |
+| `make test-e2e` | Run E2E pipeline tests with `-tags e2e`. Requires a live LLM service. |
+| `make lint` | `go vet ./...`. |
+| `make clean` | Remove the built binary and clear the Go build cache. |
+| `make help` | Print the target list. |
+
+---
+
+## `gotestsum` (Optional)
+
+The Makefile auto-detects [gotestsum](https://github.com/gotestyourself/gotestsum) on your `PATH` (or at `~/go/bin/gotestsum`). If found, tests are run through `gotestsum` with the `pkgname-and-test-fails` format for readable output; otherwise it falls back to plain `go test`. No configuration is needed — install gotestsum to get the nicer output:
+
+```bash
+go install gotest.tools/gotestsum@latest
+```
+
+---
+
+## Test Suite
+
+### 1. Unit Tests (`make test-unit`)
+
 Isolated, fast-running tests that verify core logic, config parsing, AST path type resolutions, and security rule matchers.
+
 - **Location**: `internal/**/*_test.go`
+- **Flag**: `-short` — skips long-running or integration-style tests, keeping the unit run fast.
 - **Focus**: Chunker parsing, classification logic, magic byte detection, config validation, and helpers.
 - **Requirement**: No external dependencies or running LLM services required.
 
 ### 2. Pipeline E2E Tests (`make test-e2e`)
+
 Runs the full commit pipeline (PREVIEW and APPLY) and release flows using a real LLM instance.
+
 - **Location**: `test/pipeline/` and `test/release/`
+- **Flag**: `-tags e2e` — the build tag that enables E2E test files.
 - **Focus**: Committing changes, generating changelogs, staging files, and verifying AST annotations with live model feedback.
 - **Prerequisite**: An active local Ollama instance (recommended model: `qwen3.5:latest`) or an OpenAI-compatible API endpoint configured via the environment variables `LLM_BASE_URL` and `LLM_MODEL`.
+
+#### Test Directory Structure
+
+| Directory | Contents |
+|-----------|---------|
+| `test/pipeline/` | End-to-end commit pipeline tests (PREVIEW → APPLY, AST annotations, security blocks). |
+| `test/release/` | Release-flow tests (changelog generation, version bumping, tagging). |
 
 ---
 


### PR DESCRIPTION
## Chain Context

| Field | Value |
|-------|-------|
| Chain | docs-rewrite |
| Tracker PR | [#191](https://github.com/blak0p/git-courer/pull/191) |
| Position | 4 of 4 (FINAL) |
| Base | `feat/docs-rewrite-03-polish` |
| Depends on | PR #3 — polish |
| Follow-up | None (final PR) |
| Review budget | ~70 / 400 |
| Starts at | PR #3 branch |
| Ends with | All 12 docs files updated |

### Chain Overview

```text
main
 └── #191 Tracker PR (draft)
      └── #192 PR #1 — architecture/config/commands
           └── #193 PR #2 — mcp-clients + hooks
                └── #194 PR #3 — polish
                     └── 📍 #NNN This PR (FINAL)
```

### Scope
- **Includes**: Add ParseModelSize 14B threshold, filterDiff behavior, test file exceptions, static analysis timeout, AI override to security docs; add CGO requirement, gotestsum, build/help targets, test flags, test directory structure to testing docs; remove speculative model recommendations table, add self-benchmarking guidance, num_parallel field, llm.enabled:false behavior to models docs
- **Excludes**: All other docs files (already updated in PRs 1-3)

### Autonomy
- [ ] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit

---

## Summary

Phase 4 (final) of the documentation rewrite. Detail docs:

- **security-architecture.md**: Added ParseModelSize 14B threshold, filterDiff behavior (removes test files + prompts before LLM scan), test file double exemption (_test.go skips binary audit AND regex), runStaticAnalysis 30s timeout, AI override of low-confidence regex matches
- **testing.md**: Added CGO_ENABLED=1 requirement, Make Targets table (build/help), gotestsum auto-detection, -short/-tags e2e flags, test directory structure
- **models.md**: Removed speculative model recommendations table, added self-benchmarking guidance, llm.enabled: false section, num_parallel field docs, api_key adapter-level note