### PR TITLE
fix: support multi-agent detection and deny git

### DIFF
--- a/internal/delivery/cli/hook_check.go
+++ b/internal/delivery/cli/hook_check.go
@@ -32,23 +32,57 @@ var isStdinPipe = func() bool {
 // This is a thin adapter — all classification logic lives in the gitcmd
 // package so it can be unit-tested independently.
 //
-// When no args are provided and stdin is a pipe, it reads Codex hook JSON
-// from stdin, extracts the command, and classifies it. For git commands it
-// emits additionalContext suggesting the git-courer MCP tool. Non-git
-// commands exit cleanly with no output.
+// When no args are provided and stdin is a pipe, it reads multi-agent hook
+// JSON from stdin (Codex, Claude Code, or Antigravity shape), detects the
+// calling agent from the top-level JSON keys, extracts the command, and
+// classifies it. For git commands it emits the agent-specific deny output so
+// the agent is blocked from running raw git and is pointed at the git-courer
+// MCP tool. Non-git commands exit cleanly with no output.
 type HookCheckCommand struct {
-	Stdin  io.Reader // for testing; nil = os.Stdin
-	Stdout io.Writer // for testing; nil = os.Stdout
+	Stdin  io.Reader  // for testing; nil = os.Stdin
+	Stdout io.Writer  // for testing; nil = os.Stdout
 }
 
-// codexHookInput represents the JSON structure Codex sends via stdin
-// for PreToolUse hooks.
-type codexHookInput struct {
-	Event struct {
-		Input struct {
+// agentType identifies the calling agent from its stdin JSON shape.
+type agentType int
+
+const (
+	agentUnknown     agentType = iota
+	agentCodex                 // {"event": {...}}
+	agentClaude                // {"tool_name": "..."}
+	agentAntigravity           // {"toolCall": {...}}
+)
+
+// hookInput represents the three supported stdin shapes. Each pointer
+// field is nil when the corresponding JSON key is absent, so a single
+// json.Unmarshal enables agent detection via nil checks. Only one shape is
+// expected per invocation.
+type hookInput struct {
+	Event *struct {
+		Input *struct {
 			Command string `json:"command"`
 		} `json:"input"`
 	} `json:"event"`
+
+	ToolName string `json:"tool_name"`
+	ToolInput *struct {
+		Command string `json:"command"`
+	} `json:"tool_input"`
+
+	ToolCall *struct {
+		Name string `json:"name"`
+		Args *struct {
+			CommandLine string `json:"CommandLine"`
+		} `json:"args"`
+	} `json:"toolCall"`
+}
+
+// antigravityHookOutput is the top-level deny format Antigravity expects:
+// a flat {"allow_tool": false, "deny_reason": "..."} object (not nested
+// under hookSpecificOutput like Codex/Claude).
+type antigravityHookOutput struct {
+	AllowTool   bool   `json:"allow_tool"`
+	DenyReason  string `json:"deny_reason"`
 }
 
 // codexHookOutput represents the JSON structure Codex expects as output
@@ -99,23 +133,43 @@ func (c HookCheckCommand) Run(args []string) error {
 	return nil
 }
 
-// runStdinMode reads Codex hook JSON from stdin, extracts the command,
-// and emits Codex hook output. For git commands it includes additionalContext
-// suggesting the MCP tool, so the agent knows to use git-courer instead.
-// Non-git commands exit cleanly with no output.
+// runStdinMode reads multi-agent hook JSON from stdin, detects the calling
+// agent from the top-level JSON keys (event → Codex, tool_name → Claude Code,
+// toolCall → Antigravity), extracts the command, and emits the agent-specific
+// deny output for git commands. Unrecognized or unparseable stdin falls back
+// to exit 0 with no output (safe fallback). Non-git commands exit cleanly
+// with no output.
 func (c HookCheckCommand) runStdinMode(stdin io.Reader, stdout io.Writer) error {
 	data, err := io.ReadAll(stdin)
 	if err != nil {
 		return fmt.Errorf("hook-check: failed to read stdin: %w", err)
 	}
 
-	var input codexHookInput
+	var input hookInput
 	if err := json.Unmarshal(data, &input); err != nil {
-		// If we can't parse the input, exit cleanly (safe fallback).
+		// Unparseable stdin — exit cleanly (safe fallback).
 		return nil
 	}
 
-	command := input.Event.Input.Command
+	var command string
+	var agent agentType
+
+	switch {
+	case input.Event != nil && input.Event.Input != nil:
+		command = input.Event.Input.Command
+		agent = agentCodex
+	case input.ToolName != "":
+		if input.ToolInput != nil {
+			command = input.ToolInput.Command
+		}
+		agent = agentClaude
+	case input.ToolCall != nil && input.ToolCall.Args != nil:
+		command = input.ToolCall.Args.CommandLine
+		agent = agentAntigravity
+	default:
+		return nil
+	}
+
 	if command == "" {
 		return nil
 	}
@@ -127,18 +181,27 @@ func (c HookCheckCommand) runStdinMode(stdin io.Reader, stdout io.Writer) error 
 		return nil
 	}
 
-	// Suggest the MCP tool via additionalContext — never deny.
-	// Codex always asks the user for permission on bash commands anyway.
-	// The agent sees the suggestion and the golden rules from SessionStart.
-	additionalContext := fmt.Sprintf("Use git-courer/%s instead of bash %s", result.MCPTool, command)
+	reason := fmt.Sprintf("Use git-courer/%s instead of bash %s", result.MCPTool, command)
 
-	output := codexHookOutput{}
-	output.HookSpecificOutput.HookEventName = "PreToolUse"
-	output.HookSpecificOutput.AdditionalContext = additionalContext
-
-	if err := json.NewEncoder(stdout).Encode(output); err != nil {
-		return fmt.Errorf("hook-check: failed to encode output: %w", err)
+	switch agent {
+	case agentCodex, agentClaude:
+		output := codexHookOutput{}
+		output.HookSpecificOutput.HookEventName = "PreToolUse"
+		output.HookSpecificOutput.PermissionDecision = "deny"
+		output.HookSpecificOutput.PermissionDecisionReason = reason
+		if err := json.NewEncoder(stdout).Encode(output); err != nil {
+			return fmt.Errorf("hook-check: failed to encode output: %w", err)
+		}
+	case agentAntigravity:
+		output := antigravityHookOutput{
+			AllowTool:  false,
+			DenyReason: reason,
+		}
+		if err := json.NewEncoder(stdout).Encode(output); err != nil {
+			return fmt.Errorf("hook-check: failed to encode output: %w", err)
+		}
 	}
+
 	return nil
 }
 

--- a/internal/delivery/cli/hook_check_test.go
+++ b/internal/delivery/cli/hook_check_test.go
@@ -99,8 +99,8 @@ func TestHookCheckRun_EmptyArg(t *testing.T) {
 	}
 }
 
-// TestHookCheckStdin_GitCommand verifies stdin mode emits additionalContext
-// suggesting the MCP tool for git commands.
+// TestHookCheckStdin_GitCommand verifies stdin mode emits a deny decision for
+// git commands (Codex shape), pointing the agent at the git-courer MCP tool.
 func TestHookCheckStdin_GitCommand(t *testing.T) {
 	input := `{"event":{"input":{"command":"git status"}}}`
 	var stdinBuf bytes.Buffer
@@ -129,11 +129,11 @@ func TestHookCheckStdin_GitCommand(t *testing.T) {
 	if output.HookSpecificOutput.HookEventName != "PreToolUse" {
 		t.Errorf("HookEventName: got %q, want %q", output.HookSpecificOutput.HookEventName, "PreToolUse")
 	}
-	if !strings.Contains(output.HookSpecificOutput.AdditionalContext, "git-courer/status") {
-		t.Errorf("AdditionalContext missing MCP tool suggestion: %q", output.HookSpecificOutput.AdditionalContext)
+	if output.HookSpecificOutput.PermissionDecision != "deny" {
+		t.Errorf("PermissionDecision: got %q, want %q", output.HookSpecificOutput.PermissionDecision, "deny")
 	}
-	if output.HookSpecificOutput.PermissionDecision != "" {
-		t.Errorf("PermissionDecision should be empty (suggest, not deny), got %q", output.HookSpecificOutput.PermissionDecision)
+	if !strings.Contains(output.HookSpecificOutput.PermissionDecisionReason, "git-courer/status") {
+		t.Errorf("PermissionDecisionReason missing MCP tool: %q", output.HookSpecificOutput.PermissionDecisionReason)
 	}
 }
 
@@ -179,6 +179,122 @@ func TestHookCheckStdin_InvalidJSON(t *testing.T) {
 
 	if stdoutBuf.Len() > 0 {
 		t.Errorf("expected no output for invalid JSON, got: %s", stdoutBuf.String())
+	}
+}
+
+// TestHookCheckStdin_ClaudeCode_GitCommand verifies stdin mode emits a deny
+// decision for git commands in the Claude Code stdin shape.
+func TestHookCheckStdin_ClaudeCode_GitCommand(t *testing.T) {
+	input := `{"tool_name":"Bash","tool_input":{"command":"git status"}}`
+	var stdinBuf bytes.Buffer
+	stdinBuf.WriteString(input)
+
+	var stdoutBuf bytes.Buffer
+	cmd := HookCheckCommand{
+		Stdin:  &stdinBuf,
+		Stdout: &stdoutBuf,
+	}
+
+	err := cmd.Run([]string{})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if stdoutBuf.Len() == 0 {
+		t.Fatal("expected output for git command, got empty")
+	}
+
+	var output codexHookOutput
+	if jsonErr := json.Unmarshal(stdoutBuf.Bytes(), &output); jsonErr != nil {
+		t.Fatalf("stdout is not valid JSON: %v\noutput: %q", jsonErr, stdoutBuf.String())
+	}
+
+	if output.HookSpecificOutput.PermissionDecision != "deny" {
+		t.Errorf("PermissionDecision: got %q, want %q", output.HookSpecificOutput.PermissionDecision, "deny")
+	}
+	if !strings.Contains(output.HookSpecificOutput.PermissionDecisionReason, "git-courer/status") {
+		t.Errorf("PermissionDecisionReason missing MCP tool: %q", output.HookSpecificOutput.PermissionDecisionReason)
+	}
+}
+
+// TestHookCheckStdin_ClaudeCode_NonGitCommand verifies stdin mode produces no
+// output for non-git commands in the Claude Code stdin shape.
+func TestHookCheckStdin_ClaudeCode_NonGitCommand(t *testing.T) {
+	input := `{"tool_name":"Bash","tool_input":{"command":"ls -la"}}`
+	var stdinBuf bytes.Buffer
+	stdinBuf.WriteString(input)
+
+	var stdoutBuf bytes.Buffer
+	cmd := HookCheckCommand{
+		Stdin:  &stdinBuf,
+		Stdout: &stdoutBuf,
+	}
+
+	err := cmd.Run([]string{})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if stdoutBuf.Len() > 0 {
+		t.Errorf("expected no output for non-git command, got: %s", stdoutBuf.String())
+	}
+}
+
+// TestHookCheckStdin_Antigravity_GitCommand verifies stdin mode emits an
+// Antigravity deny (allow_tool: false) for git commands.
+func TestHookCheckStdin_Antigravity_GitCommand(t *testing.T) {
+	input := `{"toolCall":{"name":"run_command","args":{"CommandLine":"git status"}}}`
+	var stdinBuf bytes.Buffer
+	stdinBuf.WriteString(input)
+
+	var stdoutBuf bytes.Buffer
+	cmd := HookCheckCommand{
+		Stdin:  &stdinBuf,
+		Stdout: &stdoutBuf,
+	}
+
+	err := cmd.Run([]string{})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if stdoutBuf.Len() == 0 {
+		t.Fatal("expected output for git command, got empty")
+	}
+
+	var output antigravityHookOutput
+	if jsonErr := json.Unmarshal(stdoutBuf.Bytes(), &output); jsonErr != nil {
+		t.Fatalf("stdout is not valid JSON: %v\noutput: %q", jsonErr, stdoutBuf.String())
+	}
+
+	if output.AllowTool {
+		t.Errorf("AllowTool: got true, want false")
+	}
+	if !strings.Contains(output.DenyReason, "git-courer/status") {
+		t.Errorf("DenyReason missing MCP tool: %q", output.DenyReason)
+	}
+}
+
+// TestHookCheckStdin_Antigravity_NonGitCommand verifies stdin mode produces
+// no output for non-git commands in the Antigravity stdin shape.
+func TestHookCheckStdin_Antigravity_NonGitCommand(t *testing.T) {
+	input := `{"toolCall":{"name":"run_command","args":{"CommandLine":"ls -la"}}}`
+	var stdinBuf bytes.Buffer
+	stdinBuf.WriteString(input)
+
+	var stdoutBuf bytes.Buffer
+	cmd := HookCheckCommand{
+		Stdin:  &stdinBuf,
+		Stdout: &stdoutBuf,
+	}
+
+	err := cmd.Run([]string{})
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if stdoutBuf.Len() > 0 {
+		t.Errorf("expected no output for non-git command, got: %s", stdoutBuf.String())
 	}
 }
 

--- a/internal/installer/mcp_config.go
+++ b/internal/installer/mcp_config.go
@@ -325,7 +325,7 @@ func ConfigureMCP(client *MCPClient, binPath string) error {
 	// Delete old physical GIT_COURER.md if present
 	_ = os.Remove(filepath.Join(filepath.Dir(configPath), gitCourerMdFilename))
 
-	// Apply the OpenCode policy (permission.bash "git *": "ask" and
+	// Apply the OpenCode policy (permission.bash "git *": "deny" and
 	// instructions AGENTS.md path). Idempotent merge.
 	if client.Name == "opencode" {
 		if policyErr := configureOpenCodePolicy(configPath); policyErr != nil {
@@ -623,7 +623,7 @@ func SetupClient(clientName, binPath string) error {
 }
 
 // configureOpenCodePolicy merges the git-courer policy into opencode.json:
-//   - permission.bash["git *"] = "ask" (preserving any existing keys; Go's
+//   - permission.bash["git *"] = "deny" (preserving any existing keys; Go's
 //     alphabetical map sort on json.MarshalIndent naturally places "git *"
 //     after "*" for last-match-wins).
 //   - instructions array includes the path to GIT_COURER.md in the same
@@ -671,7 +671,7 @@ func configureOpenCodePolicy(configPath string) error {
 		}
 	}
 
-	// permission.bash["git *"] = "ask"
+	// permission.bash["git *"] = "deny"
 	perm, _ := config["permission"].(map[string]interface{})
 	if perm == nil {
 		perm = make(map[string]interface{})
@@ -682,7 +682,7 @@ func configureOpenCodePolicy(configPath string) error {
 		bash = make(map[string]interface{})
 		perm["bash"] = bash
 	}
-	bash["git *"] = "ask"
+	bash["git *"] = "deny"
 
 	// instructions array includes AGENTS.md path, and old GIT_COURER.md path is removed.
 	agentsPath := filepath.Join(filepath.Dir(configPath), "AGENTS.md")

--- a/internal/installer/opencode_policy_test.go
+++ b/internal/installer/opencode_policy_test.go
@@ -1,5 +1,5 @@
 // Package installer_test verifies OpenCode policy configuration
-// (permission.bash "git *": "ask" rule and GIT_COURER.md instructions entry)
+// (permission.bash "git *": "deny" rule and GIT_COURER.md instructions entry)
 // added in SDD 4 — Global Agent Policy for OpenCode.
 package installer
 
@@ -209,7 +209,7 @@ func gitCourerMdPath(configPath string) string {
 // --- configureOpenCodePolicy tests (T1) ---
 
 // TestConfigureOpenCodePolicy_AddsGitStarRule verifies
-// configureOpenCodePolicy adds "git *": "ask" to permission.bash on a fresh
+// configureOpenCodePolicy adds "git *": "deny" to permission.bash on a fresh
 // opencode.json with no permission key.
 func TestConfigureOpenCodePolicy_AddsGitStarRule(t *testing.T) {
 	dir := t.TempDir()
@@ -224,7 +224,7 @@ func TestConfigureOpenCodePolicy_AddsGitStarRule(t *testing.T) {
 	}
 
 	cfg := readOpenCodeConfig(t, configPath)
-	assertBashRule(t, cfg, "git *", "ask")
+	assertBashRule(t, cfg, "git *", "deny")
 }
 
 // TestConfigureOpenCodePolicy_PreservesExistingBashKeys verifies that an
@@ -246,7 +246,7 @@ func TestConfigureOpenCodePolicy_PreservesExistingBashKeys(t *testing.T) {
 
 	cfg := readOpenCodeConfig(t, configPath)
 	assertBashRule(t, cfg, "*", "allow")
-	assertBashRule(t, cfg, "git *", "ask")
+	assertBashRule(t, cfg, "git *", "deny")
 
 	// Last-match-wins: "git *" must serialize after "*".
 	order := bashRuleOrder(t, configPath)
@@ -401,7 +401,7 @@ func TestConfigureOpenCodePolicy_CorruptJSONBackupsAndWritesFresh(t *testing.T) 
 
 	// Fresh config must be valid JSON with the policy.
 	cfg := readOpenCodeConfig(t, configPath)
-	assertBashRule(t, cfg, "git *", "ask")
+	assertBashRule(t, cfg, "git *", "deny")
 	assertInstructionsContains(t, cfg, gitCourerMdPath(configPath))
 }
 

--- a/internal/installer/v26_test.go
+++ b/internal/installer/v26_test.go
@@ -281,7 +281,7 @@ func TestRestoreBackup_NoBackupIsNoop(t *testing.T) {
 
 // TestConfigureMCP_OpenCodePolicyEarlyReturnPath verifies that when
 // opencode.json already contains git-courer (early-return path in
-// ConfigureMCP), the policy entries (permission.bash "git *": "ask" and
+// ConfigureMCP), the policy entries (permission.bash "git *": "deny" and
 // GIT_COURER.md in instructions) are still applied. This proves the wiring
 // calls configureOpenCodePolicy in the already-configured branch.
 func TestConfigureMCP_OpenCodePolicyEarlyReturnPath(t *testing.T) {
@@ -309,7 +309,7 @@ func TestConfigureMCP_OpenCodePolicyEarlyReturnPath(t *testing.T) {
 	}
 
 	cfg := readOpenCodeConfig(t, configPath)
-	assertBashRule(t, cfg, "git *", "ask")
+	assertBashRule(t, cfg, "git *", "deny")
 	assertInstructionsContains(t, cfg, filepath.Join(filepath.Dir(configPath), "AGENTS.md"))
 }
 
@@ -345,7 +345,7 @@ func TestConfigureMCP_OpenCodePolicyNormalPath(t *testing.T) {
 		t.Error("git-courer MCP entry missing in normal path")
 	}
 	// Policy present.
-	assertBashRule(t, cfg, "git *", "ask")
+	assertBashRule(t, cfg, "git *", "deny")
 	assertInstructionsContains(t, cfg, filepath.Join(filepath.Dir(configPath), "AGENTS.md"))
 }
 


### PR DESCRIPTION
Closes #199

## PR Type

- [x] Bug fix

## Summary

- `runStdinMode` now detects Codex, Claude Code, and Antigravity from stdin JSON keys
- Codex and Claude Code emit `permissionDecision: "deny"` (was `additionalContext` suggestion)
- Antigravity emits top-level `{"allow_tool": false, "deny_reason": "..."}` with exit 0
- OpenCode policy changed from `"ask"` to `"deny"` for `bash["git *"]`
- Non-git commands on all agents: exit 0 with no output

## Changes

| File | Change |
|------|--------|
| `internal/delivery/cli/hook_check.go` | Unified `hookInput` struct, `agentType` enum, `antigravityHookOutput` struct, `runStdinMode` rewrite with nil-check dispatch |
| `internal/delivery/cli/hook_check_test.go` | 4 new tests (Claude Code git/non-git, Antigravity git/non-git), 1 updated (Codex deny format) |
| `internal/installer/mcp_config.go` | `bash["git *"] = "ask"` → `"deny"` |
| `internal/installer/opencode_policy_test.go` | 3 asserts updated to `"deny"` |
| `internal/installer/v26_test.go` | 2 asserts updated to `"deny"` |

## Test Plan

- [x] `go test ./internal/delivery/cli/...` passes
- [x] `go test ./internal/installer/...` passes
- [x] `go build ./...` passes
- [x] `go test ./...` passes

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers