### PR TITLE
fix: omit raw diff when annotated content present

### DIFF
--- a/internal/delivery/mcp/shared/diff_result_test.go
+++ b/internal/delivery/mcp/shared/diff_result_test.go
@@ -28,8 +28,8 @@ func TestDiffResultJSON_AnnotatedPresent(t *testing.T) {
 	assert.Contains(t, parsed, "annotated", "JSON should contain annotated key when Annotated is non-empty")
 	assert.Equal(t, "handler.go\n@@ -1,3 +1,3 @@ [NEW_FUNC: Helper]", parsed["annotated"])
 
-	// Verify other keys still present
-	assert.Contains(t, parsed, "diff")
+	// Verify other keys still present — diff is omitted when annotated is present
+	assert.NotContains(t, parsed, "diff")
 	assert.Contains(t, parsed, "total_lines")
 }
 

--- a/internal/delivery/mcp/shared/helpers.go
+++ b/internal/delivery/mcp/shared/helpers.go
@@ -398,9 +398,10 @@ func FormatStatusJSON(s domain.Status, limit, offset int, filter string, userNam
 }
 
 // DiffResultJSON formats a DiffResult into a JSON string.
+// When Annotated is present, it is a superset of Diff (raw content + AST labels),
+// so the raw diff field is omitted to avoid duplication.
 func DiffResultJSON(res DiffResult) string {
 	m := map[string]interface{}{
-		"diff":                res.Diff,
 		"total_lines":         res.TotalLines,
 		"lines_shown":         res.LinesShown,
 		"offset":              res.Offset,
@@ -423,6 +424,8 @@ func DiffResultJSON(res DiffResult) string {
 	}
 	if res.Annotated != "" {
 		m["annotated"] = res.Annotated
+	} else {
+		m["diff"] = res.Diff
 	}
 
 	return MustJSON(m)


### PR DESCRIPTION
Closes #200

## Summary

- Removes redundant `diff` field from JSON when `annotated` is present
- Annotated diff is a superset (raw content + AST labels), so raw diff is pure duplication
- Saves ~2x tokens per diff response for LLM consumers

## Changes

| File | Change |
|------|--------|
| `internal/delivery/mcp/shared/helpers.go` | Emit `diff` only when `Annotated` is empty |
| `internal/delivery/mcp/shared/diff_result_test.go` | Assert `diff` is absent when annotated present |

## Test Plan

- [x] `go test ./internal/delivery/mcp/shared/...` — all pass
- [x] `go test ./internal/delivery/mcp/core/...` — all pass
- [x] `TestDiffResultJSON_AnnotatedPresent` verifies `diff` is omitted
- [x] `TestDiffResultJSON_AnnotatedEmpty` verifies `diff` is still present