### PR TITLE
fix: unborn-first-commit — soporte para repos recién inicializados

### DIFF
--- a/internal/adapters/git/backup_test.go
+++ b/internal/adapters/git/backup_test.go
@@ -363,3 +363,62 @@ func TestCreateBackup_AutoPruneGate_PruneErrorDoesNotBlock(t *testing.T) {
 		t.Errorf("new backup ref %s was not created", backup.Ref)
 	}
 }
+
+// TestCollectReachabilityTips_UnbornRepo_SkipsHead verifies that on a repo
+// with zero commits (unborn HEAD), collectReachabilityTips tolerates the
+// rev-parse HEAD failure, skips the HEAD tip, and returns the local branch
+// tips (empty on a fresh repo). No error. See spec delta "Backup prune on
+// unborn repo".
+func TestCollectReachabilityTips_UnbornRepo_SkipsHead(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+	// Force a default branch name so symbolic-ref is consistent.
+	gitRun(t, dir, "symbolic-ref", "HEAD", "refs/heads/master")
+	a := New(dir)
+
+	// No commits — HEAD is unborn. No branches exist either (refs/heads/ is
+	// empty), so the expected result is an empty slice with no error.
+	tips, err := a.collectReachabilityTips()
+	if err != nil {
+		t.Fatalf("collectReachabilityTips on unborn repo should not error, got: %v", err)
+	}
+	if len(tips) != 0 {
+		t.Errorf("collectReachabilityTips on unborn repo with no branches = %v, want empty", tips)
+	}
+}
+
+// TestCollectReachabilityTips_UnbornRepo_WithBranchTips verifies that on an
+// unborn repo that still has local branch refs pointing at commits (e.g.,
+// created by a prior session), collectReachabilityTips skips the unborn HEAD
+// tip but still collects the branch tips. See spec delta "Backup prune on
+// unborn repo".
+func TestCollectReachabilityTips_UnbornRepo_WithBranchTips(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+	gitRun(t, dir, "symbolic-ref", "HEAD", "refs/heads/master")
+	a := New(dir)
+
+	// Commit on master, create a feature branch at that commit.
+	featureCommit := commitFile(t, a, dir, "base.txt", "base")
+	gitRun(t, dir, "branch", "feature")
+	// Make HEAD unborn: delete the master ref via update-ref -d (ref-level,
+	// works even when HEAD points at it — HEAD becomes unborn).
+	gitRun(t, dir, "update-ref", "-d", "refs/heads/master")
+	// HEAD is now unborn (symbolic-ref still points at refs/heads/master which
+	// no longer exists), but refs/heads/feature points at featureCommit.
+
+	tips, err := a.collectReachabilityTips()
+	if err != nil {
+		t.Fatalf("collectReachabilityTips should tolerate unborn HEAD, got: %v", err)
+	}
+	// The feature branch tip must be collected even though HEAD was skipped.
+	found := false
+	for _, tip := range tips {
+		if tip == featureCommit {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("feature branch tip %s not collected; tips = %v", featureCommit, tips)
+	}
+}

--- a/internal/adapters/git/exec_backup.go
+++ b/internal/adapters/git/exec_backup.go
@@ -218,16 +218,20 @@ func (a *ExecAdapter) listBackupRefs() ([]domain.Backup, error) {
 }
 
 // collectReachabilityTips returns the commit OIDs for HEAD and every local
-// branch tip under refs/heads/. HEAD is always first.
+// branch tip under refs/heads/. HEAD is always first when it resolves. On an
+// unborn repo (zero commits) rev-parse HEAD fails; the HEAD tip is skipped
+// and only branch tips are returned. See the unborn-first-commit spec delta
+// "Backup prune on unborn repo".
 func (a *ExecAdapter) collectReachabilityTips() ([]string, error) {
 	var tips []string
 
-	head, err := a.runGit("rev-parse", "HEAD")
-	if err != nil {
-		return nil, fmt.Errorf("resolving HEAD: %w", err)
-	}
-	if h := strings.TrimSpace(head); h != "" {
-		tips = append(tips, h)
+	// HEAD is best-effort: on an unborn repo rev-parse HEAD fails, so skip
+	// the HEAD tip rather than aborting the whole prune. Branch tips below
+	// still protect any commits reachable from local branches.
+	if head, err := a.runGit("rev-parse", "HEAD"); err == nil {
+		if h := strings.TrimSpace(head); h != "" {
+			tips = append(tips, h)
+		}
 	}
 
 	// Local branch tips: one OID per line.

--- a/internal/adapters/git/exec_read_info.go
+++ b/internal/adapters/git/exec_read_info.go
@@ -66,20 +66,28 @@ func (a *ExecAdapter) Status() (domain.Status, error) {
 	status.Branch, _ = a.CurrentBranch()
 	status.IsClean = len(status.Files) == 0
 
-	// Get ahead/behind info
-	abOut, err := a.runGit("rev-list", "--left-right", "--count", "HEAD...@{upstream}")
-	if err == nil {
-		status.HasUpstream = true
-		parts := strings.Fields(strings.TrimSpace(abOut))
-		if len(parts) == 2 {
-			if ahead, err := strconv.Atoi(parts[0]); err == nil {
-				status.Ahead = ahead
-			}
-			if behind, err := strconv.Atoi(parts[1]); err == nil {
-				status.Behind = behind
+	// Ahead/behind only make sense when HEAD resolves to a commit. On an
+	// unborn repo (zero commits) rev-list would crash; detect unborn via
+	// rev-parse --verify HEAD. When HEAD is unborn OR no upstream is
+	// configured, Ahead/Behind stay nil — the JSON null signal. See the
+	// spec delta "Status ahead/behind on unborn or upstream-less repos".
+	if _, verifyErr := a.runGit("rev-parse", "--verify", "HEAD"); verifyErr == nil {
+		abOut, err := a.runGit("rev-list", "--left-right", "--count", "HEAD...@{upstream}")
+		if err == nil {
+			status.HasUpstream = true
+			parts := strings.Fields(strings.TrimSpace(abOut))
+			if len(parts) == 2 {
+				if ahead, err := strconv.Atoi(parts[0]); err == nil {
+					status.Ahead = &ahead
+				}
+				if behind, err := strconv.Atoi(parts[1]); err == nil {
+					status.Behind = &behind
+				}
 			}
 		}
+		// err != nil here means no upstream configured — leave Ahead/Behind nil.
 	}
+	// verifyErr != nil means unborn HEAD — leave Ahead/Behind nil.
 
 	return status, nil
 }

--- a/internal/adapters/git/exec_read_test.go
+++ b/internal/adapters/git/exec_read_test.go
@@ -533,3 +533,59 @@ func TestDiffStatStagedWithPath(t *testing.T) {
 		t.Error("DiffStatStaged(subdir) should contain the staged file")
 	}
 }
+
+// TestStatus_UnbornRepo_ReturnsNilAheadBehind verifies Status on a freshly
+// init'd repo (unborn HEAD, no commits) skips the rev-list ahead/behind call
+// and reports Ahead==nil, Behind==nil. See spec delta "Unborn branch".
+func TestStatus_UnbornRepo_ReturnsNilAheadBehind(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+
+	// Stage a file so the working tree has content but no commits exist.
+	os.WriteFile(filepath.Join(dir, "staged.txt"), []byte("content"), 0644)
+	adapter := New(dir)
+	adapter.Add([]string{"staged.txt"})
+
+	status, err := adapter.Status()
+	if err != nil {
+		t.Fatalf("Status() on unborn repo should not error, got: %v", err)
+	}
+	if status.Ahead != nil {
+		t.Errorf("Status().Ahead = %v, want nil on unborn repo", *status.Ahead)
+	}
+	if status.Behind != nil {
+		t.Errorf("Status().Behind = %v, want nil on unborn repo", *status.Behind)
+	}
+	if status.HasUpstream {
+		t.Error("Status().HasUpstream should be false on unborn repo")
+	}
+}
+
+// TestStatus_RepoWithCommitsNoUpstream_ReturnsNilAheadBehind verifies that a
+// repo WITH commits but no configured upstream reports Ahead==nil, Behind==nil
+// (not 0). See spec delta "Commits exist but no upstream configured".
+func TestStatus_RepoWithCommitsNoUpstream_ReturnsNilAheadBehind(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+
+	adapter := New(dir)
+	os.WriteFile(filepath.Join(dir, "file.txt"), []byte("x"), 0644)
+	adapter.Add([]string{"file.txt"})
+	if _, err := adapter.Commit("initial"); err != nil {
+		t.Fatalf("Commit error: %v", err)
+	}
+
+	status, err := adapter.Status()
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if status.Ahead != nil {
+		t.Errorf("Status().Ahead = %v, want nil when no upstream configured", *status.Ahead)
+	}
+	if status.Behind != nil {
+		t.Errorf("Status().Behind = %v, want nil when no upstream configured", *status.Behind)
+	}
+	if status.HasUpstream {
+		t.Error("HasUpstream should be false when no upstream configured")
+	}
+}

--- a/internal/adapters/git/exec_write_commit.go
+++ b/internal/adapters/git/exec_write_commit.go
@@ -114,8 +114,18 @@ func (a *ExecAdapter) WriteTree() (string, error) {
 	return hash, nil
 }
 
+// CommitTree creates a commit object pointing at treeHash. When parentHash
+// is empty the resulting commit has no parent (a root commit) — the -p flag
+// is omitted entirely. This is required for the first commit on a freshly
+// init'd repo (unborn HEAD), where applyPlumbing passes "" as parentHash
+// because Head() fails. See the unborn-first-commit spec delta.
 func (a *ExecAdapter) CommitTree(treeHash, parentHash, message string) (string, error) {
-	out, err := a.runGit("commit-tree", treeHash, "-p", parentHash, "-m", message)
+	args := []string{"commit-tree", treeHash}
+	if parentHash != "" {
+		args = append(args, "-p", parentHash)
+	}
+	args = append(args, "-m", message)
+	out, err := a.runGit(args...)
 	if err != nil {
 		return "", err
 	}

--- a/internal/adapters/git/exec_write_commit_test.go
+++ b/internal/adapters/git/exec_write_commit_test.go
@@ -192,3 +192,64 @@ func TestHead_UnbornRepo_ReturnsError(t *testing.T) {
 		t.Fatal("Head() should return error on unborn repo (no commits)")
 	}
 }
+
+// TestCommitTree_EmptyParent_CreatesRootCommit verifies CommitTree omits the
+// -p flag when parentHash is empty, producing a valid root commit on a repo
+// with zero commits. See spec delta "Commit plumbing supports root commits".
+func TestCommitTree_EmptyParent_CreatesRootCommit(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+
+	adapter := New(dir)
+
+	// Stage a file and write the tree (no commits exist yet — unborn).
+	os.WriteFile(filepath.Join(dir, "root.txt"), []byte("root content"), 0644)
+	adapter.Add([]string{"root.txt"})
+	treeHash, err := adapter.WriteTree()
+	if err != nil {
+		t.Fatalf("WriteTree() error = %v", err)
+	}
+
+	// Create a root commit with empty parent — must NOT pass -p.
+	commitHash, err := adapter.CommitTree(treeHash, "", "root commit")
+	if err != nil {
+		t.Fatalf("CommitTree(tree, \"\", msg) error = %v", err)
+	}
+	if len(commitHash) != 40 {
+		t.Errorf("CommitTree() hash length = %d, want 40 (got %q)", len(commitHash), commitHash)
+	}
+
+	// Verify the commit object exists and is a commit.
+	cmd := exec.Command("git", "cat-file", "-t", commitHash)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("cat-file -t %s failed: %v", commitHash, err)
+	}
+	if strings.TrimSpace(string(out)) != "commit" {
+		t.Errorf("cat-file -t %s = %q, want 'commit'", commitHash, strings.TrimSpace(string(out)))
+	}
+
+	// Verify it has NO parent (root commit) — git cat-file -p shows no "parent" line.
+	cmd = exec.Command("git", "cat-file", "-p", commitHash)
+	cmd.Dir = dir
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("cat-file -p %s failed: %v", commitHash, err)
+	}
+	if strings.Contains(string(out), "parent ") {
+		t.Errorf("root commit must have no parent line, got:\n%s", string(out))
+	}
+
+	// Point HEAD at it and verify HEAD resolves — repo is no longer unborn.
+	if _, err := adapter.UpdateRef("HEAD", commitHash); err != nil {
+		t.Fatalf("UpdateRef(HEAD, %s) error = %v", commitHash, err)
+	}
+	head, err := adapter.Head()
+	if err != nil {
+		t.Fatalf("Head() after UpdateRef error = %v", err)
+	}
+	if head != commitHash {
+		t.Errorf("Head() = %q, want %q", head, commitHash)
+	}
+}

--- a/internal/core/domain/git.go
+++ b/internal/core/domain/git.go
@@ -11,8 +11,8 @@ type Status struct {
 	IsClean     bool         `json:"is_clean"`
 	RepoPath    string       `json:"repo_path"`
 	Branch      string       `json:"branch"`
-	Ahead       int          `json:"ahead,omitempty"`
-	Behind      int          `json:"behind,omitempty"`
+	Ahead       *int         `json:"ahead"`
+	Behind      *int         `json:"behind"`
 	HasUpstream bool         `json:"has_upstream"`
 	Files       []FileStatus `json:"files"`
 	Staged      int          `json:"staged_count"`

--- a/internal/core/domain/git_test.go
+++ b/internal/core/domain/git_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestReleaseIntent_JSONSerialization(t *testing.T) {
@@ -39,3 +41,40 @@ func TestReleaseIntent_JSONSerialization(t *testing.T) {
 		}
 	})
 }
+
+// TestStatus_AheadBehind_NullableJSON verifies the *int contract for
+// Status.Ahead/Behind: nil MUST serialize as JSON null (not omitted, not 0),
+// and a concrete value MUST serialize as a number. This is the unborn-repo
+// signal contract — see spec delta "Status ahead/behind on unborn or
+// upstream-less repos".
+func TestStatus_AheadBehind_NullableJSON(t *testing.T) {
+	t.Run("nil Ahead/Behind serialize as null", func(t *testing.T) {
+		s := Status{Branch: "main"}
+		data, err := json.Marshal(s)
+		assert.NoError(t, err)
+		jsonStr := string(data)
+		// null is the explicit signal — NOT omitted, NOT 0.
+		assert.Contains(t, jsonStr, `"ahead":null`, "nil Ahead must be null, not omitted")
+		assert.Contains(t, jsonStr, `"behind":null`, "nil Behind must be null, not omitted")
+	})
+
+	t.Run("set Ahead/Behind serialize as numbers", func(t *testing.T) {
+		ahead, behind := 3, 1
+		s := Status{Branch: "main", Ahead: &ahead, Behind: &behind}
+		data, err := json.Marshal(s)
+		assert.NoError(t, err)
+		jsonStr := string(data)
+		assert.Contains(t, jsonStr, `"ahead":3`)
+		assert.Contains(t, jsonStr, `"behind":1`)
+	})
+
+	t.Run("deserializes null back to nil", func(t *testing.T) {
+		jsonData := `{"is_clean":false,"repo_path":"","branch":"main","ahead":null,"behind":null,"has_upstream":false,"files":null,"staged_count":0,"modified_count":0,"untracked_count":0,"conflicted_count":0}`
+		var s Status
+		assert.NoError(t, json.Unmarshal([]byte(jsonData), &s))
+		assert.Nil(t, s.Ahead, "null must deserialize to nil")
+		assert.Nil(t, s.Behind, "null must deserialize to nil")
+	})
+}
+
+// requires import of assert (added above)

--- a/internal/delivery/mcp/core/commit_handler.go
+++ b/internal/delivery/mcp/core/commit_handler.go
@@ -673,10 +673,13 @@ func (h *Handler) applyPlumbing(ctx context.Context, jobID string, pushAfter boo
 		message = overrideCommitType(message, typeOverride)
 	}
 
-	// Get parent commit hash
+	// Get parent commit hash. On an unborn repo (zero commits) Head() fails
+	// because HEAD doesn't resolve. Tolerate this by passing "" as parentHash
+	// — CommitTree omits the -p flag and creates a valid root commit. See the
+	// unborn-first-commit spec delta "First commit on a fresh repo".
 	parentHash, err := h.git.Head()
 	if err != nil {
-		return nil, fmt.Errorf("APPLY: failed to get HEAD: %w", err)
+		parentHash = ""
 	}
 
 	// Create commit from tree snapshot

--- a/internal/delivery/mcp/core/commit_handler_noai_test.go
+++ b/internal/delivery/mcp/core/commit_handler_noai_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/blak0p/git-courer/internal/core/domain"
@@ -257,5 +258,58 @@ func TestHandleCommit_NoAI_KeepsPrefix(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "success", resp.Status)
 	assert.Contains(t, resp.Message, "docs: update documentation")
+}
+
+// TestHandleCommit_NoAI_ApplyPlumbing_UnbornRepo verifies applyPlumbing
+// tolerates Head() failure on an unborn repo: it sets parentHash="" and
+// CommitTree creates a root commit. See spec delta "First commit on a fresh repo".
+func TestHandleCommit_NoAI_ApplyPlumbing_UnbornRepo(t *testing.T) {
+	mGit := new(mockGit)
+	h := NewHandler(mGit, nil, nil, nil, "", nil, nil)
+	h.SetLLMEnabled(false)
+
+	mGit.On("Add", []string{"root.go"}).Return(nil)
+	mGit.On("WriteTree").Return("roottree123", nil).Once()
+
+	// PREVIEW
+	req := mcpgo.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"command":      "PREVIEW",
+		"message":      "feat: initial commit",
+		"target_paths": "root.go",
+	}
+	res, err := h.HandleCommit(context.Background(), req)
+	assert.NoError(t, err)
+	var resp struct {
+		JobID string `json:"job_id"`
+	}
+	assert.NoError(t, json.Unmarshal([]byte(res.Content[0].(mcpgo.TextContent).Text), &resp))
+	assert.NotEmpty(t, resp.JobID)
+
+	// APPLY on unborn repo: Head() fails → parentHash="" → CommitTree omits -p.
+	mGit.On("Head").Return("", fmt.Errorf("rev-parse HEAD: bad revision"))
+	mGit.On("CommitTree", "roottree123", "", "feat: initial commit").Return("rootcommit456", nil).Once()
+	mGit.On("UpdateRef", "HEAD", "rootcommit456").Return("SUCCESS", nil).Once()
+	// Metadata amend path: Add(MetadataDir) + WriteTree + CommitTree("") + UpdateRef.
+	mGit.On("Add", []string{domain.MetadataDir}).Return(nil)
+	mGit.On("WriteTree").Return("metadatatree789", nil).Once()
+	mGit.On("CommitTree", "metadatatree789", "", "feat: initial commit").Return("replacementroot000", nil).Once()
+	mGit.On("UpdateRef", "HEAD", "replacementroot000").Return("SUCCESS", nil).Once()
+	mGit.On("Reset", "HEAD", ".").Return("SUCCESS", nil)
+
+	reqApply := mcpgo.CallToolRequest{}
+	reqApply.Params.Arguments = map[string]any{
+		"command": "APPLY",
+		"job_id":  resp.JobID,
+	}
+	resApply, err := h.HandleCommit(context.Background(), reqApply)
+	assert.NoError(t, err)
+	assert.NotNil(t, resApply)
+
+	// The result must report the replacement commit hash (metadata amend path).
+	text := resApply.Content[0].(mcpgo.TextContent).Text
+	assert.Contains(t, text, `"status":"applied"`)
+	assert.Contains(t, text, "replacementroot000")
+	mGit.AssertExpectations(t)
 }
 

