### PR TITLE
fix: refactor git-courer permissions and update hook event tracking

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,7 +20,7 @@ Every git operation today returns text and leaves reasoning to the caller. git-c
 
 | Pillar | Focus | Issues |
 |--------|-------|--------|
-| Agent MCP DX | Make AI agents prefer git-courer tools over bash. Better descriptions, prompt injection, seamless setup. | [#151](https://github.com/blak0p/git-courer/issues/151), [#143](https://github.com/blak0p/git-courer/issues/143), [#152](https://github.com/blak0p/git-courer/issues/152) |
+| Agent MCP DX | Make AI agents prefer git-courer tools over bash. Better descriptions, prompt injection, seamless setup. | [#151](https://github.com/blak0p/git-courer/issues/151), [#143](https://github.com/blak0p/git-courer/issues/143), [#152](https://github.com/blak0p/git-courer/issues/152), [#191](https://github.com/blak0p/git-courer/issues/191) |
 | Git workflow completeness | Cover every git operation with structured tooling. Branch from any ref, enrich PR attribution, full cycle. | [#144](https://github.com/blak0p/git-courer/issues/144), [#145](https://github.com/blak0p/git-courer/issues/145) |
 | Semantic depth | Deeper AST analysis: `delete:` type detection, cross-file refactoring detection, automatic breaking-change classification. | [#51](https://github.com/blak0p/git-courer/issues/51) |
 | Scale & performance | Large-repo performance, parallel graph operations. | Post-v2 |
@@ -38,6 +38,7 @@ Every git operation today returns text and leaves reasoning to the caller. git-c
 | [#151](https://github.com/blak0p/git-courer/issues/151) | Interactive release wizard | Draft |
 | [#152](https://github.com/blak0p/git-courer/issues/152) | Inject prompt rules into CLI agents | Draft |
 | [#180](https://github.com/blak0p/git-courer/issues/180) | Backup auto-prune (reachability-based) | Draft |
+| [#191](https://github.com/blak0p/git-courer/issues/191) | Agent rules reinforcement & hooks bug fix | Draft |
 
 All issues are independent — no blockers between them. Implement in any order.
 

--- a/internal/delivery/cli/hook_check.go
+++ b/internal/delivery/cli/hook_check.go
@@ -100,8 +100,8 @@ func (c HookCheckCommand) Run(args []string) error {
 }
 
 // runStdinMode reads Codex hook JSON from stdin, extracts the command,
-// and emits Codex hook output. For git commands it includes additionalContext
-// suggesting the MCP tool, so the agent knows to use git-courer instead.
+// and emits Codex hook output. For git commands it denies permission and
+// redirects to the git-courer MCP tool.
 // Non-git commands exit cleanly with no output.
 func (c HookCheckCommand) runStdinMode(stdin io.Reader, stdout io.Writer) error {
 	data, err := io.ReadAll(stdin)
@@ -127,14 +127,10 @@ func (c HookCheckCommand) runStdinMode(stdin io.Reader, stdout io.Writer) error 
 		return nil
 	}
 
-	// Suggest the MCP tool via additionalContext — never deny.
-	// Codex always asks the user for permission on bash commands anyway.
-	// The agent sees the suggestion and the golden rules from SessionStart.
-	additionalContext := fmt.Sprintf("Use git-courer/%s instead of bash %s", result.MCPTool, command)
-
 	output := codexHookOutput{}
 	output.HookSpecificOutput.HookEventName = "PreToolUse"
-	output.HookSpecificOutput.AdditionalContext = additionalContext
+	output.HookSpecificOutput.PermissionDecision = "deny"
+	output.HookSpecificOutput.PermissionDecisionReason = fmt.Sprintf("Use git-courer/%s instead of bash %s", result.MCPTool, command)
 
 	if err := json.NewEncoder(stdout).Encode(output); err != nil {
 		return fmt.Errorf("hook-check: failed to encode output: %w", err)
@@ -208,8 +204,9 @@ type PreInvocationHookCommand struct {
 	Stdout io.Writer // for testing; nil = os.Stdout
 }
 
-// Run reads stdin (ignored) and emits golden rules as Codex hook output with
-// HookEventName=PreInvocation. No permissionDecision is set.
+// Run reads stdin (ignored) and emits golden rules as Codex hook output.
+// It accepts an optional first argument in args to override the HookEventName
+// from the default "PreInvocation".
 func (c PreInvocationHookCommand) Run(args []string) error {
 	stdout := c.Stdout
 	if stdout == nil {
@@ -223,8 +220,13 @@ func (c PreInvocationHookCommand) Run(args []string) error {
 	}
 	_, _ = io.ReadAll(stdin)
 
+	eventName := "PreInvocation"
+	if len(args) > 0 && args[0] != "" {
+		eventName = args[0]
+	}
+
 	output := codexHookOutput{}
-	output.HookSpecificOutput.HookEventName = "PreInvocation"
+	output.HookSpecificOutput.HookEventName = eventName
 	output.HookSpecificOutput.AdditionalContext = installer.GoldenRulesAdditionalContext
 
 	return json.NewEncoder(stdout).Encode(output)

--- a/internal/delivery/cli/hook_check_test.go
+++ b/internal/delivery/cli/hook_check_test.go
@@ -99,8 +99,8 @@ func TestHookCheckRun_EmptyArg(t *testing.T) {
 	}
 }
 
-// TestHookCheckStdin_GitCommand verifies stdin mode emits additionalContext
-// suggesting the MCP tool for git commands.
+// TestHookCheckStdin_GitCommand verifies stdin mode denies raw git commands
+// and redirects to the git-courer MCP tool.
 func TestHookCheckStdin_GitCommand(t *testing.T) {
 	input := `{"event":{"input":{"command":"git status"}}}`
 	var stdinBuf bytes.Buffer
@@ -129,11 +129,15 @@ func TestHookCheckStdin_GitCommand(t *testing.T) {
 	if output.HookSpecificOutput.HookEventName != "PreToolUse" {
 		t.Errorf("HookEventName: got %q, want %q", output.HookSpecificOutput.HookEventName, "PreToolUse")
 	}
-	if !strings.Contains(output.HookSpecificOutput.AdditionalContext, "git-courer/status") {
-		t.Errorf("AdditionalContext missing MCP tool suggestion: %q", output.HookSpecificOutput.AdditionalContext)
+	if output.HookSpecificOutput.PermissionDecision != "deny" {
+		t.Errorf("PermissionDecision: got %q, want %q", output.HookSpecificOutput.PermissionDecision, "deny")
 	}
-	if output.HookSpecificOutput.PermissionDecision != "" {
-		t.Errorf("PermissionDecision should be empty (suggest, not deny), got %q", output.HookSpecificOutput.PermissionDecision)
+	expectedReason := "Use git-courer/status instead of bash git status"
+	if output.HookSpecificOutput.PermissionDecisionReason != expectedReason {
+		t.Errorf("PermissionDecisionReason: got %q, want %q", output.HookSpecificOutput.PermissionDecisionReason, expectedReason)
+	}
+	if output.HookSpecificOutput.AdditionalContext != "" {
+		t.Errorf("AdditionalContext should be empty, got %q", output.HookSpecificOutput.AdditionalContext)
 	}
 }
 
@@ -273,6 +277,35 @@ func TestPreInvocationHookCommand_ReturnsGoldenRules(t *testing.T) {
 	}
 	if output.HookSpecificOutput.PermissionDecision != "" {
 		t.Errorf("PermissionDecision should be empty, got %q", output.HookSpecificOutput.PermissionDecision)
+	}
+}
+
+// TestPreInvocationHookCommand_CustomEventName verifies pre-invocation-hook
+// returns golden rules as additionalContext with a custom HookEventName
+// when passed as an argument.
+func TestPreInvocationHookCommand_CustomEventName(t *testing.T) {
+	var stdinBuf bytes.Buffer
+	var stdoutBuf bytes.Buffer
+	cmd := PreInvocationHookCommand{
+		Stdin:  &stdinBuf,
+		Stdout: &stdoutBuf,
+	}
+
+	err := cmd.Run([]string{"UserPromptSubmit"})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	var output codexHookOutput
+	if jsonErr := json.Unmarshal(stdoutBuf.Bytes(), &output); jsonErr != nil {
+		t.Fatalf("stdout is not valid JSON: %v\noutput: %q", jsonErr, stdoutBuf.String())
+	}
+
+	if output.HookSpecificOutput.HookEventName != "UserPromptSubmit" {
+		t.Errorf("HookEventName: got %q, want %q", output.HookSpecificOutput.HookEventName, "UserPromptSubmit")
+	}
+	if !strings.Contains(output.HookSpecificOutput.AdditionalContext, "Golden Rules") {
+		t.Errorf("AdditionalContext missing golden rules: %q", output.HookSpecificOutput.AdditionalContext)
 	}
 }
 

--- a/internal/installer/hooks.go
+++ b/internal/installer/hooks.go
@@ -63,7 +63,7 @@ var claudeGitCourerHookEvents = []string{
 	"PreToolUse",
 	"SessionStart",
 	"SubagentStart",
-	"PreInvocation",
+	"UserPromptSubmit",
 }
 
 // mergeClaudeHooks merges the git-courer hook entries in gitcourer into the
@@ -140,10 +140,10 @@ func claudeHooksStatus(settingsPath string) string {
 
 	// Expected (event, matcher) pairs installed by git-courer.
 	expected := map[string]string{
-		"PreToolUse":    "Bash",
-		"SessionStart":  "startup|resume",
-		"SubagentStart": "general-purpose|Explore|Plan",
-		"PreInvocation": "",
+		"PreToolUse":       "Bash",
+		"SessionStart":     "startup|resume",
+		"SubagentStart":    "general-purpose|Explore|Plan",
+		"UserPromptSubmit": "",
 	}
 
 	found := 0

--- a/internal/installer/hooks_test.go
+++ b/internal/installer/hooks_test.go
@@ -284,10 +284,10 @@ func gitCourerMergeInput(binPath string) map[string][]claudeHookEntry {
 				Hooks:   []claudeHookCmd{{Type: "command", Command: binPath + " subagent-start-hook", Args: []string{}, Timeout: 10}},
 			},
 		},
-		"PreInvocation": {
+		"UserPromptSubmit": {
 			{
 				Matcher: "",
-				Hooks:   []claudeHookCmd{{Type: "command", Command: binPath + " pre-invocation-hook", Args: []string{}, Timeout: 10}},
+				Hooks:   []claudeHookCmd{{Type: "command", Command: binPath + " pre-invocation-hook", Args: []string{"UserPromptSubmit"}, Timeout: 10}},
 			},
 		},
 	}

--- a/internal/installer/mcp_config.go
+++ b/internal/installer/mcp_config.go
@@ -32,10 +32,12 @@ const gitCourerMdContent = "# git-courer — Golden Rules\n" +
 	"\n" +
 	"## Golden Rules — save tokens and prevent mistakes\n" +
 	"\n" +
-	"0. On session start (MANDATORY) → ALWAYS run `session start` to create an isolated worktree before starting any task.\n" +
-	"1. Before any mutation → ALWAYS check `status` to know the repository state and identify active changes.\n" +
-	"2. Before push or PR (or when verifying changes) → ALWAYS check `diff` + `review` to verify active diff checks.\n" +
-	"3. Before PR → ALWAYS run `pr-review` to run all checks and verify changes in a single call."
+	"0. On session start (MANDATORY) → ALWAYS run `session start <branch_name>` to create your isolated worktree on a custom branch.\n" +
+	"1. Immediately after start → run `session select <session_id>` to redirect all MCP operations to the session worktree.\n" +
+	"2. Work location → perform all file reads, writes, and commands strictly inside the designated session worktree path.\n" +
+	"3. Before any mutation → ALWAYS check `status` to know the repository state and identify active changes.\n" +
+	"4. Before push or PR (or when verifying changes) → ALWAYS check `diff` + `review` to verify active diff checks.\n" +
+	"5. Before PR → ALWAYS run `pr-review` to run all checks and verify changes in a single call."
 
 // MCPClient represents an MCP client configuration.
 type MCPClient struct {
@@ -879,7 +881,7 @@ func installClaudeHooks(settingsPath, binPath string) error {
 			{
 				Matcher: "",
 				Hooks: []claudeHookCmd{
-					{Type: "command", Command: binPath + " pre-invocation-hook", Args: []string{}, Timeout: 10},
+					{Type: "command", Command: binPath + " pre-invocation-hook", Args: []string{"UserPromptSubmit"}, Timeout: 10},
 				},
 			},
 		},
@@ -1188,7 +1190,7 @@ func installAntigravityPermissions(settingsPath, binPath string) error {
 		}
 	}
 
-	// permissions.allow and permissions.ask — merge git-courer entries.
+	// permissions.allow, permissions.ask and permissions.block — merge git-courer entries.
 	perm, _ := settings["permissions"].(map[string]interface{})
 	if perm == nil {
 		perm = make(map[string]interface{})
@@ -1200,11 +1202,21 @@ func installAntigravityPermissions(settingsPath, binPath string) error {
 	allow = mergeStringEntry(allow, "mcp(git-courer/*)")
 	perm["allow"] = allow
 
-	// ask: command(git *), command(*)
+	// block: command(git *)
+	block, _ := perm["block"].([]interface{})
+	block = mergeStringEntry(block, "command(git *)")
+	perm["block"] = block
+
+	// ask: command(*)
 	ask, _ := perm["ask"].([]interface{})
-	ask = mergeStringEntry(ask, "command(git *)")
 	ask = mergeStringEntry(ask, "command(*)")
-	perm["ask"] = ask
+	// Clean up command(git *) from ask if it was present there
+	ask = filterStringEntries(ask, []string{"command(git *)"})
+	if len(ask) == 0 {
+		delete(perm, "ask")
+	} else {
+		perm["ask"] = ask
+	}
 
 	data, err := json.MarshalIndent(settings, "", "  ")
 	if err != nil {
@@ -1217,7 +1229,7 @@ func installAntigravityPermissions(settingsPath, binPath string) error {
 // the Antigravity settings.json at settingsPath. Behavior:
 //   - If settingsPath + ".gc.bak" exists, it is restored over settingsPath and
 //     the .bak file is removed.
-//   - Otherwise the three git-courer permission entries are removed in place,
+//   - Otherwise the git-courer permission entries are removed in place,
 //     preserving non-git-courer keys.
 //   - Idempotent: running twice does not error.
 func removeAntigravityPermissions(settingsPath string) error {
@@ -1271,6 +1283,17 @@ func removeAntigravityPermissions(settingsPath string) error {
 				delete(perm, "ask")
 			} else {
 				perm["ask"] = filtered
+			}
+		}
+	}
+	if block, ok := perm["block"].([]interface{}); ok {
+		filtered := filterStringEntries(block, []string{"command(git *)"})
+		if len(filtered) != len(block) {
+			changed = true
+			if len(filtered) == 0 {
+				delete(perm, "block")
+			} else {
+				perm["block"] = filtered
 			}
 		}
 	}

--- a/internal/installer/mcp_config_test.go
+++ b/internal/installer/mcp_config_test.go
@@ -537,6 +537,7 @@ type antigravitySettingsShell struct {
 	Permissions struct {
 		Allow []string `json:"allow"`
 		Ask   []string `json:"ask"`
+		Block []string `json:"block"`
 	} `json:"permissions"`
 	Theme string `json:"theme"`
 }
@@ -580,8 +581,11 @@ func TestInstallAntigravityPermissions_CreatesFreshFile(t *testing.T) {
 	if !containsString(s.Permissions.Allow, "mcp(git-courer/*)") {
 		t.Errorf("permissions.allow missing mcp(git-courer/*): %v", s.Permissions.Allow)
 	}
-	if !containsString(s.Permissions.Ask, "command(git *)") {
-		t.Errorf("permissions.ask missing command(git *): %v", s.Permissions.Ask)
+	if !containsString(s.Permissions.Block, "command(git *)") {
+		t.Errorf("permissions.block missing command(git *): %v", s.Permissions.Block)
+	}
+	if containsString(s.Permissions.Ask, "command(git *)") {
+		t.Errorf("permissions.ask should not contain command(git *): %v", s.Permissions.Ask)
 	}
 	if !containsString(s.Permissions.Ask, "command(*)") {
 		t.Errorf("permissions.ask missing command(*): %v", s.Permissions.Ask)
@@ -618,8 +622,11 @@ func TestInstallAntigravityPermissions_MergesPreservingExisting(t *testing.T) {
 	if !containsString(s.Permissions.Allow, "mcp(git-courer/*)") {
 		t.Errorf("permissions.allow missing mcp(git-courer/*): %v", s.Permissions.Allow)
 	}
-	if !containsString(s.Permissions.Ask, "command(git *)") {
-		t.Errorf("permissions.ask missing command(git *): %v", s.Permissions.Ask)
+	if !containsString(s.Permissions.Block, "command(git *)") {
+		t.Errorf("permissions.block missing command(git *): %v", s.Permissions.Block)
+	}
+	if containsString(s.Permissions.Ask, "command(git *)") {
+		t.Errorf("permissions.ask should not contain command(git *): %v", s.Permissions.Ask)
 	}
 	if !containsString(s.Permissions.Ask, "command(*)") {
 		t.Errorf("permissions.ask missing command(*): %v", s.Permissions.Ask)
@@ -718,14 +725,14 @@ func TestInstallAntigravityPermissions_NoDuplicateEntries(t *testing.T) {
 	if countAllow != 1 {
 		t.Errorf("expected 1 mcp(git-courer/*) in allow, got %d (duplicate detected)", countAllow)
 	}
-	countAskGit := 0
-	for _, v := range s.Permissions.Ask {
+	countBlockGit := 0
+	for _, v := range s.Permissions.Block {
 		if v == "command(git *)" {
-			countAskGit++
+			countBlockGit++
 		}
 	}
-	if countAskGit != 1 {
-		t.Errorf("expected 1 command(git *) in ask, got %d (duplicate detected)", countAskGit)
+	if countBlockGit != 1 {
+		t.Errorf("expected 1 command(git *) in block, got %d (duplicate detected)", countBlockGit)
 	}
 }
 
@@ -799,7 +806,7 @@ func TestRemoveAntigravityPermissions_StripsWithoutBackup(t *testing.T) {
 	dir := t.TempDir()
 	settingsPath := filepath.Join(dir, "settings.json")
 
-	existing := `{"permissions":{"allow":["command(npm *)","mcp(git-courer/*)"],"ask":["command(git *)","command(*)"]}}`
+	existing := `{"permissions":{"allow":["command(npm *)","mcp(git-courer/*)"],"ask":["command(*)"],"block":["command(git *)"]}}`
 	if err := os.WriteFile(settingsPath, []byte(existing), 0644); err != nil {
 		t.Fatalf("write existing: %v", err)
 	}
@@ -815,11 +822,11 @@ func TestRemoveAntigravityPermissions_StripsWithoutBackup(t *testing.T) {
 	if containsString(s.Permissions.Allow, "mcp(git-courer/*)") {
 		t.Errorf("mcp(git-courer/*) was not stripped: %v", s.Permissions.Allow)
 	}
-	if containsString(s.Permissions.Ask, "command(git *)") {
-		t.Errorf("command(git *) was not stripped: %v", s.Permissions.Ask)
-	}
 	if containsString(s.Permissions.Ask, "command(*)") {
 		t.Errorf("command(*) was not stripped: %v", s.Permissions.Ask)
+	}
+	if containsString(s.Permissions.Block, "command(git *)") {
+		t.Errorf("command(git *) was not stripped from block: %v", s.Permissions.Block)
 	}
 }
 


### PR DESCRIPTION
WHY
The previous permission model merged all commands into a single bucket, creating security gaps where dangerous operations could execute without explicit blocking. Additionally, the PreInvocation event was not being tracked by git-courer, causing monitoring failures for workflow initiation.

WHAT
* Added dedicated block key settings to explicitly deny shell access and isolate restricted actions from general asks.
* Replaced deprecated 'PreInvocation' string literal with 'UserPromptSubmit' in hook mappings.
* Implemented cleanup logic to remove redundant entries across allow, ask, and block sections during merging.

<!--
  Thank you for contributing to git-courer!
  Please follow the conventional commit format and ensure tests pass.
-->

Closes #

## Summary

<!-- Describe what this PR does -->

## Changes

| File | Change |
|------|--------|
|  |  |

## Test Plan

<!-- How did you verify this works? -->
