### PR TITLE
feat: replace BFS with Louvain clustering

### DIFF
--- a/internal/infra/chunkers/diff.go
+++ b/internal/infra/chunkers/diff.go
@@ -55,6 +55,9 @@ func NewDiffChunker(opts ...Option) *DiffChunker {
 	for _, o := range opts {
 		o(c)
 	}
+	// Thread the resolved maxFilesPerChunk into the unified pass so that
+	// createClusters → splitOversizedClusters honors the configured limit.
+	c.unifiedPass.maxFilesPerChunk = c.maxFilesPerChunk
 	return c
 }
 

--- a/internal/infra/chunkers/louvain_test.go
+++ b/internal/infra/chunkers/louvain_test.go
@@ -1,0 +1,331 @@
+package chunkers
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/bluekeyes/go-gitdiff/gitdiff"
+)
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+// These helpers mirror the ones that lived in the now-deleted
+// louvain_compare_test.go. They are test-only utilities for building weighted
+// graphs from a compact edge-spec notation and for computing modularity.
+
+// buildTestGraph creates a weighted undirected graph from a list of edge specs.
+// Each spec is "node1 node2 weight". Both endpoints are added as graph nodes.
+func buildTestGraph(specs []string) map[string]map[string]int {
+	graph := make(map[string]map[string]int)
+	for _, s := range specs {
+		parts := strings.Fields(s)
+		if len(parts) < 3 {
+			continue
+		}
+		u, v := parts[0], parts[1]
+		w := 0
+		fmt.Sscanf(parts[2], "%d", &w)
+		if graph[u] == nil {
+			graph[u] = make(map[string]int)
+		}
+		if graph[v] == nil {
+			graph[v] = make(map[string]int)
+		}
+		graph[u][v] = w
+		graph[v][u] = w
+	}
+	return graph
+}
+
+// modularity computes the standard Newman-Girvan modularity for a partition.
+// Q = (1/2m) * Σ_ij [A_ij - (k_i * k_j / 2m)] * δ(c_i, c_j)
+// Returns 0 for graphs with no edges.
+func modularity(graph map[string]map[string]int, clusters [][]string) float64 {
+	// Build node -> cluster index
+	nodeCluster := make(map[string]int)
+	for ci, cluster := range clusters {
+		for _, n := range cluster {
+			nodeCluster[n] = ci
+		}
+	}
+
+	// Total edge weight (2m)
+	totalWeight := 0
+	for u := range graph {
+		for _, w := range graph[u] {
+			totalWeight += w
+		}
+	}
+	if totalWeight == 0 {
+		return 0
+	}
+	m := float64(totalWeight) / 2.0
+
+	// Weighted degree of each node
+	k := make(map[string]float64)
+	for u := range graph {
+		var sum int
+		for _, w := range graph[u] {
+			sum += w
+		}
+		k[u] = float64(sum)
+	}
+
+	var q float64
+	for u := range graph {
+		for v, w := range graph[u] {
+			if nodeCluster[u] == nodeCluster[v] {
+				aij := float64(w)
+				q += aij - (k[u]*k[v])/(2.0*m)
+			}
+		}
+	}
+	q /= 2.0 * m
+
+	return q
+}
+
+// ─── 3.1 louvainClusters ─────────────────────────────────────────────────────
+
+func TestLouvainClusters(t *testing.T) {
+	tests := []struct {
+		name           string
+		graph          map[string]map[string]int
+		wantClusters   int     // expected number of clusters
+		wantModularity float64 // minimum modularity (0 if trivial)
+	}{
+		{
+			name:           "0 nodes",
+			graph:          map[string]map[string]int{},
+			wantClusters:   0,
+			wantModularity: 0,
+		},
+		{
+			name:           "1 node",
+			graph:          map[string]map[string]int{"a.go": {}},
+			wantClusters:   1,
+			wantModularity: 0,
+		},
+		{
+			name:           "no edges",
+			graph:          map[string]map[string]int{"a.go": {}, "b.go": {}},
+			wantClusters:   2,
+			wantModularity: 0,
+		},
+		{
+			name: "chain strong-weak-strong",
+			graph: buildTestGraph([]string{
+				"a.go b.go 1000",
+				"b.go c.go 1",
+				"c.go d.go 1000",
+			}),
+			wantClusters:   2,
+			wantModularity: 0.7,
+		},
+		{
+			name: "dense groups",
+			graph: buildTestGraph([]string{
+				"a1.go a2.go 100", "a1.go a3.go 100", "a2.go a3.go 100",
+				"b1.go b2.go 100", "b1.go b3.go 100", "b2.go b3.go 100",
+			}),
+			wantClusters:   2,
+			wantModularity: 0.3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := louvainClusters(tt.graph)
+			if len(got) != tt.wantClusters {
+				t.Errorf("louvainClusters() got %d clusters, want %d", len(got), tt.wantClusters)
+			}
+			if tt.wantModularity > 0 {
+				q := modularity(tt.graph, got)
+				if q < tt.wantModularity {
+					t.Errorf("modularity = %.4f, want >= %.4f", q, tt.wantModularity)
+				}
+			}
+		})
+	}
+}
+
+func TestLouvainClusters_Deterministic(t *testing.T) {
+	graph := buildTestGraph([]string{
+		"a.go b.go 1000",
+		"b.go c.go 1",
+		"c.go d.go 1000",
+		"d.go e.go 500",
+		"e.go f.go 100",
+	})
+	first := louvainClusters(graph)
+	for i := 0; i < 10; i++ {
+		got := louvainClusters(graph)
+		if !reflect.DeepEqual(first, got) {
+			t.Errorf("iteration %d: different result", i)
+		}
+	}
+}
+
+// ─── 3.2 mergeBridgeClusters ─────────────────────────────────────────────────
+
+func TestMergeBridgeClusters(t *testing.T) {
+	tests := []struct {
+		name     string
+		clusters [][]string
+		graph    map[string]map[string]int
+		want     int // expected number of clusters after merge
+	}{
+		{
+			name:     "strong bridge 600",
+			clusters: [][]string{{"a.go"}, {"b.go"}},
+			graph:    buildTestGraph([]string{"a.go b.go 600"}),
+			want:     1,
+		},
+		{
+			name:     "weak bridge 400",
+			clusters: [][]string{{"a.go"}, {"b.go"}},
+			graph:    buildTestGraph([]string{"a.go b.go 400"}),
+			want:     2,
+		},
+		{
+			name:     "single cluster",
+			clusters: [][]string{{"a.go", "b.go"}},
+			graph:    buildTestGraph([]string{"a.go b.go 600"}),
+			want:     1,
+		},
+		{
+			name:     "no edges",
+			clusters: [][]string{{"a.go"}, {"b.go"}},
+			graph:    map[string]map[string]int{"a.go": {}, "b.go": {}},
+			want:     2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeBridgeClusters(tt.clusters, tt.graph)
+			if len(got) != tt.want {
+				t.Errorf("mergeBridgeClusters() got %d clusters, want %d", len(got), tt.want)
+			}
+		})
+	}
+}
+
+// ─── 3.3 splitOversizedClusters ──────────────────────────────────────────────
+
+func TestSplitOversizedClusters(t *testing.T) {
+	graph := buildTestGraph([]string{
+		"a.go b.go 100", "a.go c.go 100", "a.go d.go 100",
+		"b.go c.go 100", "b.go d.go 100", "c.go d.go 100",
+	})
+	// Add more files with weaker connections to node a.go.
+	for _, f := range []string{"e.go", "f.go", "g.go", "h.go", "i.go", "j.go", "k.go", "l.go"} {
+		graph[f] = map[string]int{"a.go": 10}
+		graph["a.go"][f] = 10
+	}
+
+	tests := []struct {
+		name     string
+		clusters [][]string
+		maxFiles int
+		want     int // expected number of clusters after split
+	}{
+		{
+			name: "12 files max 8",
+			clusters: [][]string{{
+				"a.go", "b.go", "c.go", "d.go", "e.go", "f.go",
+				"g.go", "h.go", "i.go", "j.go", "k.go", "l.go",
+			}},
+			maxFiles: 8,
+			want:     2,
+		},
+		{
+			name: "8 files max 8",
+			clusters: [][]string{{
+				"a.go", "b.go", "c.go", "d.go", "e.go", "f.go", "g.go", "h.go",
+			}},
+			maxFiles: 8,
+			want:     1,
+		},
+		{
+			name:     "0 files",
+			clusters: [][]string{},
+			maxFiles: 8,
+			want:     0,
+		},
+		{
+			name:     "maxFiles 0 (disabled)",
+			clusters: [][]string{{"a.go", "b.go"}},
+			maxFiles: 0,
+			want:     1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitOversizedClusters(tt.clusters, graph, tt.maxFiles)
+			if len(got) != tt.want {
+				t.Errorf("splitOversizedClusters() got %d clusters, want %d", len(got), tt.want)
+			}
+		})
+	}
+}
+
+// ─── 3.4 createClusters end-to-end integration ───────────────────────────────
+
+func TestCreateClusters_EndToEnd(t *testing.T) {
+	// Build a realistic graph using buildGraph + calculateForce, then run
+	// createClusters. Files come from different directories so the directory
+	// affinity (+100) creates intra-package edges without any cross-package
+	// edges. Every file must end up in exactly one cluster.
+	files := []*gitdiff.File{
+		{NewName: "auth/login.go", OldName: "auth/login.go"},
+		{NewName: "auth/session.go", OldName: "auth/session.go"},
+		{NewName: "db/query.go", OldName: "db/query.go"},
+		{NewName: "db/migrate.go", OldName: "db/migrate.go"},
+		{NewName: "ui/button.go", OldName: "ui/button.go"},
+	}
+
+	catalog := NewLanguageCatalog()
+	u := NewUnifiedASTPass(catalog)
+	u.maxFilesPerChunk = 10
+
+	filenames := []string{
+		"auth/login.go", "auth/session.go",
+		"db/query.go", "db/migrate.go",
+		"ui/button.go",
+	}
+	symbols := make(map[string]FileSymbols)
+	graph := u.buildGraph(files, symbols)
+	clusters := u.createClusters(graph, filenames)
+
+	// Verify every file appears in exactly one cluster.
+	seen := make(map[string]bool)
+	for _, cluster := range clusters {
+		for _, f := range cluster {
+			if seen[f] {
+				t.Errorf("file %s appears in multiple clusters", f)
+			}
+			seen[f] = true
+		}
+	}
+	for _, f := range filenames {
+		if !seen[f] {
+			t.Errorf("file %s missing from clusters", f)
+		}
+	}
+
+	// Sanity: the two auth files (same dir → +100 force) must be together.
+	authTogether := false
+	for _, cluster := range clusters {
+		if containsStr(cluster, "auth/login.go") && containsStr(cluster, "auth/session.go") {
+			authTogether = true
+		}
+	}
+	if !authTogether {
+		t.Errorf("auth/login.go and auth/session.go should be in the same cluster (dir affinity +100)")
+	}
+}
+
+// ─── 3.5 Regression safety ───────────────────────────────────────────────────
+// The louvain_compare_test.go file was deleted (it served its design-validation
+// purpose). The full `go test ./internal/infra/chunkers/` run is the regression
+// gate (task 3.6).

--- a/internal/infra/chunkers/unified.go
+++ b/internal/infra/chunkers/unified.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync/atomic"
 
@@ -69,8 +70,9 @@ func categoryLabel(filename string) string {
 // UnifiedASTPass performs a single tree-sitter parse per file and produces
 // both semantic chunk assignments and annotations.
 type UnifiedASTPass struct {
-	catalog      *LanguageCatalog
-	ProcessCount atomic.Int64 // test-only: counts ProcessWithContent invocations
+	catalog          *LanguageCatalog
+	ProcessCount     atomic.Int64 // test-only: counts ProcessWithContent invocations
+	maxFilesPerChunk int          // max files per cluster (set from DiffChunker)
 }
 
 func NewUnifiedASTPass(catalog *LanguageCatalog) *UnifiedASTPass {
@@ -566,38 +568,320 @@ func isPublicEntity(ent entity, nodes data.LanguageNodes) bool {
 	return true
 }
 
-// Process executes the unified pass over a parsed diff.
+// createClusters partitions files into semantic clusters using a three-stage
+// pipeline: Louvain community detection → bridge merging (edge weight > 500)
+// → greedy oversized-cluster splitting by maxFilesPerChunk.
+//
+// buildGraph only adds files that have at least one edge, so isolated files
+// (no semantic relationship detected) are absent from the graph. To preserve
+// the previous BFS behaviour — where every file ends up in exactly one
+// cluster — we seed the graph with all filenames as empty-node entries
+// before running Louvain. Each isolated file then becomes its own singleton
+// community (totalWeight == 0 branch of louvainClusters).
 func (u *UnifiedASTPass) createClusters(graph map[string]map[string]int, filenames []string) [][]string {
-	visited := make(map[string]bool)
-	var clusters [][]string
-	for _, f := range filenames {
-		if visited[f] {
-			continue
+	// Ensure every file is a graph node, even if it has no edges.
+	for _, name := range filenames {
+		if _, ok := graph[name]; !ok {
+			graph[name] = make(map[string]int)
 		}
-		cluster := u.bfsCluster(f, graph, visited)
-		clusters = append(clusters, cluster)
 	}
+
+	// 1. Louvain community detection
+	clusters := louvainClusters(graph)
+
+	// 2. Merge clusters connected by strong bridges (weight > 500)
+	clusters = mergeBridgeClusters(clusters, graph)
+
+	// 3. Split oversized clusters by maxFilesPerChunk
+	clusters = splitOversizedClusters(clusters, graph, u.maxFilesPerChunk)
+
 	return clusters
 }
 
-func (u *UnifiedASTPass) bfsCluster(start string, graph map[string]map[string]int, visited map[string]bool) []string {
-	var cluster []string
-	queue := []string{start}
-	for len(queue) > 0 {
-		current := queue[0]
-		queue = queue[1:]
-		if visited[current] {
-			continue
+// louvainClusters runs the Louvain community detection algorithm on a weighted
+// undirected graph and returns the resulting clusters (communities).
+// It uses a deterministic node ordering (sorted by name) and stops when no
+// further modularity gain is possible (Phase 1 only — sufficient for our sizes).
+func louvainClusters(graph map[string]map[string]int) [][]string {
+	nodes := sortedKeys(graph)
+	if len(nodes) == 0 {
+		return nil
+	}
+
+	// Total edge weight (2m)
+	totalWeight := 0
+	for _, u := range nodes {
+		for _, w := range graph[u] {
+			totalWeight += w
 		}
-		visited[current] = true
-		cluster = append(cluster, current)
-		for neighbor := range graph[current] {
-			if !visited[neighbor] {
-				queue = append(queue, neighbor)
+	}
+	if totalWeight == 0 {
+		// No edges — each node is its own cluster
+		clusters := make([][]string, len(nodes))
+		for i, n := range nodes {
+			clusters[i] = []string{n}
+		}
+		return clusters
+	}
+
+	// m = totalWeight / 2 (each edge counted twice)
+	m := float64(totalWeight) / 2.0
+
+	// Node -> community assignment
+	community := make(map[string]int)
+	for i, n := range nodes {
+		community[n] = i
+	}
+
+	// Precompute weighted degree k_i for each node
+	k := make(map[string]float64)
+	for _, u := range nodes {
+		var sum int
+		for _, w := range graph[u] {
+			sum += w
+		}
+		k[u] = float64(sum)
+	}
+
+	// Precompute sum of weights within each community (sigma_tot)
+	sigmaTot := make(map[int]float64)
+	for _, u := range nodes {
+		c := community[u]
+		sigmaTot[c] += k[u]
+	}
+
+	// Precompute self-loop weight within each community
+	// (sum of A_ij for i,j in same community)
+	selfLoop := make(map[int]float64)
+	for _, u := range nodes {
+		for v, w := range graph[u] {
+			// Only count each edge once (u < v by sorted order)
+			if u < v && community[u] == community[v] {
+				c := community[u]
+				selfLoop[c] += float64(w)
 			}
 		}
 	}
-	return cluster
+
+	// Modularity gain (Blondel et al. 2008), simplified:
+	// ΔQ = k_u_in/m - (Σ_tot * k_u) / (2m²)
+	// where Σ_tot excludes k_u (removed before evaluation) and k_u_in is
+	// computed against the target community.
+	maxIterations := 100
+	for iter := 0; iter < maxIterations; iter++ {
+		moved := false
+		for _, u := range nodes {
+			currentComm := community[u]
+
+			// Step 1: Remove u from its current community
+			sigmaTot[currentComm] -= k[u]
+			for v, w := range graph[u] {
+				if community[v] == currentComm {
+					if u < v {
+						selfLoop[currentComm] -= float64(w)
+					}
+				}
+			}
+
+			// Step 2: Compute k_u_in for each neighboring community
+			kIn := make(map[int]float64)
+			for v, w := range graph[u] {
+				c := community[v]
+				kIn[c] += float64(w)
+			}
+
+			// Step 3: Find best community to move to
+			bestComm := currentComm
+			bestGain := 0.0
+
+			// Sort candidate communities for determinism
+			candidates := make([]int, 0, len(kIn))
+			for c := range kIn {
+				candidates = append(candidates, c)
+			}
+			sort.Ints(candidates)
+
+			for _, c := range candidates {
+				gain := kIn[c]/m - (sigmaTot[c]*k[u])/(2.0*m*m)
+				if gain > bestGain {
+					bestGain = gain
+					bestComm = c
+				}
+			}
+
+			// Step 4: Move u to bestComm (which may be the original community)
+			sigmaTot[bestComm] += k[u]
+			for v, w := range graph[u] {
+				if community[v] == bestComm {
+					if u < v {
+						selfLoop[bestComm] += float64(w)
+					}
+				}
+			}
+			community[u] = bestComm
+
+			if bestComm != currentComm {
+				moved = true
+			}
+		}
+		if !moved {
+			break
+		}
+	}
+
+	// Build clusters from community assignments
+	commMap := make(map[int][]string)
+	for _, u := range nodes {
+		c := community[u]
+		commMap[c] = append(commMap[c], u)
+	}
+
+	clusters := make([][]string, 0, len(commMap))
+	for _, members := range commMap {
+		sort.Strings(members)
+		clusters = append(clusters, members)
+	}
+	// Sort clusters by first member for determinism
+	sort.Slice(clusters, func(i, j int) bool {
+		return clusters[i][0] < clusters[j][0]
+	})
+
+	return clusters
+}
+
+// mergeBridgeClusters merges clusters connected by an edge weight > 500.
+// Such edges represent semantic links (same package/path bonus) that justify
+// keeping otherwise-separated communities together.
+func mergeBridgeClusters(clusters [][]string, graph map[string]map[string]int) [][]string {
+	if len(clusters) <= 1 {
+		return clusters
+	}
+
+	// Build node → cluster index
+	nodeCluster := make(map[string]int)
+	for i, c := range clusters {
+		for _, n := range c {
+			nodeCluster[n] = i
+		}
+	}
+
+	// Track which clusters to merge (union-find style)
+	parent := make([]int, len(clusters))
+	for i := range parent {
+		parent[i] = i
+	}
+	var find func(int) int
+	find = func(x int) int {
+		if parent[x] != x {
+			parent[x] = find(parent[x])
+		}
+		return parent[x]
+	}
+	union := func(a, b int) {
+		pa, pb := find(a), find(b)
+		if pa < pb {
+			parent[pb] = pa
+		} else {
+			parent[pa] = pb
+		}
+	}
+
+	// Check each edge: if weight > 500 and connects different clusters, merge
+	for u, neighbors := range graph {
+		for v, w := range neighbors {
+			if w > 500 {
+				cu := nodeCluster[u]
+				cv := nodeCluster[v]
+				if cu != cv {
+					union(cu, cv)
+				}
+			}
+		}
+	}
+
+	// Build merged clusters
+	merged := make(map[int][]string)
+	for _, c := range clusters {
+		for _, n := range c {
+			root := find(nodeCluster[n])
+			merged[root] = append(merged[root], n)
+		}
+	}
+
+	result := make([][]string, 0, len(merged))
+	for _, members := range merged {
+		sort.Strings(members)
+		result = append(result, members)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i][0] < result[j][0]
+	})
+
+	return result
+}
+
+// splitOversizedClusters splits clusters exceeding maxFiles into two groups:
+// the top `maxFiles` files by intra-cluster connection strength form the
+// primary sub-cluster, the remainder form a secondary sub-cluster.
+func splitOversizedClusters(clusters [][]string, graph map[string]map[string]int, maxFiles int) [][]string {
+	if maxFiles <= 0 {
+		return clusters
+	}
+
+	var result [][]string
+	for _, cluster := range clusters {
+		if len(cluster) <= maxFiles {
+			result = append(result, cluster)
+			continue
+		}
+
+		// Compute intra-cluster connection strength per file
+		strength := make(map[string]int)
+		for _, u := range cluster {
+			var s int
+			for v, w := range graph[u] {
+				if containsStr(cluster, v) {
+					s += w
+				}
+			}
+			strength[u] = s
+		}
+
+		// Sort by strength descending (stable for determinism)
+		sorted := make([]string, len(cluster))
+		copy(sorted, cluster)
+		sort.SliceStable(sorted, func(i, j int) bool {
+			return strength[sorted[i]] > strength[sorted[j]]
+		})
+
+		// Top maxFiles form primary cluster, remainder form new cluster
+		result = append(result, sorted[:maxFiles])
+		result = append(result, sorted[maxFiles:])
+	}
+
+	return result
+}
+
+// containsStr reports whether slice contains s. Package-level helper used by
+// splitOversizedClusters; named to avoid colliding with any future contains.
+func containsStr(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// sortedKeys returns the keys of graph sorted alphabetically. Used for
+// deterministic iteration in the Louvain pipeline.
+func sortedKeys(graph map[string]map[string]int) []string {
+	keys := make([]string, 0, len(graph))
+	for k := range graph {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func (u *UnifiedASTPass) Process(files []*gitdiff.File, maxChunkSize int) ([]domain.DiffChunk, []domain.Label, error) {


### PR DESCRIPTION
## Chain Context

| Field | Value |
|-------|-------|
| Chain | graph-clustering |
| Tracker PR | #210 |
| Position | 1 of 2 |
| Base | `feat/graph-clustering` |
| Depends on | None |
| Follow-up | #212 (tests) |
| Review budget | 310 / 400 |
| Starts at | main |
| Ends with | Louvain pipeline in place, regression green |

### Chain Overview

```
main
 └── #210 Tracker PR (draft)
      └── 📍 #211 This PR (core)
           └── #212 Next PR (tests)
```

### Scope
- Includes: Louvain community detection, bridge merging (weight > 500), greedy oversized-cluster split, maxFilesPerChunk wiring
- Excludes: New tests, louvain_compare_test.go deletion (PR 2)

### Autonomy
- [x] CI is expected to pass for this PR branch
- [x] This PR has one deliverable scope
- [x] This PR can be rolled back without unrelated changes
- [x] Tests, docs, or manual verification cover this unit

---

Closes #208