### PR TITLE
refactor: granular deny for 23 git subcommands, allow for uncovered ones

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -12,7 +12,7 @@ git-courer uses four hook events. Each event has a matcher (which agent actions 
 
 | Event | Matcher | Command | Fires When | Purpose |
 |-------|---------|---------|------------|---------|
-| `PreToolUse` | `Bash` (Claude Code, Codex) / `run_command` (Antigravity) | `git-courer hook-check` | The agent is about to run a shell command | Classify the command; if it's a git command, emit `additionalContext` suggesting the git-courer MCP tool. **Never denies** — only suggests. |
+| `PreToolUse` | `Bash` (Claude Code, Codex) / `run_command` (Antigravity) | `git-courer hook-check` | The agent is about to run a shell command | Classify the command; if it's a covered git subcommand, emit a deny decision pointing the agent at the git-courer MCP tool. **Denies** covered git subcommands with a message pointing to the equivalent git-courer MCP tool. |
 | `SessionStart` | `startup\|resume` | `git-courer session-start-hook` | A new agent session starts (or resumes) | Inject the Golden Rules into the agent's context so the workflow is known from the first turn. |
 | `SubagentStart` | `general-purpose\|Explore\|Plan` | `git-courer subagent-start-hook` | A subagent is spawned | Inject the Golden Rules into the subagent's context, so subagents also follow `session start` → `status` → `diff`/`review` → `pr-review`. |
 | `PreInvocation` | *(empty matcher)* | `git-courer pre-invocation-hook` | Before every model call (Antigravity only) | Inject the Golden Rules before each model invocation. Compensates for clients that have no `SessionStart`/`SubagentStart` events. |
@@ -32,7 +32,7 @@ Every hook subcommand emits a JSON object on stdout shaped for the Codex hook co
 
 - `hookEventName` echoes the event (`PreToolUse`, `SessionStart`, `SubagentStart`, `PreInvocation`).
 - `additionalContext` is the Golden Rules markdown for the three context-injection hooks. For `PreToolUse` it is a short suggestion like `Use git-courer/<tool> instead of bash <command>` when the command is a git command; for non-git commands, `hook-check` exits cleanly with **no output** (no decision is emitted, no command is denied).
-- `permissionDecision` / `permissionDecisionReason` are **never set** by git-courer — it never denies a command. The agent (and the user, via the client's own permission prompt) always retains the final say.
+- `permissionDecision` / `permissionDecisionReason` are set to `'deny'` for covered git subcommands.
 
 ---
 
@@ -72,7 +72,7 @@ Clients store hooks differently and support different event subsets. git-courer 
 ### OpenCode — no hooks (policy + prompt block instead)
 
 - **No hooks**: OpenCode does not support lifecycle hooks. git-courer instead injects:
-  - `permission.bash["git *"] = "ask"` into `opencode.json` — OpenCode asks before raw git commands.
+  - `permission.bash["git {sub}"] = "deny"` (granular, one entry per covered subcommand) plus `"git *": "ask"` as a fallback into `opencode.json` — OpenCode denies the 23 covered git subcommands and asks before any other raw git command.
   - The `AGENTS.md` path into the `instructions` array — so OpenCode reads the Golden Rules from the prompt block it already loads.
 - See [mcp-clients.md § OpenCode Policy Injection](./mcp-clients.md#5-opencode-policy-injection).
 

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -265,7 +265,7 @@ The MCP tool form returns the same diagnostic envelope as structured JSON (engra
 git-courer hook-check "<shell command>"
 ```
 
-This is the command the `PreToolUse` hooks invoke. It classifies a shell command via the gitcmd classifier and emits the result as JSON on stdout. For git commands it includes `additionalContext` suggesting the git-courer MCP tool instead of bash — it **never denies** a command, it only nudges.
+This is the command the `PreToolUse` hooks invoke. It classifies a shell command via the gitcmd classifier and emits the result as JSON on stdout. For the 23 git subcommands covered by git-courer MCP tools it emits `permissionDecision: "deny"` with a message pointing to the equivalent tool. Unknown git subcommands also get deny as a safe default. Non-git commands and uncovered git subcommands exit cleanly with no output.
 
 When invoked with no args and stdin is a pipe (Codex hook mode), it reads the Codex hook JSON from stdin, extracts the command, classifies it, and emits a Codex-shaped `hookSpecificOutput` with `additionalContext`. Non-git commands exit cleanly with no output.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -147,7 +147,7 @@ If `doctor` reports `MCP configured: no` but you already ran `mcp setup`, the cl
 
 ## `hook-check` troubleshooting
 
-`hook-check` classifies a shell command and emits JSON; it **never denies** a command — it only adds `additionalContext` suggesting the git-courer MCP tool for git commands.
+`hook-check` classifies a shell command and emits JSON. For the 23 git subcommands covered by git-courer MCP tools (status, diff, commit, etc.) it emits `permissionDecision: "deny"` with a message pointing to the equivalent tool. For unknown git subcommands it also emits deny as a safe default. Non-git commands and uncovered git subcommands (init, clone, config, etc.) exit cleanly with no output.
 
 ```bash
 # Direct invocation

--- a/internal/classifier/gitcmd/classifier.go
+++ b/internal/classifier/gitcmd/classifier.go
@@ -13,13 +13,15 @@ import "strings"
 //
 // Decision is one of:
 //   - "allow" — the command is safe to run as-is (non-git, maintenance, etc.)
-//   - "ask"   — the command is a git mutation/read the agent should run via
-//               the suggested MCP tool instead.
+//   - "deny"  — the command is a git subcommand covered by a git-courer MCP
+//     tool; the agent should use that tool instead of raw git.
+//   - "ask"   — the command is an unknown git subcommand with no known MCP
+//     equivalent; the safe default is to ask before running.
 //
 // MCPTool is the git-courer MCP tool name that should be used in place of the
-// raw git subcommand. It is empty when Decision is "allow".
+// raw git subcommand. It is empty when Decision is "allow" or "ask".
 //
-// Reason is a human-readable explanation shown to the agent. For "ask"
+// Reason is a human-readable explanation shown to the agent. For "deny"
 // decisions it follows the format "Use git-courer/{tool} instead of bash
 // git {subcommand}".
 type Result struct {
@@ -30,59 +32,68 @@ type Result struct {
 }
 
 // mcpTools maps a git subcommand to the git-courer MCP tool that should be
-// used instead. Maintenance and informational commands are intentionally
-// absent — they are allowed directly by Classify.
+// used instead. Only the 23 subcommands covered by a git-courer MCP tool are
+// listed here; Classify returns "deny" for these. Maintenance and
+// informational commands are intentionally absent — they are allowed directly
+// by Classify.
 var mcpTools = map[string]string{
-	"status":       "status",
-	"diff":         "diff",
-	"commit":       "commit",
-	"log":          "history",
-	"branch":       "branch",
-	"merge":        "integrate",
-	"rebase":       "integrate",
-	"cherry-pick":  "integrate",
-	"revert":       "rewrite",
-	"reset":        "rewrite",
-	"stash":        "stash",
-	"push":         "sync",
-	"pull":         "sync",
-	"fetch":        "sync",
-	"show":         "history",
-	"blame":        "history",
-	"remote":       "sync",
-	"config":       "config",
-	"add":          "stage",
-	"restore":      "stage",
-	"clean":        "stage",
-	"rm":           "stage",
-	"mv":           "stage",
-	"switch":       "branch",
-	"checkout":     "branch",
-	"worktree":     "branch",
-	"shortlog":     "history",
-	"describe":     "history",
-	"reflog":       "history",
-	"notes":        "history",
-	"archive":      "history",
+	"status":      "status",
+	"diff":        "diff",
+	"commit":      "commit",
+	"log":         "history",
+	"branch":      "branch",
+	"merge":       "integrate",
+	"rebase":      "integrate",
+	"cherry-pick": "integrate",
+	"revert":      "rewrite",
+	"reset":       "rewrite",
+	"stash":       "stash",
+	"push":        "sync",
+	"pull":        "sync",
+	"fetch":       "sync",
+	"blame":       "history",
+	"add":         "stage",
+	"restore":     "stage",
+	"clean":       "stage",
+	"rm":          "stage",
+	"switch":      "branch",
+	"checkout":    "branch",
+	"worktree":    "branch",
+	"reflog":      "history",
 }
 
 // allowedSubcommands are git subcommands with no MCP equivalent that are safe
-// to run directly (maintenance, informational, one-time setup).
+// to run directly (maintenance, informational, one-time setup, and the 8
+// subcommands that git-courer does not yet cover).
 var allowedSubcommands = map[string]bool{
-	"gc":           true,
-	"fsck":         true,
-	"prune":        true,
-	"repack":       true,
-	"maintenance":  true,
-	"help":         true,
-	"version":      true,
-	"init":         true,
-	"clone":        true,
+	"gc":            true,
+	"fsck":          true,
+	"init":          true,
+	"clone":         true,
+	"show":          true,
+	"remote":        true,
+	"config":        true,
+	"mv":            true,
+	"shortlog":      true,
+	"describe":      true,
+	"notes":         true,
+	"archive":       true,
+	"submodule":     true,
+	"bisect":        true,
+	"verify-commit": true,
+	"verify-tag":    true,
+	"grep":          true,
+	"cherry":        true,
+	"ls-files":      true,
+	"ls-tree":       true,
+	"ls-remote":     true,
+	"tag":           true,
 }
 
 // Classify inspects a command string and returns a Result indicating whether
-// the agent should run it directly ("allow") or use the corresponding
-// git-courer MCP tool instead ("ask").
+// the agent should run it directly ("allow"), use the corresponding
+// git-courer MCP tool instead ("deny"), or prompt before running ("ask" — the
+// safe default for unknown git subcommands).
 //
 // Classify is a pure function — it has no side effects and is deterministic
 // for a given input.
@@ -115,7 +126,7 @@ func Classify(command string) Result {
 	}
 
 	if tool, ok := mcpTools[sub]; ok {
-		r.Decision = "ask"
+		r.Decision = "deny"
 		r.MCPTool = tool
 		r.Reason = "Use git-courer/" + tool + " instead of bash git " + sub
 		return r

--- a/internal/classifier/gitcmd/classifier_test.go
+++ b/internal/classifier/gitcmd/classifier_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 // TestClassify_KnownGitSubcommands verifies each known git subcommand maps
-// to the expected MCP tool with decision "ask" and a reason that references
+// to the expected MCP tool with decision "deny" and a reason that references
 // the suggested tool.
 func TestClassify_KnownGitSubcommands(t *testing.T) {
 	t.Parallel()
@@ -32,23 +32,15 @@ func TestClassify_KnownGitSubcommands(t *testing.T) {
 		{"push", "git push", "sync", "git-courer/sync"},
 		{"pull", "git pull", "sync", "git-courer/sync"},
 		{"fetch", "git fetch", "sync", "git-courer/sync"},
-		{"show", "git show", "history", "git-courer/history"},
 		{"blame", "git blame", "history", "git-courer/history"},
-		{"remote", "git remote", "sync", "git-courer/sync"},
-		{"config", "git config", "config", "git-courer/config"},
 		{"add", "git add", "stage", "git-courer/stage"},
 		{"restore", "git restore", "stage", "git-courer/stage"},
 		{"clean", "git clean", "stage", "git-courer/stage"},
 		{"rm", "git rm", "stage", "git-courer/stage"},
-		{"mv", "git mv", "stage", "git-courer/stage"},
 		{"switch", "git switch", "branch", "git-courer/branch"},
 		{"checkout", "git checkout", "branch", "git-courer/branch"},
 		{"worktree", "git worktree", "branch", "git-courer/branch"},
-		{"shortlog", "git shortlog", "history", "git-courer/history"},
-		{"describe", "git describe", "history", "git-courer/history"},
 		{"reflog", "git reflog", "history", "git-courer/history"},
-		{"notes", "git notes", "history", "git-courer/history"},
-		{"archive", "git archive", "history", "git-courer/history"},
 	}
 
 	for _, tt := range tests {
@@ -57,8 +49,8 @@ func TestClassify_KnownGitSubcommands(t *testing.T) {
 			if r.Command != tt.command {
 				t.Errorf("Command: got %q, want %q", r.Command, tt.command)
 			}
-			if r.Decision != "ask" {
-				t.Errorf("Decision: got %q, want %q", r.Decision, "ask")
+			if r.Decision != "deny" {
+				t.Errorf("Decision: got %q, want %q", r.Decision, "deny")
 			}
 			if r.MCPTool != tt.wantTool {
 				t.Errorf("MCPTool: got %q, want %q", r.MCPTool, tt.wantTool)
@@ -81,13 +73,28 @@ func TestClassify_MaintenanceCommands(t *testing.T) {
 	commands := []string{
 		"git gc",
 		"git fsck",
-		"git prune",
-		"git repack",
-		"git maintenance",
-		"git help",
-		"git version",
 		"git init",
 		"git clone",
+		// The 8 subcommands git-courer does not yet cover — allowed directly.
+		"git show",
+		"git remote",
+		"git config",
+		"git mv",
+		"git shortlog",
+		"git describe",
+		"git notes",
+		"git archive",
+		// Additional allowed subcommands with no MCP equivalent.
+		"git submodule",
+		"git bisect",
+		"git verify-commit",
+		"git verify-tag",
+		"git grep",
+		"git cherry",
+		"git ls-files",
+		"git ls-tree",
+		"git ls-remote",
+		"git tag",
 	}
 
 	for _, cmd := range commands {
@@ -183,8 +190,8 @@ func TestClassify_GitWithSubcommandArgs(t *testing.T) {
 	t.Parallel()
 
 	r := Classify("git status --short --branch")
-	if r.Decision != "ask" {
-		t.Errorf("Decision: got %q, want ask", r.Decision)
+	if r.Decision != "deny" {
+		t.Errorf("Decision: got %q, want deny", r.Decision)
 	}
 	if r.MCPTool != "status" {
 		t.Errorf("MCPTool: got %q, want status", r.MCPTool)

--- a/internal/delivery/cli/hook_check.go
+++ b/internal/delivery/cli/hook_check.go
@@ -39,8 +39,8 @@ var isStdinPipe = func() bool {
 // the agent is blocked from running raw git and is pointed at the git-courer
 // MCP tool. Non-git commands exit cleanly with no output.
 type HookCheckCommand struct {
-	Stdin  io.Reader  // for testing; nil = os.Stdin
-	Stdout io.Writer  // for testing; nil = os.Stdout
+	Stdin  io.Reader // for testing; nil = os.Stdin
+	Stdout io.Writer // for testing; nil = os.Stdout
 }
 
 // agentType identifies the calling agent from its stdin JSON shape.
@@ -64,7 +64,7 @@ type hookInput struct {
 		} `json:"input"`
 	} `json:"event"`
 
-	ToolName string `json:"tool_name"`
+	ToolName  string `json:"tool_name"`
 	ToolInput *struct {
 		Command string `json:"command"`
 	} `json:"tool_input"`
@@ -81,8 +81,8 @@ type hookInput struct {
 // a flat {"allow_tool": false, "deny_reason": "..."} object (not nested
 // under hookSpecificOutput like Codex/Claude).
 type antigravityHookOutput struct {
-	AllowTool   bool   `json:"allow_tool"`
-	DenyReason  string `json:"deny_reason"`
+	AllowTool  bool   `json:"allow_tool"`
+	DenyReason string `json:"deny_reason"`
 }
 
 // codexHookOutput represents the JSON structure Codex expects as output
@@ -176,12 +176,15 @@ func (c HookCheckCommand) runStdinMode(stdin io.Reader, stdout io.Writer) error 
 
 	result := gitcmd.Classify(command)
 
-	// Only emit output for git commands (Decision == "ask").
-	if result.Decision != "ask" {
+	// Emit output for any non-allow decision. "deny" (covered git subcommand)
+	// and "ask" (unknown git subcommand — safe default) both emit a deny so the
+	// agent is blocked from running raw git. Only pure "allow" (non-git or
+	// maintenance) exits cleanly with no output.
+	if result.Decision == "allow" {
 		return nil
 	}
 
-	reason := fmt.Sprintf("Use git-courer/%s instead of bash %s", result.MCPTool, command)
+	reason := result.Reason
 
 	switch agent {
 	case agentCodex, agentClaude:
@@ -298,4 +301,3 @@ func (c PreInvocationHookCommand) Run(args []string) error {
 
 	return json.NewEncoder(stdout).Encode(output)
 }
-

--- a/internal/delivery/cli/hook_check_test.go
+++ b/internal/delivery/cli/hook_check_test.go
@@ -31,8 +31,8 @@ func TestHookCheckRun_GitCommand(t *testing.T) {
 	if result["Command"] != "git status" {
 		t.Errorf("Command: got %q, want %q", result["Command"], "git status")
 	}
-	if result["Decision"] != "ask" {
-		t.Errorf("Decision: got %q, want %q", result["Decision"], "ask")
+	if result["Decision"] != "deny" {
+		t.Errorf("Decision: got %q, want %q", result["Decision"], "deny")
 	}
 	if result["MCPTool"] != "status" {
 		t.Errorf("MCPTool: got %q, want %q", result["MCPTool"], "status")
@@ -482,7 +482,7 @@ func TestHookCheckRun_GitCommand_OldStdout(t *testing.T) {
 	if result["Command"] != "git status" {
 		t.Errorf("Command: got %q, want %q", result["Command"], "git status")
 	}
-	if result["Decision"] != "ask" {
-		t.Errorf("Decision: got %q, want %q", result["Decision"], "ask")
+	if result["Decision"] != "deny" {
+		t.Errorf("Decision: got %q, want %q", result["Decision"], "deny")
 	}
 }

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -157,6 +157,14 @@ func RunUninstall() error {
 				fmt.Fprintf(os.Stderr, "  ⚠ Failed to strip OpenCode policy: %v\n", err)
 			}
 		}
+		// Strip git-courer @pi-lab/permissions rules from the Pi agent
+		// settings.json. Called AFTER restoreBackup for the same reason as
+		// opencode above. Only applies to the pi client.
+		if client.Name == "pi" {
+			if err := removePiPermissions(piPermissionsPath()); err != nil {
+				fmt.Fprintf(os.Stderr, "  ⚠ Failed to strip Pi permissions: %v\n", err)
+			}
+		}
 	}
 
 	// Remove binary

--- a/internal/installer/mcp_config.go
+++ b/internal/installer/mcp_config.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -42,10 +43,10 @@ const gitCourerMdContent = "# git-courer — Golden Rules\n" +
 // MCPClient represents an MCP client configuration.
 type MCPClient struct {
 	Name              string
-	Filename          string // config filename
-	RootKey           string // mcpServers, mcp, servers, context_servers
-	IsArray           bool   // continue uses array format
-	ConfigFormat      string // "json" (default) or "toml"
+	Filename          string       // config filename
+	RootKey           string       // mcpServers, mcp, servers, context_servers
+	IsArray           bool         // continue uses array format
+	ConfigFormat      string       // "json" (default) or "toml"
 	HooksConfig       *HooksConfig // nil = no hooks for this client
 	ConfigFn          func(binPath string) map[string]interface{}
 	PostInstallNotice func(binPath string) string // optional post-install warning check
@@ -271,33 +272,41 @@ func ConfigureMCP(client *MCPClient, binPath string) error {
 					fmt.Fprintf(os.Stderr, "Warning: failed to apply OpenCode policy: %v\n", policyErr)
 				}
 			}
-		// Also ensure hooks are installed (idempotent).
-		if client.HooksConfig != nil {
-			if client.HooksConfig.PermissionsPath != "" {
-				// Antigravity-style client.
-				if client.HooksConfig.HooksPath != "" {
-					if hookErr := installAntigravityHooks(client.HooksConfig.HooksPath, binPath); hookErr != nil {
-						fmt.Fprintf(os.Stderr, "Warning: failed to install Antigravity hooks: %v\n", hookErr)
+			// Also ensure hooks are installed (idempotent).
+			if client.HooksConfig != nil {
+				if client.HooksConfig.PermissionsPath != "" {
+					// Antigravity-style client.
+					if client.HooksConfig.HooksPath != "" {
+						if hookErr := installAntigravityHooks(client.HooksConfig.HooksPath, binPath); hookErr != nil {
+							fmt.Fprintf(os.Stderr, "Warning: failed to install Antigravity hooks: %v\n", hookErr)
+						}
 					}
-				}
-				if permErr := installAntigravityPermissions(client.HooksConfig.PermissionsPath, binPath); permErr != nil {
-					fmt.Fprintf(os.Stderr, "Warning: failed to install Antigravity permissions: %v\n", permErr)
-				}
-			} else {
-				if client.HooksConfig.HooksPath != "" {
-					if hookErr := installHook(client.HooksConfig.HooksPath, binPath); hookErr != nil {
-						fmt.Fprintf(os.Stderr, "Warning: failed to install hooks: %v\n", hookErr)
+					if permErr := installAntigravityPermissions(client.HooksConfig.PermissionsPath, binPath); permErr != nil {
+						fmt.Fprintf(os.Stderr, "Warning: failed to install Antigravity permissions: %v\n", permErr)
 					}
-				}
-				if client.HooksConfig.SettingsPath != "" {
-					if hookErr := installClaudeHooks(client.HooksConfig.SettingsPath, binPath); hookErr != nil {
-						fmt.Fprintf(os.Stderr, "Warning: failed to install Claude hooks: %v\n", hookErr)
+				} else {
+					if client.HooksConfig.HooksPath != "" {
+						if hookErr := installHook(client.HooksConfig.HooksPath, binPath); hookErr != nil {
+							fmt.Fprintf(os.Stderr, "Warning: failed to install hooks: %v\n", hookErr)
+						}
+					}
+					if client.HooksConfig.SettingsPath != "" {
+						if hookErr := installClaudeHooks(client.HooksConfig.SettingsPath, binPath); hookErr != nil {
+							fmt.Fprintf(os.Stderr, "Warning: failed to install Claude hooks: %v\n", hookErr)
+						}
 					}
 				}
 			}
+			// Pi-style client: install @pi-lab/permissions deny rules into
+			// ~/.pi/agent/settings.json. Pi has no lifecycle hooks config, so it
+			// is handled here like opencode (policy-only).
+			if client.Name == "pi" {
+				if permErr := installPiPermissions(piPermissionsPath(), binPath); permErr != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to install Pi permissions: %v\n", permErr)
+				}
+			}
+			return nil // Already configured
 		}
-		return nil // Already configured
-	}
 	}
 
 	// Backup existing config before mutation (only if it exists).
@@ -363,6 +372,15 @@ func ConfigureMCP(client *MCPClient, binPath string) error {
 					fmt.Fprintf(os.Stderr, "Warning: failed to install Claude hooks: %v\n", hookErr)
 				}
 			}
+		}
+	}
+
+	// Pi-style client: install @pi-lab/permissions deny rules into
+	// ~/.pi/agent/settings.json. Pi has no lifecycle hooks config, so it is
+	// handled here like opencode (policy-only).
+	if client.Name == "pi" {
+		if permErr := installPiPermissions(piPermissionsPath(), binPath); permErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to install Pi permissions: %v\n", permErr)
 		}
 	}
 
@@ -625,12 +643,18 @@ func SetupClient(clientName, binPath string) error {
 }
 
 // configureOpenCodePolicy merges the git-courer policy into opencode.json:
-//   - permission.bash["git *"] = "deny" (preserving any existing keys; Go's
-//     alphabetical map sort on json.MarshalIndent naturally places "git *"
-//     after "*" for last-match-wins).
+//   - permission.bash gains 23 granular "git {sub}": "deny" entries (one per
+//     covered subcommand) plus a "git *": "ask" fallback. The 23 deny entries
+//     are serialized BEFORE "git *": "ask" so OpenCode's last-match-wins
+//     resolution prefers the specific deny over the wildcard ask.
 //   - instructions array includes the path to GIT_COURER.md in the same
 //     directory as configPath (deduplicated; if instructions is a string it
 //     is converted to an array preserving the original entry).
+//
+// Ordering caveat: permission.bash is serialized as an ORDERED object
+// (deny entries first, "git *" last) via a custom raw-JSON builder. A plain
+// map[string]interface{} would sort keys alphabetically and place "git *"
+// before "git add" (because '*' < 'a'), which breaks last-match-wins.
 //
 // Behavior:
 //   - If opencode.json does not exist, a fresh config with the policy is
@@ -673,18 +697,26 @@ func configureOpenCodePolicy(configPath string) error {
 		}
 	}
 
-	// permission.bash["git *"] = "deny"
+	// permission.bash: 23 granular "git {sub}": "deny" + "git *": "ask".
+	// Existing non-git-courer bash keys are preserved and emitted AFTER the
+	// git-courer deny entries but BEFORE the "git *" ask fallback, so a
+	// user's own wildcard rules (e.g. "*": "allow") do not shadow the deny
+	// entries. "git *" is always last for last-match-wins.
 	perm, _ := config["permission"].(map[string]interface{})
 	if perm == nil {
 		perm = make(map[string]interface{})
 		config["permission"] = perm
 	}
-	bash, _ := perm["bash"].(map[string]interface{})
-	if bash == nil {
-		bash = make(map[string]interface{})
-		perm["bash"] = bash
-	}
-	bash["git *"] = "deny"
+	existingBash, _ := perm["bash"].(map[string]interface{})
+
+	// Build the ordered list of bash key/value pairs.
+	// 1. The 23 git-courer deny entries (deterministic order).
+	// 2. Existing user bash keys that are NOT git-courer-owned (preserved).
+	// 3. "git *": "ask" fallback (always last).
+	orderedBash := buildOpenCodeBashOrdered(existingBash)
+	// Replace the map with an ordered raw-JSON RawMessage so json.MarshalIndent
+	// of the parent config preserves this order.
+	perm["bash"] = json.RawMessage(orderedBash)
 
 	// instructions array includes AGENTS.md path, and old GIT_COURER.md path is removed.
 	agentsPath := filepath.Join(filepath.Dir(configPath), "AGENTS.md")
@@ -725,6 +757,10 @@ func configureOpenCodePolicy(configPath string) error {
 		config["instructions"] = []interface{}{agentsPath}
 	}
 
+	// Marshal the config, but force the bash RawMessage to be written inline
+	// (json.MarshalIndent already inlines RawMessage). We must ensure the
+	// RawMessage is pretty-printed consistently with the rest. Build the bash
+	// object text already indented for two levels (permission → bash).
 	data, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal opencode.json: %w", err)
@@ -732,8 +768,100 @@ func configureOpenCodePolicy(configPath string) error {
 	return os.WriteFile(configPath, data, 0644)
 }
 
+// openCodeDenySubcommands is the ordered list of the 23 git subcommands that
+// git-courer covers with an MCP tool. Each becomes a "git {sub}": "deny"
+// entry in permission.bash. The order matches the mcpTools coverage so the
+// deny block reads predictably.
+var openCodeDenySubcommands = []string{
+	"status", "diff", "commit", "log", "branch", "merge", "rebase",
+	"cherry-pick", "revert", "reset", "stash", "push", "pull", "fetch",
+	"blame", "add", "restore", "clean", "rm", "switch", "checkout",
+	"worktree", "reflog",
+}
+
+// openCodeBashOwnedKeys is the set of permission.bash keys owned by
+// git-courer (the 23 deny entries plus the "git *" ask fallback). Used to
+// identify and drop stale git-courer entries when rebuilding the ordered
+// bash object and when stripping policy on uninstall.
+var openCodeBashOwnedKeys = func() map[string]bool {
+	m := make(map[string]bool, len(openCodeDenySubcommands)+1)
+	for _, sub := range openCodeDenySubcommands {
+		m["git "+sub] = true
+	}
+	m["git *"] = true
+	return m
+}()
+
+// buildOpenCodeBashOrdered renders the permission.bash object as raw JSON
+// bytes with a deterministic key order: the 23 git-courer deny entries first
+// (in openCodeDenySubcommands order), then any existing user-owned bash keys
+// (preserved in their original map iteration order), then "git *": "ask"
+// last. This guarantees last-match-wins resolution in OpenCode regardless of
+// Go's alphabetical map sorting on marshal.
+//
+// existing is the previous permission.bash map (may be nil). User-owned keys
+// (anything not in openCodeBashOwnedKeys) are preserved; git-courer-owned keys
+// are regenerated from scratch so re-runs are idempotent.
+func buildOpenCodeBashOrdered(existing map[string]interface{}) []byte {
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	first := true
+
+	writeKV := func(key, val string) {
+		if !first {
+			buf.WriteByte(',')
+		}
+		first = false
+		// Inline a 2-space-indented key:value pair; json.Marshal of the key
+		// handles quoting/escaping, and the value is a simple string.
+		k, _ := json.Marshal(key)
+		v, _ := json.Marshal(val)
+		buf.Write(k)
+		buf.WriteByte(':')
+		buf.Write(v)
+	}
+
+	// 1. The 23 git-courer deny entries.
+	for _, sub := range openCodeDenySubcommands {
+		writeKV("git "+sub, "deny")
+	}
+
+	// 2. Existing user-owned bash keys (preserved, emitted in sorted key
+	//    order for deterministic idempotent output — Go map iteration is
+	//    randomized, so sorting is required).
+	userKeys := make([]string, 0, len(existing))
+	for k := range existing {
+		if openCodeBashOwnedKeys[k] {
+			continue // git-courer-owned — regenerated above
+		}
+		userKeys = append(userKeys, k)
+	}
+	sort.Strings(userKeys)
+	for _, k := range userKeys {
+		vBytes, err := json.Marshal(existing[k])
+		if err != nil {
+			continue // skip unmarshalable values
+		}
+		if !first {
+			buf.WriteByte(',')
+		}
+		first = false
+		kBytes, _ := json.Marshal(k)
+		buf.Write(kBytes)
+		buf.WriteByte(':')
+		buf.Write(vBytes)
+	}
+
+	// 3. "git *": "ask" fallback — always last for last-match-wins.
+	writeKV("git *", "ask")
+
+	buf.WriteByte('}')
+	return buf.Bytes()
+}
+
 // removeOpenCodePolicy strips the git-courer policy entries from opencode.json:
-//   - permission.bash["git *"] is removed (other keys preserved).
+//   - permission.bash: the 23 granular "git {sub}": "deny" entries AND the
+//     "git *": "ask" fallback are removed (other user-owned keys preserved).
 //   - GIT_COURER.md path is removed from the instructions array (other
 //     entries preserved).
 //
@@ -759,14 +887,34 @@ func removeOpenCodePolicy(configPath string) error {
 	// Detect whether any git-courer policy entry exists. If not, no-op.
 	hasPolicy := false
 
-	// Check permission.bash["git *"].
+	// Check permission.bash for any git-courer-owned key (the 23 deny entries
+	// or "git *"). Note: bash may be a json.RawMessage after configure, so
+	// handle both the map and RawMessage shapes.
 	if perm, ok := config["permission"].(map[string]interface{}); ok {
-		if bash, ok := perm["bash"].(map[string]interface{}); ok {
-			if _, exists := bash["git *"]; exists {
-				hasPolicy = true
-				delete(bash, "git *")
-				// Keep the bash map even if empty? The spec says preserve other
-				// entries. If empty, we still keep it (no harm; preserves shape).
+		switch bashRaw := perm["bash"].(type) {
+		case map[string]interface{}:
+			for key := range bashRaw {
+				if openCodeBashOwnedKeys[key] {
+					hasPolicy = true
+					delete(bashRaw, key)
+				}
+			}
+		case json.RawMessage:
+			// Decode the RawMessage into a map, strip owned keys, and reassign
+			// as a plain map so the cleaned output is a normal object.
+			var bashMap map[string]interface{}
+			if err := json.Unmarshal(bashRaw, &bashMap); err == nil {
+				for key := range bashMap {
+					if openCodeBashOwnedKeys[key] {
+						hasPolicy = true
+						delete(bashMap, key)
+					}
+				}
+				if len(bashMap) == 0 {
+					delete(perm, "bash")
+				} else {
+					perm["bash"] = bashMap
+				}
 			}
 		}
 	}

--- a/internal/installer/opencode_policy_test.go
+++ b/internal/installer/opencode_policy_test.go
@@ -16,8 +16,8 @@ import (
 // through the generic map but not asserted here.
 type openCodeShell struct {
 	Permission struct {
-		Bash        map[string]string `json:"bash"`
-		OtherKeys   map[string]interface{} `json:"-"`
+		Bash      map[string]string      `json:"bash"`
+		OtherKeys map[string]interface{} `json:"-"`
 	} `json:"permission"`
 	Instructions []string `json:"instructions"`
 }
@@ -209,8 +209,9 @@ func gitCourerMdPath(configPath string) string {
 // --- configureOpenCodePolicy tests (T1) ---
 
 // TestConfigureOpenCodePolicy_AddsGitStarRule verifies
-// configureOpenCodePolicy adds "git *": "deny" to permission.bash on a fresh
-// opencode.json with no permission key.
+// configureOpenCodePolicy adds the 23 granular "git {sub}": "deny" entries
+// plus the "git *": "ask" fallback to permission.bash on a fresh opencode.json
+// with no permission key.
 func TestConfigureOpenCodePolicy_AddsGitStarRule(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "opencode.json")
@@ -224,12 +225,70 @@ func TestConfigureOpenCodePolicy_AddsGitStarRule(t *testing.T) {
 	}
 
 	cfg := readOpenCodeConfig(t, configPath)
-	assertBashRule(t, cfg, "git *", "deny")
+	// The 23 granular deny entries must all be present.
+	for _, sub := range openCodeDenySubcommands {
+		assertBashRule(t, cfg, "git "+sub, "deny")
+	}
+	// The "git *" fallback must be "ask" (not "deny" anymore).
+	assertBashRule(t, cfg, "git *", "ask")
+}
+
+// TestConfigureOpenCodePolicy_GranularDenyEntries verifies that exactly the
+// 23 covered subcommands get a "git {sub}": "deny" entry and that no other
+// bash key is a deny entry.
+func TestConfigureOpenCodePolicy_GranularDenyEntries(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "opencode.json")
+	if err := os.WriteFile(configPath, []byte(`{}`), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := configureOpenCodePolicy(configPath); err != nil {
+		t.Fatalf("configureOpenCodePolicy: %v", err)
+	}
+
+	cfg := readOpenCodeConfig(t, configPath)
+	perm, ok := cfg["permission"].(map[string]interface{})
+	if !ok {
+		t.Fatal("permission key missing or not an object")
+	}
+	bash, ok := perm["bash"].(map[string]interface{})
+	if !ok {
+		t.Fatal("permission.bash missing or not an object")
+	}
+
+	// Every covered subcommand must be "deny".
+	for _, sub := range openCodeDenySubcommands {
+		key := "git " + sub
+		got, ok := bash[key].(string)
+		if !ok {
+			t.Errorf("permission.bash[%q] missing", key)
+			continue
+		}
+		if got != "deny" {
+			t.Errorf("permission.bash[%q]: got %q, want deny", key, got)
+		}
+	}
+	// "git *" must be the "ask" fallback.
+	if got, ok := bash["git *"].(string); !ok || got != "ask" {
+		t.Errorf("permission.bash[\"git *\"]: got %q, want ask", got)
+	}
+	// Count deny entries: must be exactly 23 (one per covered subcommand).
+	denyCount := 0
+	for _, v := range bash {
+		if s, ok := v.(string); ok && s == "deny" {
+			denyCount++
+		}
+	}
+	if denyCount != len(openCodeDenySubcommands) {
+		t.Errorf("expected %d deny entries, got %d", len(openCodeDenySubcommands), denyCount)
+	}
 }
 
 // TestConfigureOpenCodePolicy_PreservesExistingBashKeys verifies that an
-// existing "*" rule is preserved alongside the new "git *" rule, and that
-// "git *" appears AFTER "*" in the serialized JSON (last-match-wins).
+// existing "*" rule is preserved alongside the new git-courer deny entries,
+// and that every "git {sub}": "deny" entry appears BEFORE "git *": "ask" in
+// the serialized JSON (last-match-wins ordering).
 func TestConfigureOpenCodePolicy_PreservesExistingBashKeys(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "opencode.json")
@@ -246,24 +305,41 @@ func TestConfigureOpenCodePolicy_PreservesExistingBashKeys(t *testing.T) {
 
 	cfg := readOpenCodeConfig(t, configPath)
 	assertBashRule(t, cfg, "*", "allow")
-	assertBashRule(t, cfg, "git *", "deny")
+	for _, sub := range openCodeDenySubcommands {
+		assertBashRule(t, cfg, "git "+sub, "deny")
+	}
+	assertBashRule(t, cfg, "git *", "ask")
 
-	// Last-match-wins: "git *" must serialize after "*".
+	// Last-match-wins: every "git {sub}": "deny" must appear BEFORE "git *"
+	// in the serialized JSON. The user's "*" rule is emitted after the deny
+	// block but before "git *".
 	order := bashRuleOrder(t, configPath)
-	starIdx, gitIdx := -1, -1
+	gitStarIdx := -1
 	for i, k := range order {
-		if k == "*" {
-			starIdx = i
-		}
 		if k == "git *" {
-			gitIdx = i
+			gitStarIdx = i
+			break
 		}
 	}
-	if starIdx == -1 || gitIdx == -1 {
-		t.Fatalf("expected both * and git * in order %v", order)
+	if gitStarIdx == -1 {
+		t.Fatalf("expected git * in order %v", order)
 	}
-	if gitIdx < starIdx {
-		t.Errorf("git * (idx %d) must appear AFTER * (idx %d) for last-match-wins; order=%v", gitIdx, starIdx, order)
+	for _, sub := range openCodeDenySubcommands {
+		key := "git " + sub
+		idx := -1
+		for i, k := range order {
+			if k == key {
+				idx = i
+				break
+			}
+		}
+		if idx == -1 {
+			t.Errorf("expected %q in order %v", key, order)
+			continue
+		}
+		if idx > gitStarIdx {
+			t.Errorf("%q (idx %d) must appear BEFORE git * (idx %d); order=%v", key, idx, gitStarIdx, order)
+		}
 	}
 }
 
@@ -401,21 +477,37 @@ func TestConfigureOpenCodePolicy_CorruptJSONBackupsAndWritesFresh(t *testing.T) 
 
 	// Fresh config must be valid JSON with the policy.
 	cfg := readOpenCodeConfig(t, configPath)
-	assertBashRule(t, cfg, "git *", "deny")
+	for _, sub := range openCodeDenySubcommands {
+		assertBashRule(t, cfg, "git "+sub, "deny")
+	}
+	assertBashRule(t, cfg, "git *", "ask")
 	assertInstructionsContains(t, cfg, gitCourerMdPath(configPath))
 }
 
 // --- removeOpenCodePolicy tests (T1) ---
 
-// TestRemoveOpenCodePolicy_StripsGitStarRule verifies the "git *" rule is
-// removed while preserving other permission.bash keys.
+// TestRemoveOpenCodePolicy_StripsGitStarRule verifies the 23 granular deny
+// entries AND the "git *" fallback are removed while preserving other
+// permission.bash keys.
 func TestRemoveOpenCodePolicy_StripsGitStarRule(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "opencode.json")
-	existing := `{
-		"permission": {"bash": {"*": "allow", "git *": "ask"}}
-	}`
-	if err := os.WriteFile(configPath, []byte(existing), 0644); err != nil {
+	// Start from a config that already has the git-courer policy applied
+	// (23 deny entries + "git *": "ask") plus a user-owned "*" rule.
+	perm := map[string]interface{}{
+		"bash": map[string]interface{}{
+			"*":     "allow",
+			"git *": "ask",
+		},
+	}
+	// Add the 23 deny entries to bash for a realistic starting state.
+	bash := perm["bash"].(map[string]interface{})
+	for _, sub := range openCodeDenySubcommands {
+		bash["git "+sub] = "deny"
+	}
+	cfg := map[string]interface{}{"permission": perm}
+	raw, _ := json.Marshal(cfg)
+	if err := os.WriteFile(configPath, raw, 0644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 
@@ -423,9 +515,13 @@ func TestRemoveOpenCodePolicy_StripsGitStarRule(t *testing.T) {
 		t.Fatalf("removeOpenCodePolicy: %v", err)
 	}
 
-	cfg := readOpenCodeConfig(t, configPath)
-	assertBashRule(t, cfg, "*", "allow")
-	assertBashRuleAbsent(t, cfg, "git *")
+	cfg2 := readOpenCodeConfig(t, configPath)
+	assertBashRule(t, cfg2, "*", "allow")
+	// Every git-courer-owned key must be gone.
+	for _, sub := range openCodeDenySubcommands {
+		assertBashRuleAbsent(t, cfg2, "git "+sub)
+	}
+	assertBashRuleAbsent(t, cfg2, "git *")
 }
 
 // TestRemoveOpenCodePolicy_RemovesGitCourerMdFromInstructions verifies the

--- a/internal/installer/pi_config.go
+++ b/internal/installer/pi_config.go
@@ -1,0 +1,339 @@
+package installer
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// piPermissionsPath returns the path to the Pi agent settings.json that hosts
+// the @pi-lab/permissions rules. Pi stores agent settings under
+// ~/.pi/agent/settings.json (the same file PostInstallNotice already reads
+// for the pi-mcp-adapter package list).
+func piPermissionsPath() string {
+	return filepath.Join(homeDirFn(), ".pi/agent/settings.json")
+}
+
+// piPermissionRule is one entry of @pi-lab/permissions "permissions.rules"
+// array. Match identifies the tool and command to gate; Action is "deny" or
+// "ask"; Reason is the human-readable explanation shown to the agent.
+type piPermissionRule struct {
+	Match  piPermissionMatch `json:"match"`
+	Action string            `json:"action"`
+	Reason string            `json:"reason"`
+}
+
+// piPermissionMatch identifies the tool and command a rule applies to.
+type piPermissionMatch struct {
+	Tool   string             `json:"tool"`
+	Params piPermissionParams `json:"params"`
+}
+
+// piPermissionParams carries the command string a Bash rule matches on.
+type piPermissionParams struct {
+	Command string `json:"command"`
+}
+
+// piDenySubcommands is the ordered list of the 23 git subcommands git-courer
+// covers with an MCP tool. Each becomes a deny rule for "git {sub}". The list
+// mirrors openCodeDenySubcommands so every client enforces the same coverage.
+var piDenySubcommands = []string{
+	"status", "diff", "commit", "log", "branch", "merge", "rebase",
+	"cherry-pick", "revert", "reset", "stash", "push", "pull", "fetch",
+	"blame", "add", "restore", "clean", "rm", "switch", "checkout",
+	"worktree", "reflog",
+}
+
+// piMCPToolForSubcommand maps a git subcommand to the git-courer MCP tool name
+// used in the deny reason. It mirrors the classifier mcpTools map so the
+// reason text is consistent across clients.
+var piMCPToolForSubcommand = map[string]string{
+	"status":      "status",
+	"diff":        "diff",
+	"commit":      "commit",
+	"log":         "history",
+	"branch":      "branch",
+	"merge":       "integrate",
+	"rebase":      "integrate",
+	"cherry-pick": "integrate",
+	"revert":      "rewrite",
+	"reset":       "rewrite",
+	"stash":       "stash",
+	"push":        "sync",
+	"pull":        "sync",
+	"fetch":       "sync",
+	"blame":       "history",
+	"add":         "stage",
+	"restore":     "stage",
+	"clean":       "stage",
+	"rm":          "stage",
+	"switch":      "branch",
+	"checkout":    "branch",
+	"worktree":    "branch",
+	"reflog":      "history",
+}
+
+// piGitCourerRuleReasons is the set of reason strings git-courer writes into
+// @pi-lab/permissions rules. Used to identify and strip git-courer-owned
+// rules on uninstall without clobbering user-defined rules.
+var piGitCourerRuleReasons = func() map[string]bool {
+	m := make(map[string]bool, len(piDenySubcommands)+1)
+	for _, sub := range piDenySubcommands {
+		m["Use git-courer/"+piMCPToolForSubcommand[sub]+" instead"] = true
+	}
+	m["Use git-courer tools instead of raw git"] = true
+	return m
+}()
+
+// installPiPermissions writes @pi-lab/permissions rules into the Pi agent
+// settings.json at settingsPath. It adds one deny rule per covered git
+// subcommand (23 rules) plus a single "ask" fallback for any other "git"
+// command. Existing non-git-courer rules and every other top-level settings
+// key are preserved.
+//
+// Behavior:
+//   - If settings.json does not exist, a fresh file with the git-courer
+//     rules is created (no backup).
+//   - If settings.json exists, it is backed up to settingsPath + ".gc.bak"
+//     before the first mutation. The backup is NOT overwritten on re-run.
+//   - If settings.json exists but is unparseable JSON, it is backed up and a
+//     fresh file with the git-courer rules is written.
+//   - Idempotent: running twice produces byte-identical settings.json.
+func installPiPermissions(settingsPath, binPath string) error {
+	_ = binPath // reserved for future rule customization; not used today
+
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0755); err != nil {
+		return fmt.Errorf("failed to create pi settings dir: %w", err)
+	}
+
+	// Read existing settings.json into a generic map to preserve every
+	// top-level key we do not own (packages, model, etc.).
+	settings := make(map[string]interface{})
+	fileExisted := false
+	parsedOK := false
+	if data, err := os.ReadFile(settingsPath); err == nil {
+		fileExisted = true
+		if jsonErr := json.Unmarshal(data, &settings); jsonErr != nil {
+			// Unparseable — back up the original bytes and start fresh so we
+			// can still apply the rules without clobbering user config.
+			if backupErr := backupPiSettings(settingsPath, data); backupErr != nil {
+				return fmt.Errorf("failed to backup unparseable pi settings: %w", backupErr)
+			}
+			settings = make(map[string]interface{})
+		} else {
+			parsedOK = true
+		}
+	}
+
+	// Backup existing valid settings before mutation (only if it parsed and
+	// no backup already exists from a prior install — preserves idempotency).
+	if fileExisted && parsedOK {
+		bakPath := settingsPath + ".gc.bak"
+		if _, err := os.Stat(bakPath); os.IsNotExist(err) {
+			if backupErr := backupPiSettings(settingsPath, nil); backupErr != nil {
+				return fmt.Errorf("failed to backup pi settings: %w", backupErr)
+			}
+		}
+	}
+
+	// permissions.rules — merge git-courer rules.
+	perm, _ := settings["permissions"].(map[string]interface{})
+	if perm == nil {
+		perm = make(map[string]interface{})
+		settings["permissions"] = perm
+	}
+	rules, _ := perm["rules"].([]interface{})
+
+	// Build the git-courer ruleset: 23 deny rules + 1 ask fallback.
+	gcRules := piBuildGitCourerRules()
+
+	// Merge: drop any existing git-courer-owned rules first (so re-runs are
+	// idempotent), then append the fresh git-courer rules, preserving
+	// user-defined rules in their original order.
+	merged := piMergeRules(rules, gcRules)
+	if len(merged) == 0 {
+		delete(perm, "rules")
+	} else {
+		perm["rules"] = merged
+	}
+	// Drop the permissions object entirely if it is now empty.
+	if len(perm) == 0 {
+		delete(settings, "permissions")
+	}
+
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal pi settings.json: %w", err)
+	}
+	return writeAtomic(settingsPath, data, 0644)
+}
+
+// removePiPermissions strips the git-courer permission rules from the Pi
+// agent settings.json at settingsPath. Behavior:
+//   - If settingsPath + ".gc.bak" exists, it is restored over settingsPath and
+//     the .bak file is removed.
+//   - Otherwise the git-courer rules are removed in place from
+//     permissions.rules, preserving user-defined rules and every other
+//     top-level settings key.
+//   - Idempotent: running twice does not error.
+func removePiPermissions(settingsPath string) error {
+	bakPath := settingsPath + ".gc.bak"
+	if _, err := os.Stat(bakPath); err == nil {
+		bakData, err := os.ReadFile(bakPath)
+		if err != nil {
+			return fmt.Errorf("failed to read pi settings backup: %w", err)
+		}
+		if err := writeAtomic(settingsPath, bakData, 0644); err != nil {
+			return fmt.Errorf("failed to restore pi settings backup: %w", err)
+		}
+		_ = os.Remove(bakPath)
+		return nil
+	}
+
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		// No file — nothing to remove.
+		return nil
+	}
+
+	settings := make(map[string]interface{})
+	if err := json.Unmarshal(data, &settings); err != nil {
+		// Unparseable — leave it alone rather than risk clobbering user config.
+		return nil
+	}
+
+	perm, ok := settings["permissions"].(map[string]interface{})
+	if !ok {
+		return nil // no permissions section — nothing to strip
+	}
+
+	rules, ok := perm["rules"].([]interface{})
+	if !ok {
+		return nil // no rules — nothing to strip
+	}
+
+	changed := false
+	var kept []interface{}
+	for _, v := range rules {
+		rm, ok := v.(map[string]interface{})
+		if !ok {
+			kept = append(kept, v)
+			continue
+		}
+		if reason, ok := rm["reason"].(string); ok && piGitCourerRuleReasons[reason] {
+			changed = true
+			continue // drop git-courer rule
+		}
+		kept = append(kept, v)
+	}
+
+	if !changed {
+		return nil // no git-courer rules — leave the file untouched
+	}
+
+	if len(kept) == 0 {
+		delete(perm, "rules")
+	} else {
+		perm["rules"] = kept
+	}
+	if len(perm) == 0 {
+		delete(settings, "permissions")
+	}
+
+	// If the settings map is now empty, delete the file entirely.
+	if len(settings) == 0 {
+		_ = os.Remove(settingsPath)
+		return nil
+	}
+
+	out, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal cleaned pi settings.json: %w", err)
+	}
+	if string(out) == "{}" {
+		_ = os.Remove(settingsPath)
+		return nil
+	}
+	return writeAtomic(settingsPath, out, 0644)
+}
+
+// backupPiSettings copies settingsPath to settingsPath + ".gc.bak" so
+// removePiPermissions can restore it. If extra is non-nil it is written
+// instead of reading the file (used for the unparseable case).
+func backupPiSettings(settingsPath string, extra []byte) error {
+	var data []byte
+	var err error
+	if extra != nil {
+		data = extra
+	} else {
+		data, err = os.ReadFile(settingsPath)
+		if err != nil {
+			return err
+		}
+	}
+	return os.WriteFile(settingsPath+".gc.bak", data, 0644)
+}
+
+// piBuildGitCourerRules returns the ordered list of @pi-lab/permissions rules
+// git-courer installs: 23 deny rules (one per covered git subcommand) followed
+// by a single "ask" fallback for any other "git" command.
+func piBuildGitCourerRules() []piPermissionRule {
+	rules := make([]piPermissionRule, 0, len(piDenySubcommands)+1)
+	for _, sub := range piDenySubcommands {
+		tool := piMCPToolForSubcommand[sub]
+		rules = append(rules, piPermissionRule{
+			Match: piPermissionMatch{
+				Tool:   "bash",
+				Params: piPermissionParams{Command: "git " + sub},
+			},
+			Action: "deny",
+			Reason: "Use git-courer/" + tool + " instead",
+		})
+	}
+	// Ask fallback for any other raw git invocation.
+	rules = append(rules, piPermissionRule{
+		Match: piPermissionMatch{
+			Tool:   "bash",
+			Params: piPermissionParams{Command: "git"},
+		},
+		Action: "ask",
+		Reason: "Use git-courer tools instead of raw git",
+	})
+	return rules
+}
+
+// piMergeRules merges git-courer rules into an existing rules slice. Existing
+// git-courer-owned rules (identified by their reason string) are dropped
+// first so re-runs are idempotent; user-defined rules are preserved in their
+// original order, followed by the fresh git-courer rules.
+func piMergeRules(existing []interface{}, gcRules []piPermissionRule) []interface{} {
+	// Drop stale git-courer rules from existing.
+	cleaned := make([]interface{}, 0, len(existing))
+	for _, v := range existing {
+		rm, ok := v.(map[string]interface{})
+		if !ok {
+			cleaned = append(cleaned, v)
+			continue
+		}
+		if reason, ok := rm["reason"].(string); ok && piGitCourerRuleReasons[reason] {
+			continue // drop stale git-courer rule
+		}
+		cleaned = append(cleaned, v)
+	}
+	// Append the fresh git-courer rules as generic maps.
+	for _, r := range gcRules {
+		// Marshal then unmarshal to convert the typed struct into a
+		// map[string]interface{} consistent with the existing slice shape.
+		b, err := json.Marshal(r)
+		if err != nil {
+			continue
+		}
+		var m interface{}
+		if err := json.Unmarshal(b, &m); err != nil {
+			continue
+		}
+		cleaned = append(cleaned, m)
+	}
+	return cleaned
+}

--- a/internal/installer/pi_config_test.go
+++ b/internal/installer/pi_config_test.go
@@ -1,0 +1,402 @@
+// Package installer_test verifies Pi @pi-lab/permissions configuration.
+package installer
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// piSettingsShell is the decode target for assertions on the Pi agent
+// settings.json. Only the fields the tests care about are typed.
+type piSettingsShell struct {
+	Permissions struct {
+		Rules []piPermissionRule `json:"rules"`
+	} `json:"permissions"`
+	Packages []string `json:"packages,omitempty"`
+}
+
+// readPiSettings reads and parses the Pi settings.json.
+func readPiSettings(t *testing.T, path string) piSettingsShell {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read pi settings.json: %v", err)
+	}
+	var s piSettingsShell
+	if err := json.Unmarshal(data, &s); err != nil {
+		t.Fatalf("pi settings.json is not valid JSON: %v\ncontent: %s", err, data)
+	}
+	return s
+}
+
+// piRuleCount returns the number of git-courer rules (by reason) in a slice.
+func piRuleCount(rules []piPermissionRule) int {
+	count := 0
+	for _, r := range rules {
+		if piGitCourerRuleReasons[r.Reason] {
+			count++
+		}
+	}
+	return count
+}
+
+// TestPiBuildGitCourerRules_Returns23DenyPlus1Ask verifies the rule builder
+// returns exactly 23 deny rules + 1 ask fallback, in the correct order.
+func TestPiBuildGitCourerRules_Returns23DenyPlus1Ask(t *testing.T) {
+	rules := piBuildGitCourerRules()
+	if len(rules) != 24 {
+		t.Fatalf("expected 24 rules (23 deny + 1 ask), got %d", len(rules))
+	}
+
+	// First 23 must be deny.
+	for i, r := range rules[:23] {
+		if r.Action != "deny" {
+			t.Errorf("rule %d: expected action deny, got %q", i, r.Action)
+		}
+		if r.Match.Tool != "bash" {
+			t.Errorf("rule %d: expected tool bash, got %q", i, r.Match.Tool)
+		}
+	}
+
+	// Last rule must be ask fallback.
+	last := rules[23]
+	if last.Action != "ask" {
+		t.Errorf("last rule: expected action ask, got %q", last.Action)
+	}
+	if last.Match.Params.Command != "git" {
+		t.Errorf("last rule: expected command 'git', got %q", last.Match.Params.Command)
+	}
+	if last.Reason != "Use git-courer tools instead of raw git" {
+		t.Errorf("last rule: unexpected reason %q", last.Reason)
+	}
+}
+
+// TestPiBuildGitCourerRules_AllReasonsInSet verifies every generated reason
+// string is present in piGitCourerRuleReasons (for idempotent merge/remove).
+func TestPiBuildGitCourerRules_AllReasonsInSet(t *testing.T) {
+	rules := piBuildGitCourerRules()
+	for _, r := range rules {
+		if !piGitCourerRuleReasons[r.Reason] {
+			t.Errorf("reason %q not found in piGitCourerRuleReasons", r.Reason)
+		}
+	}
+}
+
+// TestPiMergeRules_DropsStaleGitCourerRules verifies that existing git-courer
+// rules are dropped before appending fresh ones (idempotent re-run).
+func TestPiMergeRules_DropsStaleGitCourerRules(t *testing.T) {
+	gcRules := piBuildGitCourerRules()
+
+	// Simulate existing rules: 2 user rules + 24 stale git-courer rules.
+	existing := []interface{}{
+		map[string]interface{}{
+			"match":  map[string]interface{}{"tool": "bash", "params": map[string]interface{}{"command": "npm publish"}},
+			"action": "deny",
+			"reason": "User-defined npm publish block",
+		},
+	}
+	for _, r := range gcRules {
+		b, _ := json.Marshal(r)
+		var m interface{}
+		json.Unmarshal(b, &m)
+		existing = append(existing, m)
+	}
+	existing = append(existing, map[string]interface{}{
+		"match":  map[string]interface{}{"tool": "bash", "params": map[string]interface{}{"command": "rm -rf"}},
+		"action": "deny",
+		"reason": "User-defined rm block",
+	})
+
+	merged := piMergeRules(existing, gcRules)
+
+	// Should have: 2 user rules + 24 fresh git-courer rules = 26.
+	if len(merged) != 26 {
+		t.Errorf("expected 26 merged rules (2 user + 24 gc), got %d", len(merged))
+	}
+
+	// User rules must be first and preserved.
+	first, ok := merged[0].(map[string]interface{})
+	if !ok || first["reason"] != "User-defined npm publish block" {
+		t.Error("first user rule was not preserved at the front")
+	}
+	second, ok := merged[1].(map[string]interface{})
+	if !ok || second["reason"] != "User-defined rm block" {
+		t.Error("second user rule was not preserved at index 1")
+	}
+}
+
+// TestPiMergeRules_NoExistingRules verifies merge works with an empty existing
+// slice (fresh install).
+func TestPiMergeRules_NoExistingRules(t *testing.T) {
+	gcRules := piBuildGitCourerRules()
+	merged := piMergeRules(nil, gcRules)
+	if len(merged) != 24 {
+		t.Errorf("expected 24 merged rules, got %d", len(merged))
+	}
+}
+
+// TestInstallPiPermissions_CreatesFreshFile verifies installPiPermissions
+// writes 24 rules (23 deny + 1 ask) in a fresh settings.json.
+func TestInstallPiPermissions_CreatesFreshFile(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	if err := installPiPermissions(settingsPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("installPiPermissions: %v", err)
+	}
+
+	s := readPiSettings(t, settingsPath)
+	gcCount := piRuleCount(s.Permissions.Rules)
+	if gcCount != 24 {
+		t.Errorf("expected 24 git-courer rules, got %d", gcCount)
+	}
+
+	// No backup should be created when the file did not exist.
+	if _, err := os.Stat(settingsPath + ".gc.bak"); err == nil {
+		t.Error("backup should not be created when settings.json did not exist")
+	}
+}
+
+// TestInstallPiPermissions_MergesPreservingExisting verifies existing
+// non-git-courer rules and top-level keys are preserved.
+func TestInstallPiPermissions_MergesPreservingExisting(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	original := `{
+		"permissions": {
+			"rules": [
+				{"match":{"tool":"bash","params":{"command":"npm publish"}},"action":"deny","reason":"block npm publish"}
+			]
+		},
+		"packages": ["npm:pi-mcp-adapter"]
+	}`
+	if err := os.WriteFile(settingsPath, []byte(original), 0644); err != nil {
+		t.Fatalf("write original: %v", err)
+	}
+
+	if err := installPiPermissions(settingsPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("installPiPermissions: %v", err)
+	}
+
+	s := readPiSettings(t, settingsPath)
+
+	// User rule preserved.
+	foundUserRule := false
+	for _, r := range s.Permissions.Rules {
+		if r.Reason == "block npm publish" {
+			foundUserRule = true
+		}
+	}
+	if !foundUserRule {
+		t.Error("user-defined rule was not preserved")
+	}
+
+	// git-courer rules present.
+	gcCount := piRuleCount(s.Permissions.Rules)
+	if gcCount != 24 {
+		t.Errorf("expected 24 git-courer rules, got %d", gcCount)
+	}
+
+	// Non-permission key preserved.
+	if len(s.Packages) == 0 || s.Packages[0] != "npm:pi-mcp-adapter" {
+		t.Errorf("packages key was not preserved: %v", s.Packages)
+	}
+
+	// Backup created with original content.
+	bakData, err := os.ReadFile(settingsPath + ".gc.bak")
+	if err != nil {
+		t.Fatalf("backup not created: %v", err)
+	}
+	if string(bakData) != original {
+		t.Errorf("backup content mismatch:\ngot:  %s\nwant: %s", bakData, original)
+	}
+}
+
+// TestInstallPiPermissions_Idempotent verifies two runs produce byte-identical
+// output and do not overwrite the backup.
+func TestInstallPiPermissions_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	// Pre-populate so a backup is created.
+	original := `{"packages":["npm:pi-mcp-adapter"]}`
+	if err := os.WriteFile(settingsPath, []byte(original), 0644); err != nil {
+		t.Fatalf("write original: %v", err)
+	}
+
+	if err := installPiPermissions(settingsPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	first, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read after first: %v", err)
+	}
+	firstBakStat, err := os.Stat(settingsPath + ".gc.bak")
+	if err != nil {
+		t.Fatalf("backup not created: %v", err)
+	}
+
+	if err := installPiPermissions(settingsPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	second, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("read after second: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Errorf("not idempotent — outputs differ\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+
+	// Backup should not be overwritten on re-run.
+	secondBakStat, err := os.Stat(settingsPath + ".gc.bak")
+	if err != nil {
+		t.Fatalf("backup missing after second run: %v", err)
+	}
+	if !secondBakStat.ModTime().Equal(firstBakStat.ModTime()) {
+		t.Errorf("backup was overwritten on second run: before=%v after=%v", firstBakStat.ModTime(), secondBakStat.ModTime())
+	}
+}
+
+// TestInstallPiPermissions_HandlesUnparseable verifies that when settings.json
+// exists but is invalid JSON, it is backed up and a fresh file is written.
+func TestInstallPiPermissions_HandlesUnparseable(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	corrupt := `{not valid json`
+	if err := os.WriteFile(settingsPath, []byte(corrupt), 0644); err != nil {
+		t.Fatalf("write corrupt: %v", err)
+	}
+
+	if err := installPiPermissions(settingsPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("installPiPermissions on corrupt file: %v", err)
+	}
+
+	s := readPiSettings(t, settingsPath)
+	gcCount := piRuleCount(s.Permissions.Rules)
+	if gcCount != 24 {
+		t.Errorf("expected 24 git-courer rules after recovery, got %d", gcCount)
+	}
+
+	bakData, err := os.ReadFile(settingsPath + ".gc.bak")
+	if err != nil {
+		t.Fatalf("backup of corrupt file not created: %v", err)
+	}
+	if string(bakData) != corrupt {
+		t.Errorf("backup content mismatch:\ngot:  %s\nwant: %s", bakData, corrupt)
+	}
+}
+
+// TestRemovePiPermissions_RestoresBackup verifies that when a .gc.bak exists,
+// removePiPermissions restores it and removes the .bak.
+func TestRemovePiPermissions_RestoresBackup(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	current := `{"permissions":{"rules":[{"match":{"tool":"bash","params":{"command":"git status"}},"action":"deny","reason":"Use git-courer/status instead"}]}}`
+	if err := os.WriteFile(settingsPath, []byte(current), 0644); err != nil {
+		t.Fatalf("write current: %v", err)
+	}
+	backup := `{"packages":["npm:pi-mcp-adapter"]}`
+	if err := os.WriteFile(settingsPath+".gc.bak", []byte(backup), 0644); err != nil {
+		t.Fatalf("write backup: %v", err)
+	}
+
+	if err := removePiPermissions(settingsPath); err != nil {
+		t.Fatalf("removePiPermissions: %v", err)
+	}
+
+	restored, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("settings.json not restored: %v", err)
+	}
+	if string(restored) != backup {
+		t.Errorf("restored content mismatch:\ngot:  %s\nwant: %s", restored, backup)
+	}
+	if _, err := os.Stat(settingsPath + ".gc.bak"); err == nil {
+		t.Error("backup file should have been removed after restore")
+	}
+}
+
+// TestRemovePiPermissions_StripsWithoutBackup verifies that when no .gc.bak
+// exists, removePiPermissions strips git-courer rules while preserving
+// user-defined rules and other top-level keys.
+func TestRemovePiPermissions_StripsWithoutBackup(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	existing := `{
+		"permissions": {
+			"rules": [
+				{"match":{"tool":"bash","params":{"command":"npm publish"}},"action":"deny","reason":"block npm publish"},
+				{"match":{"tool":"bash","params":{"command":"git status"}},"action":"deny","reason":"Use git-courer/status instead"},
+				{"match":{"tool":"bash","params":{"command":"git"}},"action":"ask","reason":"Use git-courer tools instead of raw git"}
+			]
+		},
+		"packages": ["npm:pi-mcp-adapter"]
+	}`
+	if err := os.WriteFile(settingsPath, []byte(existing), 0644); err != nil {
+		t.Fatalf("write existing: %v", err)
+	}
+
+	if err := removePiPermissions(settingsPath); err != nil {
+		t.Fatalf("removePiPermissions: %v", err)
+	}
+
+	s := readPiSettings(t, settingsPath)
+
+	// User rule preserved.
+	foundUserRule := false
+	for _, r := range s.Permissions.Rules {
+		if r.Reason == "block npm publish" {
+			foundUserRule = true
+		}
+	}
+	if !foundUserRule {
+		t.Error("user-defined rule was removed")
+	}
+
+	// git-courer rules stripped.
+	for _, r := range s.Permissions.Rules {
+		if piGitCourerRuleReasons[r.Reason] {
+			t.Errorf("git-courer rule with reason %q was not stripped", r.Reason)
+		}
+	}
+
+	// Non-permission key preserved.
+	if len(s.Packages) == 0 || s.Packages[0] != "npm:pi-mcp-adapter" {
+		t.Errorf("packages key was not preserved: %v", s.Packages)
+	}
+}
+
+// TestRemovePiPermissions_Idempotent verifies that running removePiPermissions
+// twice does not error.
+func TestRemovePiPermissions_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	if err := installPiPermissions(settingsPath, "/usr/local/bin/git-courer"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	if err := removePiPermissions(settingsPath); err != nil {
+		t.Fatalf("first remove: %v", err)
+	}
+	if err := removePiPermissions(settingsPath); err != nil {
+		t.Fatalf("second remove: %v", err)
+	}
+}
+
+// TestRemovePiPermissions_NoOpWhenNoFile verifies that removePiPermissions
+// returns nil when settings.json does not exist.
+func TestRemovePiPermissions_NoOpWhenNoFile(t *testing.T) {
+	dir := t.TempDir()
+	settingsPath := filepath.Join(dir, "does-not-exist.json")
+
+	if err := removePiPermissions(settingsPath); err != nil {
+		t.Errorf("removePiPermissions on missing file returned error: %v", err)
+	}
+}

--- a/internal/installer/v26_test.go
+++ b/internal/installer/v26_test.go
@@ -281,9 +281,10 @@ func TestRestoreBackup_NoBackupIsNoop(t *testing.T) {
 
 // TestConfigureMCP_OpenCodePolicyEarlyReturnPath verifies that when
 // opencode.json already contains git-courer (early-return path in
-// ConfigureMCP), the policy entries (permission.bash "git *": "deny" and
-// GIT_COURER.md in instructions) are still applied. This proves the wiring
-// calls configureOpenCodePolicy in the already-configured branch.
+// ConfigureMCP), the policy entries (the 23 granular "git {sub}": "deny"
+// rules, the "git *": "ask" fallback, and GIT_COURER.md in instructions) are
+// still applied. This proves the wiring calls configureOpenCodePolicy in the
+// already-configured branch.
 func TestConfigureMCP_OpenCodePolicyEarlyReturnPath(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "opencode.json")
@@ -309,7 +310,10 @@ func TestConfigureMCP_OpenCodePolicyEarlyReturnPath(t *testing.T) {
 	}
 
 	cfg := readOpenCodeConfig(t, configPath)
-	assertBashRule(t, cfg, "git *", "deny")
+	for _, sub := range openCodeDenySubcommands {
+		assertBashRule(t, cfg, "git "+sub, "deny")
+	}
+	assertBashRule(t, cfg, "git *", "ask")
 	assertInstructionsContains(t, cfg, filepath.Join(filepath.Dir(configPath), "AGENTS.md"))
 }
 
@@ -344,8 +348,11 @@ func TestConfigureMCP_OpenCodePolicyNormalPath(t *testing.T) {
 	if _, ok := mcp["git-courer"]; !ok {
 		t.Error("git-courer MCP entry missing in normal path")
 	}
-	// Policy present.
-	assertBashRule(t, cfg, "git *", "deny")
+	// Policy present: 23 granular deny + "git *": "ask" fallback.
+	for _, sub := range openCodeDenySubcommands {
+		assertBashRule(t, cfg, "git "+sub, "deny")
+	}
+	assertBashRule(t, cfg, "git *", "ask")
 	assertInstructionsContains(t, cfg, filepath.Join(filepath.Dir(configPath), "AGENTS.md"))
 }
 


### PR DESCRIPTION
Closes #205

## PR Type
- [x] Code refactoring

## Summary
- Replace overly aggressive `"git *": "deny"` with granular three-level classification
- 23 covered subcommands → deny with MCP tool suggestion
- 22 uncovered subcommands (init, clone, config, submodule, etc.) → allow
- Unknown git subcommands → ask (safe default)
- Pi gets @pi-lab/permissions deny/ask rules

## Changes
| File | Change |
|------|--------|
| `internal/classifier/gitcmd/classifier.go` | mcpTools 31→23, allowedSubcommands 9→22, deny decision |
| `internal/delivery/cli/hook_check.go` | Emit deny for deny+ask, verbatim reason |
| `internal/installer/mcp_config.go` | OpenCode granular policy + Pi wiring + ordered JSON builder |
| `internal/installer/pi_config.go` | New: Pi @pi-lab/permissions install/remove |
| `internal/installer/installer.go` | RunUninstall strips Pi permissions |
| `internal/classifier/gitcmd/classifier_test.go` | deny assertions, updated maintenance list |
| `internal/delivery/cli/hook_check_test.go` | deny assertions |
| `internal/installer/opencode_policy_test.go` | Granular assertions + new test |
| `internal/installer/pi_config_test.go` | New: 11 Pi unit tests |
| `internal/installer/v26_test.go` | Granular assertions (ripple) |
| `docs/hooks.md` | Deny behavior docs |
| `docs/mcp-clients.md` | Deny behavior docs |
| `docs/troubleshooting.md` | Deny behavior docs |

## Test Plan
- [x] `go test ./...` — all 40+ packages pass
- [x] `go vet` — clean
- [x] 11 new Pi unit tests for install/remove/merge/idempotency

## Contributor Checklist
- [x] Linked an approved issue (#205 — status:approved)
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
- [x] Docs updated for behavior change