--- a/internal/delivery/mcp/prreview/handler.go
+++ b/internal/delivery/mcp/prreview/handler.go
@@ -63,6 +63,9 @@ func (h *Handler) HandlePRReview(ctx context.Context, req mcpgo.CallToolRequest)
 	}
 
 	// 3. Build branch info
+	// Ahead/Behind are *int (nullable): on an unborn repo or a repo with no
+	// upstream they are nil. Copy the pointer directly so the null signal
+	// propagates to BranchInfo — no dereference needed.
 	branchInfo := BranchInfo{
 		Name:        status.Branch,
 		Ahead:       status.Ahead,

--- a/internal/delivery/mcp/prreview/handler_test.go
+++ b/internal/delivery/mcp/prreview/handler_test.go
@@ -21,6 +21,9 @@ type mockGit struct {
 	mock.Mock
 }
 
+// intptr is a test fixture helper for the *int Ahead/Behind fields.
+func intptr(v int) *int { return &v }
+
 func (m *mockGit) Status() (domain.Status, error) {
 	args := m.Called()
 	return args.Get(0).(domain.Status), args.Error(1)
@@ -169,8 +172,8 @@ func TestPRReview_NoTestCommand(t *testing.T) {
 	git := new(mockGit)
 	git.On("Status").Return(domain.Status{
 		Branch:      "feat/branch",
-		Ahead:       3,
-		Behind:      1,
+		Ahead:       intptr(3),
+		Behind:      intptr(1),
 		HasUpstream: true,
 		Conflicted:  0,
 	}, nil)
@@ -204,8 +207,8 @@ func TestPRReview_TestCommandFromProjectConfig(t *testing.T) {
 	git := new(mockGit)
 	git.On("Status").Return(domain.Status{
 		Branch:      "feat/branch",
-		Ahead:       2,
-		Behind:      0,
+		Ahead:       intptr(2),
+		Behind:      intptr(0),
 		HasUpstream: true,
 		Conflicted:  0,
 	}, nil)
@@ -247,8 +250,8 @@ func TestPRReview_TestFail(t *testing.T) {
 	git := new(mockGit)
 	git.On("Status").Return(domain.Status{
 		Branch:      "feat/branch",
-		Ahead:       2,
-		Behind:      0,
+		Ahead:       intptr(2),
+		Behind:      intptr(0),
 		HasUpstream: true,
 		Conflicted:  0,
 	}, nil)
@@ -296,8 +299,8 @@ func TestPRReview_Conflict(t *testing.T) {
 	git := new(mockGit)
 	git.On("Status").Return(domain.Status{
 		Branch:     "feat/branch",
-		Ahead:      1,
-		Behind:     0,
+		Ahead:      intptr(1),
+		Behind:     intptr(0),
 		Conflicted: 2,
 		Files: []domain.FileStatus{
 			{Path: "file1.go", Status: "U"},
@@ -366,8 +369,8 @@ func TestPRReview_DefaultTargetBranch(t *testing.T) {
 	git := new(mockGit)
 	git.On("Status").Return(domain.Status{
 		Branch:      "feat/branch",
-		Ahead:       1,
-		Behind:      0,
+		Ahead:       intptr(1),
+		Behind:      intptr(0),
 		HasUpstream: true,
 		Conflicted:  0,
 	}, nil)
@@ -398,8 +401,8 @@ func TestPRReview_DiffStats(t *testing.T) {
 	git := new(mockGit)
 	git.On("Status").Return(domain.Status{
 		Branch:      "feat/branch",
-		Ahead:       3,
-		Behind:      0,
+		Ahead:       intptr(3),
+		Behind:      intptr(0),
 		HasUpstream: true,
 		Conflicted:  0,
 	}, nil)
@@ -497,8 +500,8 @@ func TestPRReview_ProjectConfigLoadError(t *testing.T) {
 	git := new(mockGit)
 	git.On("Status").Return(domain.Status{
 		Branch:      "feat/branch",
-		Ahead:       1,
-		Behind:      0,
+		Ahead:       intptr(1),
+		Behind:      intptr(0),
 		HasUpstream: true,
 		Conflicted:  0,
 	}, nil)
@@ -523,4 +526,45 @@ func TestPRReview_ProjectConfigLoadError(t *testing.T) {
 	assert.NoError(t, json.Unmarshal([]byte(text), &result))
 	assert.Equal(t, "no_test_command", result.Status)
 	assert.Contains(t, result.Hint, "SET_TEST_COMMAND")
+}
+
+// TestPRReview_NilAheadBehind verifies the handler propagates nil Ahead/Behind
+// (unborn repo or no-upstream signal) into BranchInfo as JSON null — no panic,
+// no 0. See spec delta "pr-review handler copies status to BranchInfo".
+func TestPRReview_NilAheadBehind(t *testing.T) {
+	git := new(mockGit)
+	git.On("Status").Return(domain.Status{
+		Branch:      "main",
+		Ahead:       nil, // unborn / no upstream
+		Behind:      nil,
+		HasUpstream: false,
+		Conflicted:  0,
+	}, nil)
+	git.On("MergeBase", "main", "main").Return("", fmt.Errorf("no merge base"))
+
+	tmpDir := t.TempDir()
+	h := newTestHandler(git, tmpDir, nil)
+
+	req := mcpgo.CallToolRequest{
+		Params: mcpgo.CallToolParams{
+			Name:      "pr_review",
+			Arguments: map[string]any{},
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		res, err := h.HandlePRReview(context.Background(), req)
+		assert.NoError(t, err)
+		require.NotNil(t, res)
+
+		text := res.Content[0].(mcpgo.TextContent).Text
+		var result PRReviewResult
+		assert.NoError(t, json.Unmarshal([]byte(text), &result))
+		assert.Nil(t, result.Branch.Ahead, "BranchInfo.Ahead must stay nil for unborn/no-upstream")
+		assert.Nil(t, result.Branch.Behind, "BranchInfo.Behind must stay nil for unborn/no-upstream")
+		// JSON serialization must emit null, not 0.
+		assert.Contains(t, text, `"ahead":null`)
+		assert.Contains(t, text, `"behind":null`)
+	})
+	git.AssertExpectations(t)
 }

--- a/internal/delivery/mcp/prreview/result.go
+++ b/internal/delivery/mcp/prreview/result.go
@@ -14,8 +14,8 @@ type PRReviewResult struct {
 // BranchInfo holds branch divergence data.
 type BranchInfo struct {
 	Name        string `json:"name"`
-	Ahead       int    `json:"ahead"`
-	Behind      int    `json:"behind"`
+	Ahead       *int   `json:"ahead"`
+	Behind      *int   `json:"behind"`
 	MergeBase   string `json:"merge_base"`
 	HasUpstream bool   `json:"has_upstream"`
 }

--- a/internal/delivery/mcp/session/session.go
+++ b/internal/delivery/mcp/session/session.go
@@ -146,6 +146,12 @@ func allowedParams(command string) []string {
 	}
 }
 
+// emptyTreeHash is the well-known SHA-1 of git's empty tree object
+// (git mktree < /dev/null). Used as the session base commit on a freshly
+// init'd repo where HEAD is unborn (Head() fails). See the unborn-first-commit
+// spec delta "Start session on fresh repo".
+const emptyTreeHash = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
 // handleStart creates an isolated session: a branch ref + a linked worktree +
 // a metadata file. On worktree failure it rolls back the branch ref so no
 // orphan branch remains.
@@ -165,9 +171,13 @@ func (h *Handler) handleStart(params map[string]any) (*mcpgo.CallToolResult, err
 		return shared.JSONErrorResult("start", fmt.Errorf("goal is required for start"))
 	}
 
+	// On an unborn repo (zero commits) Head() fails because HEAD doesn't
+	// resolve. Fall back to the empty-tree hash so CreateRef can still anchor
+	// the session branch at the empty tree. See the unborn-first-commit spec
+	// delta "Start session on fresh repo".
 	baseCommit, err := h.git.Head()
 	if err != nil {
-		return shared.JSONErrorResult("start", fmt.Errorf("failed to read HEAD: %w", err))
+		baseCommit = emptyTreeHash
 	}
 
 	id := computeSessionID(goal)

--- a/internal/delivery/mcp/session/session_test.go
+++ b/internal/delivery/mcp/session/session_test.go
@@ -639,3 +639,33 @@ func TestHandleDiscard_MissingConfirmedReturnsError(t *testing.T) {
 	text := resultText(t, res)
 	assert.Contains(t, text, "confirmed")
 }
+
+// TestHandleStart_UnbornRepo_UsesEmptyTreeHash verifies handleStart falls back
+// to emptyTreeHash as baseCommit when Head() fails on an unborn repo (zero
+// commits). The session branch ref is created at the empty tree, and the
+// worktree is checked out. See spec delta "Start session on fresh repo".
+func TestHandleStart_UnbornRepo_UsesEmptyTreeHash(t *testing.T) {
+	mockGit := new(MockGit)
+	h := NewHandler(mockGit)
+	h.metaDir = t.TempDir()
+
+	id := computeSessionID("first commit")
+	// Head() fails on unborn repo.
+	mockGit.On("Head").Return("", assertError("rev-parse HEAD: bad revision"))
+	// baseCommit must be the empty-tree hash, not a real commit.
+	emptyTree := "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+	mockGit.On("CreateRef", "refs/heads/"+id, emptyTree).Return(nil)
+	mockGit.On("AddWorktree", "../git-courer-worktrees/"+id, ""+id).
+		Return("../git-courer-worktrees/"+id, nil)
+
+	args := map[string]any{"command": "start", "agent": "claude", "goal": "first commit"}
+	res, err := h.HandleSession(context.Background(), sessionReq(args))
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	text := resultText(t, res)
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+	assert.Equal(t, emptyTree, parsed["base_commit"], "base_commit must be emptyTreeHash on unborn repo")
+	mockGit.AssertExpectations(t)
+}

--- a/internal/delivery/mcp/shared/formatters_test.go
+++ b/internal/delivery/mcp/shared/formatters_test.go
@@ -7,12 +7,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// intptr returns a pointer to v — a fixture helper for the *int Ahead/Behind
+// fields introduced by the unborn-repo nullable contract.
+func intptr(v int) *int { return &v }
+
 func TestFormatStatusJSON(t *testing.T) {
 	t.Run("formats status with files", func(t *testing.T) {
 		status := domain.Status{
 			Branch: "main",
-			Ahead:  2,
-			Behind: 1,
+			Ahead:  intptr(2),
+			Behind: intptr(1),
 			Files: []domain.FileStatus{
 				{Path: "main.go", Status: "M", Staged: true},
 				{Path: "README.md", Status: "A", Staged: false},
@@ -67,6 +71,25 @@ func TestFormatStatusJSON(t *testing.T) {
 		assert.Contains(t, result, `"branch"`)
 		assert.Contains(t, result, `"main"`)
 		assert.Contains(t, result, `"clean":true`)
+	})
+
+	// Spec delta "FormatStatusJSON on unborn repo": nil Ahead/Behind MUST
+	// serialize as JSON null, and the call MUST NOT panic on nil dereference.
+	t.Run("nil ahead/behind serialize as null without panic", func(t *testing.T) {
+		status := domain.Status{Branch: "main", IsClean: true}
+		// Assert no panic — FormatStatusJSON must not dereference nil pointers.
+		assert.NotPanics(t, func() {
+			result := FormatStatusJSON(status, 100, 0, "", "", "", "", "")
+			assert.Contains(t, result, `"ahead":null`)
+			assert.Contains(t, result, `"behind":null`)
+		})
+	})
+
+	t.Run("set ahead/behind serialize as numbers", func(t *testing.T) {
+		status := domain.Status{Branch: "main", Ahead: intptr(5), Behind: intptr(2)}
+		result := FormatStatusJSON(status, 100, 0, "", "", "", "", "")
+		assert.Contains(t, result, `"ahead":5`)
+		assert.Contains(t, result, `"behind":2`)
 	})
 }
 

--- a/internal/delivery/mcp/shared/helpers.go
+++ b/internal/delivery/mcp/shared/helpers.go
@@ -375,6 +375,11 @@ func FormatStatusJSON(s domain.Status, limit, offset int, filter string, userNam
 		})
 	}
 
+	// Ahead/Behind are *int (nullable): nil on unborn repos or when no
+	// upstream is configured. We pass the pointer (or nil) to MustJSON
+	// directly — encoding/json marshals a nil *int as JSON null, which is
+	// the explicit "no data" signal per the unborn-first-commit spec delta.
+	// No dereference here: a nil dereference would panic on unborn repos.
 	return MustJSON(map[string]interface{}{
 		"branch":       s.Branch,
 		"ahead":        s.Ahead,


### PR DESCRIPTION
Closes #204

## Summary

- git-courer ahora funciona en repos recién inicializados (unborn branch, sin commits)
- `Status.Ahead`/`Behind` pasan a `*int` con `null` en unborn (semánticamente correcto)
- `CommitTree` omite `-p` cuando no hay parent (root commit)
- `session start` y `backup` toleran unborn HEAD

## Changes

| File | Change |
|------|--------|
| `internal/core/domain/git.go` | `Status.Ahead/Behind`: `int` → `*int`, sin `omitempty` |
| `internal/delivery/mcp/prreview/result.go` | `BranchInfo.Ahead/Behind`: `int` → `*int` |
| `internal/adapters/git/exec_write_commit.go` | `CommitTree`: args condicionales, omite `-p` si no hay parent |
| `internal/delivery/mcp/core/commit_handler.go` | `applyPlumbing`: tolera `Head()` fallando |
| `internal/adapters/git/exec_read_info.go` | `Status`: detecta unborn, skipea `rev-list` |
| `internal/delivery/mcp/shared/helpers.go` | `FormatStatusJSON`: nil-safe `*int` |
| `internal/delivery/mcp/prreview/handler.go` | nil-safe copy a `BranchInfo` |
| `internal/delivery/mcp/session/session.go` | `handleStart`: `emptyTreeHash` fallback |
| `internal/adapters/git/exec_backup.go` | `collectReachabilityTips`: tolera unborn |
| 8 test files | Tests nuevos para cada fix point |

## Test Plan

- [x] `go test ./... -short` — 40 packages, 0 regresiones
- [x] `go vet ./...` — clean
- [x] Tests nuevos: CommitTree con parent vacío, Status en unborn, FormatStatusJSON con nil, backup en unborn, session start en unborn
