### PR TITLE
fix(session): clear activeSession pointer on discard to prevent MCP server lockup

### DIFF
--- a/internal/delivery/mcp/session/session.go
+++ b/internal/delivery/mcp/session/session.go
@@ -410,6 +410,12 @@ func (h *Handler) handleDiscard(params map[string]any) (*mcpgo.CallToolResult, e
 	}
 	_ = h.store.Delete(sess.ID)
 
+	// Clear the active session if it matches the discarded one. A mismatch
+	// (or nil active session) is a no-op — we never clobber another agent's
+	// selection. Runs regardless of cleanup errors so the MCP server never
+	// keeps a dangling pointer to a removed worktree.
+	h.clearActiveSessionIfMatch(sess.ID)
+
 	if len(cleanupErrs) > 0 {
 		payload, _ := json.Marshal(map[string]any{
 			"status":   "partial",

--- a/internal/delivery/mcp/session/session_test.go
+++ b/internal/delivery/mcp/session/session_test.go
@@ -601,8 +601,12 @@ func TestHandleStatus_ReturnsSessionState(t *testing.T) {
 }
 
 func TestHandleDiscard_RemovesWorktreeBranchMetadata(t *testing.T) {
-	h, mockGit, store := newHandlerWithStore(t)
+	h, mockGit, store, active := newHandlerWithStoreAndActive(t)
 	sess := fixtureSession()
+
+	// Pre-select the session so we can verify discard clears it, mirroring
+	// the finish test in session_select_test.go.
+	active.Store(sess)
 
 	store.On("Get", "fix-bug").Return(sess, nil)
 	mockGit.On("RemoveWorktree", "../git-courer-worktrees/fix-bug").Return(nil)
@@ -615,6 +619,13 @@ func TestHandleDiscard_RemovesWorktreeBranchMetadata(t *testing.T) {
 	require.NotNil(t, res)
 	text := resultText(t, res)
 	assert.Contains(t, text, `"status":"success"`)
+
+	// activeSession should now be nil — discard must not leave a dangling
+	// pointer to the removed worktree.
+	v := active.Load()
+	if s, ok := v.(*domain.Session); ok && s != nil {
+		t.Errorf("activeSession should be cleared after discard, got %v", s)
+	}
 	mockGit.AssertExpectations(t)
 	store.AssertExpectations(t)
 }


### PR DESCRIPTION
Closes #197

## Summary

- `handleDiscard()` now calls `clearActiveSessionIfMatch()` after removing the worktree, matching the same pattern already used in `handleFinish()`
- Without this fix, discarding the active session leaves a dangling pointer to a non-existent worktree, causing every subsequent MCP tool call to fail with `chdir: no such file or directory`
- Test updated to verify `activeSession` is nil after discard

## Changes

| File | Change |
|------|--------|
| `internal/delivery/mcp/session/session.go` | Added `h.clearActiveSessionIfMatch(sess.ID)` in `handleDiscard()` after `store.Delete` |
| `internal/delivery/mcp/session/session_test.go` | Updated `TestHandleDiscard_RemovesWorktreeBranchMetadata` to pre-select session and assert active pointer is cleared |

## Test Plan

- [x] `go test ./internal/delivery/mcp/session/...` — 27/27 tests pass
- [x] `go build ./...` — passes