### PR TITLE
feat: group commit metadata by workspace instead of branch for changelog

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -292,12 +292,12 @@ func runRelease(args []string) {
 
 	gitAdapter := gitadapter.New(".")
 
-	// Create branch-scoped commit store
+	// Create workspace-scoped commit store
 	commitStore := commitstore.NewFilesystemCommitStore(".", gitAdapter)
 	currentBranch, branchErr := gitAdapter.CurrentBranch()
 	if branchErr == nil && currentBranch != "" {
-		if err := commitStore.SetBranch(currentBranch); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to set branch store: %v\n", err)
+		if err := commitStore.SetWorkspace(currentBranch); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to set workspace store: %v\n", err)
 		}
 	}
 

--- a/internal/adapters/commitstore/adapter.go
+++ b/internal/adapters/commitstore/adapter.go
@@ -23,6 +23,7 @@ type jsonEntry struct {
 	Message string `json:"message"`
 	Author  string `json:"author"`
 	Date    string `json:"date"`
+	Branch  string `json:"branch"`
 }
 
 // FilesystemCommitStore implements ports.CommitStore using a JSONL file.
@@ -32,9 +33,10 @@ type FilesystemCommitStore struct {
 	mu         sync.Mutex
 	git        ports.Git
 	baseDir    string // workDir + domain.MetadataDir — immutable after construction
-	currentDir string // active directory: baseDir (legacy) or baseDir + "/branches/<sanitized>"
+	currentDir string // active directory: baseDir (legacy) or baseDir + "/workspace/<sanitized>"
 	path       string // active file path: currentDir + "/commits.json"
-	branch     string // current unsanitized branch name (empty = legacy mode)
+	branch     string // current unsanitized branch name (empty = no ref update)
+	workspace  string // current workspace id (empty = legacy global path)
 }
 
 // NewFilesystemCommitStore creates a FilesystemCommitStore that persists
@@ -75,6 +77,7 @@ func (s *FilesystemCommitStore) Append(entries ...domain.CommitEntry) error {
 			Message: entry.Message(),
 			Author:  entry.Author(),
 			Date:    entry.Date(),
+			Branch:  entry.Branch(),
 		})
 	}
 
@@ -143,6 +146,7 @@ func (s *FilesystemCommitStore) readLocked() ([]domain.CommitEntry, error) {
 		entry, err := domain.NewCommitEntry(je.SHA, je.Message,
 			domain.WithAuthor(je.Author),
 			domain.WithDate(je.Date),
+			domain.WithBranch(je.Branch),
 		)
 		if err != nil {
 			log.Printf("commit store: skipping invalid entry: %v", err)
@@ -174,6 +178,7 @@ func (s *FilesystemCommitStore) readLocked() ([]domain.CommitEntry, error) {
 		entry, err := domain.NewCommitEntry(je.SHA, je.Message,
 			domain.WithAuthor(je.Author),
 			domain.WithDate(je.Date),
+			domain.WithBranch(je.Branch),
 		)
 		if err != nil {
 			log.Printf("commit store: skipping invalid entry at line %d: %v", lineNum, err)
@@ -204,6 +209,7 @@ func (s *FilesystemCommitStore) write(entries []domain.CommitEntry) error {
 			Message: entry.Message(),
 			Author:  entry.Author(),
 			Date:    entry.Date(),
+			Branch:  entry.Branch(),
 		})
 	}
 
@@ -259,7 +265,8 @@ func (s *FilesystemCommitStore) entriesEqual(a, b []domain.CommitEntry) bool {
 		if a[i].SHA() != b[i].SHA() ||
 			a[i].Message() != b[i].Message() ||
 			a[i].Author() != b[i].Author() ||
-			a[i].Date() != b[i].Date() {
+			a[i].Date() != b[i].Date() ||
+			a[i].Branch() != b[i].Branch() {
 			return false
 		}
 	}
@@ -286,23 +293,42 @@ func (s *FilesystemCommitStore) Clear() error {
 	return nil
 }
 
-// SetBranch switches the store to read/write from a branch-scoped path:
+// SetWorkspace switches the store to read/write from a workspace-scoped path:
 //
-//	.git/git-courer/branches/<sanitized>/commits.json
+//	.git/git-courer/workspace/<id>/commits.json
 //
-// If name is empty, returns an error.
-// After calling SetBranch, Append/Read/Clear operate on the branch path.
+// The id is sanitized conditionally: a valid UUID passes unchanged (UUIDs are
+// filesystem-safe); a non-UUID (e.g. a branch name) is sanitized via
+// SanitizeBranchName. If id is empty, returns an error.
+// After calling SetWorkspace, Append/Read/Clear operate on the workspace path.
 // Thread-safe: serialized by the adapter's mutex.
-func (s *FilesystemCommitStore) SetBranch(name string) error {
-	if name == "" {
-		return fmt.Errorf("SetBranch: branch name must not be empty")
+func (s *FilesystemCommitStore) SetWorkspace(workspaceID string) error {
+	if workspaceID == "" {
+		return fmt.Errorf("SetWorkspace: workspace id must not be empty")
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	sanitized := sanitizeBranchName(name)
-	s.currentDir = filepath.Join(s.baseDir, "branches", sanitized)
+	var sanitized string
+	if isUUID(workspaceID) {
+		sanitized = workspaceID
+	} else {
+		sanitized = SanitizeBranchName(workspaceID)
+	}
+	s.currentDir = filepath.Join(s.baseDir, "workspace", sanitized)
 	s.path = filepath.Join(s.currentDir, "commits.json")
-	s.branch = name
+	s.workspace = workspaceID
+	return nil
+}
+
+// SetBranchRef sets the branch name used for the refs/courer/<branch> ref
+// update that accompanies Append. It is separate from SetWorkspace because ref
+// naming must stay branch-keyed for push/pull while the workspace UUID is
+// meaningless as a ref name. An empty branch disables the ref update.
+// Thread-safe: serialized by the adapter's mutex.
+func (s *FilesystemCommitStore) SetBranchRef(branch string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.branch = branch
 	return nil
 }
 
@@ -397,6 +423,7 @@ func (s *FilesystemCommitStore) ReadAllBranches() (map[string][]domain.CommitEnt
 		e, err := domain.NewCommitEntry(je.SHA, je.Message,
 			domain.WithAuthor(je.Author),
 			domain.WithDate(je.Date),
+			domain.WithBranch(je.Branch),
 		)
 			if err != nil {
 				log.Printf("[WARN] commit store: skipping invalid entry in branch %q: %v", branchName, err)
@@ -412,6 +439,8 @@ func (s *FilesystemCommitStore) ReadAllBranches() (map[string][]domain.CommitEnt
 
 // RemoveAllBranchDirs removes the entire branches/ directory subtree.
 // If the directory does not exist, returns nil (idempotent).
+//
+// DEPRECATED: branches/ storage is kept for passive coexistence only.
 func (s *FilesystemCommitStore) RemoveAllBranchDirs() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -422,6 +451,89 @@ func (s *FilesystemCommitStore) RemoveAllBranchDirs() error {
 	}
 	if err := os.RemoveAll(branchesDir); err != nil {
 		return fmt.Errorf("commit store: remove branches: %w", s.sanitizePathError(err))
+	}
+	return nil
+}
+
+// ReadAllWorkspaces reads commit entries from ALL workspace stores.
+// Returns a map of workspace id → entries. If no workspaces exist, returns
+// an empty map with no error. Malformed directories are skipped with a log warning.
+func (s *FilesystemCommitStore) ReadAllWorkspaces() (map[string][]domain.CommitEntry, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	result := make(map[string][]domain.CommitEntry)
+	workspacesDir := filepath.Join(s.baseDir, "workspace")
+
+	entries, err := os.ReadDir(workspacesDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return result, nil
+		}
+		return nil, fmt.Errorf("commit store: read workspaces dir: %w", s.sanitizePathError(err))
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		workspaceID := entry.Name()
+		workspacePath := filepath.Join(workspacesDir, workspaceID, "commits.json")
+
+		data, err := os.ReadFile(workspacePath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				result[workspaceID] = []domain.CommitEntry{}
+				continue
+			}
+			log.Printf("[WARN] commit store: skipping workspace %q: %v", workspaceID, err)
+			result[workspaceID] = []domain.CommitEntry{}
+			continue
+		}
+
+		if len(data) == 0 {
+			result[workspaceID] = []domain.CommitEntry{}
+			continue
+		}
+
+		var jEntries []jsonEntry
+		if err := json.Unmarshal(data, &jEntries); err != nil {
+			log.Printf("[WARN] commit store: skipping workspace %q: invalid JSON: %v", workspaceID, err)
+			result[workspaceID] = []domain.CommitEntry{}
+			continue
+		}
+
+		var parsed []domain.CommitEntry
+		for _, je := range jEntries {
+			e, err := domain.NewCommitEntry(je.SHA, je.Message,
+				domain.WithAuthor(je.Author),
+				domain.WithDate(je.Date),
+				domain.WithBranch(je.Branch),
+			)
+			if err != nil {
+				log.Printf("[WARN] commit store: skipping invalid entry in workspace %q: %v", workspaceID, err)
+				continue
+			}
+			parsed = append(parsed, e)
+		}
+		result[workspaceID] = parsed
+	}
+
+	return result, nil
+}
+
+// RemoveAllWorkspaceDirs removes the entire workspace/ directory subtree.
+// If the directory does not exist, returns nil (idempotent).
+func (s *FilesystemCommitStore) RemoveAllWorkspaceDirs() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	workspacesDir := filepath.Join(s.baseDir, "workspace")
+	if _, err := os.Stat(workspacesDir); os.IsNotExist(err) {
+		return nil // idempotent
+	}
+	if err := os.RemoveAll(workspacesDir); err != nil {
+		return fmt.Errorf("commit store: remove workspaces: %w", s.sanitizePathError(err))
 	}
 	return nil
 }

--- a/internal/adapters/commitstore/adapter_test.go
+++ b/internal/adapters/commitstore/adapter_test.go
@@ -320,19 +320,19 @@ func TestFilesystemCommitStore_AppendMultiple(t *testing.T) {
 	}
 }
 
-func TestFilesystemCommitStore_SetBranch_SetsPath(t *testing.T) {
+func TestFilesystemCommitStore_SetWorkspace_BranchName_SetsPath(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
 	store := NewFilesystemCommitStore(tmpDir, nil)
 
-	err := store.SetBranch("feat/auth")
+	err := store.SetWorkspace("feat/auth")
 	if err != nil {
-		t.Fatalf("SetBranch() error: %v", err)
+		t.Fatalf("SetWorkspace() error: %v", err)
 	}
 
-	// Verify path is branch-scoped
-	expectedDir := filepath.Join(tmpDir, ".git/git-courer", "branches", "feat-auth")
+	// Verify path is workspace-scoped (branch name sanitized)
+	expectedDir := filepath.Join(tmpDir, ".git/git-courer", "workspace", "feat-auth")
 	expectedPath := filepath.Join(expectedDir, "commits.json")
 
 	if store.currentDir != expectedDir {
@@ -341,49 +341,68 @@ func TestFilesystemCommitStore_SetBranch_SetsPath(t *testing.T) {
 	if store.path != expectedPath {
 		t.Errorf("path = %q, want %q", store.path, expectedPath)
 	}
-	if store.branch != "feat/auth" {
-		t.Errorf("branch = %q, want %q", store.branch, "feat/auth")
+	if store.workspace != "feat/auth" {
+		t.Errorf("workspace = %q, want %q", store.workspace, "feat/auth")
 	}
 }
 
-func TestFilesystemCommitStore_SetBranch_EmptyName(t *testing.T) {
+func TestFilesystemCommitStore_SetWorkspace_UUID_PassesUnchanged(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
 	store := NewFilesystemCommitStore(tmpDir, nil)
 
-	err := store.SetBranch("")
-	if err == nil {
-		t.Fatal("SetBranch(\"\") should return an error")
-	}
-	if !strings.Contains(err.Error(), "branch name must not be empty") {
-		t.Errorf("error message = %q, want mention of empty branch name", err.Error())
-	}
-}
-
-func TestFilesystemCommitStore_SetBranch_SwitchesPaths(t *testing.T) {
-	t.Parallel()
-
-	tmpDir := t.TempDir()
-	store := NewFilesystemCommitStore(tmpDir, nil)
-
-	err := store.SetBranch("feat/auth")
+	uuid := "a1b2c3d4-e5f6-4789-8a01-234567890abc"
+	err := store.SetWorkspace(uuid)
 	if err != nil {
-		t.Fatalf("first SetBranch() error: %v", err)
+		t.Fatalf("SetWorkspace() error: %v", err)
+	}
+
+	// UUIDs are filesystem-safe and pass through unsanitized.
+	expectedDir := filepath.Join(tmpDir, ".git/git-courer", "workspace", uuid)
+	if store.currentDir != expectedDir {
+		t.Errorf("currentDir = %q, want %q", store.currentDir, expectedDir)
+	}
+}
+
+func TestFilesystemCommitStore_SetWorkspace_EmptyName(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	store := NewFilesystemCommitStore(tmpDir, nil)
+
+	err := store.SetWorkspace("")
+	if err == nil {
+		t.Fatal("SetWorkspace(\"\") should return an error")
+	}
+	if !strings.Contains(err.Error(), "workspace id must not be empty") {
+		t.Errorf("error message = %q, want mention of empty workspace id", err.Error())
+	}
+}
+
+func TestFilesystemCommitStore_SetWorkspace_SwitchesPaths(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	store := NewFilesystemCommitStore(tmpDir, nil)
+
+	err := store.SetWorkspace("feat/auth")
+	if err != nil {
+		t.Fatalf("first SetWorkspace() error: %v", err)
 	}
 	firstPath := store.path
 
-	err = store.SetBranch("main")
+	err = store.SetWorkspace("main")
 	if err != nil {
-		t.Fatalf("second SetBranch() error: %v", err)
+		t.Fatalf("second SetWorkspace() error: %v", err)
 	}
 	secondPath := store.path
 
 	if firstPath == secondPath {
-		t.Errorf("path did not change after second SetBranch: %q", firstPath)
+		t.Errorf("path did not change after second SetWorkspace: %q", firstPath)
 	}
-	if store.branch != "main" {
-		t.Errorf("branch = %q, want %q", store.branch, "main")
+	if store.workspace != "main" {
+		t.Errorf("workspace = %q, want %q", store.workspace, "main")
 	}
 }
 
@@ -393,19 +412,14 @@ func TestFilesystemCommitStore_RemoveBranch_DeletesDirectory(t *testing.T) {
 	tmpDir := t.TempDir()
 	store := NewFilesystemCommitStore(tmpDir, nil)
 
-	// SetBranch and Append to create the directory and file
-	if err := store.SetBranch("feat/auth"); err != nil {
-		t.Fatalf("SetBranch() error: %v", err)
-	}
-	entry := makeEntry(t, validSHA("aa000000000000000000000000000000000000"), "feat: first commit")
-	if err := store.Append(entry); err != nil {
-		t.Fatalf("Append() error: %v", err)
-	}
-
-	// Verify directory exists
+	// Create a branches/ directory manually (legacy coexistence path).
 	branchDir := filepath.Join(tmpDir, ".git/git-courer", "branches", "feat-auth")
-	if _, err := os.Stat(branchDir); os.IsNotExist(err) {
-		t.Fatalf("branch directory should exist after Append: %v", err)
+	if err := os.MkdirAll(branchDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error: %v", err)
+	}
+	commitsPath := filepath.Join(branchDir, "commits.json")
+	if err := os.WriteFile(commitsPath, []byte("[]"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
 	}
 
 	err := store.RemoveBranch("feat/auth")
@@ -487,7 +501,7 @@ func TestFilesystemCommitStore_SetBranch_ConcurrentAccess(t *testing.T) {
 		go func(idx int) {
 			defer wg.Done()
 			branch := "feat/branch"
-			if err := store.SetBranch(branch); err != nil {
+			if err := store.SetWorkspace(branch); err != nil {
 				errCh <- err
 				return
 			}
@@ -515,23 +529,23 @@ func TestFilesystemCommitStore_SetBranch_ConcurrentAccess(t *testing.T) {
 	}
 }
 
-func TestFilesystemCommitStore_SanitizePathError_WithBranch(t *testing.T) {
+func TestFilesystemCommitStore_SanitizePathError_WithWorkspace(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
 	store := NewFilesystemCommitStore(tmpDir, nil)
 
-	if err := store.SetBranch("feat/auth"); err != nil {
-		t.Fatalf("SetBranch() error: %v", err)
+	if err := store.SetWorkspace("feat/auth"); err != nil {
+		t.Fatalf("SetWorkspace() error: %v", err)
 	}
 
 	// Trigger an error by making the path unwritable
-	branchDir := filepath.Join(tmpDir, ".git/git-courer", "branches", "feat-auth")
-	if err := os.MkdirAll(branchDir, 0o755); err != nil {
+	workspaceDir := filepath.Join(tmpDir, ".git/git-courer", "workspace", "feat-auth")
+	if err := os.MkdirAll(workspaceDir, 0o755); err != nil {
 		t.Fatalf("MkdirAll() error: %v", err)
 	}
 	// Create a directory where the file should be
-	if err := os.MkdirAll(filepath.Join(branchDir, "commits.json"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(workspaceDir, "commits.json"), 0o755); err != nil {
 		t.Fatalf("MkdirAll() error: %v", err)
 	}
 
@@ -549,16 +563,16 @@ func TestFilesystemCommitStore_SanitizePathError_WithBranch(t *testing.T) {
 	}
 }
 
-// --- T1.4: Integration tests for branch-scoped commit store ---
+// --- T1.4: Integration tests for workspace-scoped commit store ---
 
-func TestFilesystemCommitStore_AfterSetBranch_AppendWritesToBranchFile(t *testing.T) {
+func TestFilesystemCommitStore_AfterSetWorkspace_AppendWritesToWorkspaceFile(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
 	store := NewFilesystemCommitStore(tmpDir, nil)
 
-	if err := store.SetBranch("feat/auth"); err != nil {
-		t.Fatalf("SetBranch() error: %v", err)
+	if err := store.SetWorkspace("feat/auth"); err != nil {
+		t.Fatalf("SetWorkspace() error: %v", err)
 	}
 
 	entry := makeEntry(t, validSHA("aa000000000000000000000000000000000000"), "feat: branch commit")
@@ -566,31 +580,31 @@ func TestFilesystemCommitStore_AfterSetBranch_AppendWritesToBranchFile(t *testin
 		t.Fatalf("Append() error: %v", err)
 	}
 
-	// Verify the file exists at the branch-scoped path
-	branchFilePath := filepath.Join(tmpDir, ".git/git-courer", "branches", "feat-auth", "commits.json")
-	data, err := os.ReadFile(branchFilePath)
+	// Verify the file exists at the workspace-scoped path
+	workspaceFilePath := filepath.Join(tmpDir, ".git/git-courer", "workspace", "feat-auth", "commits.json")
+	data, err := os.ReadFile(workspaceFilePath)
 	if err != nil {
-		t.Fatalf("branch file should exist at %s: %v", branchFilePath, err)
+		t.Fatalf("workspace file should exist at %s: %v", workspaceFilePath, err)
 	}
 	if len(data) == 0 {
-		t.Errorf("branch file is empty")
+		t.Errorf("workspace file is empty")
 	}
 
 	// Verify the legacy file does NOT exist
 	legacyPath := filepath.Join(tmpDir, ".git/git-courer", "commits.json")
 	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
-		t.Errorf("legacy file should not exist when SetBranch was called")
+		t.Errorf("legacy file should not exist when SetWorkspace was called")
 	}
 }
 
-func TestFilesystemCommitStore_AfterSetBranch_ReadReturnsBranchEntries(t *testing.T) {
+func TestFilesystemCommitStore_AfterSetWorkspace_ReadReturnsWorkspaceEntries(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
 	store := NewFilesystemCommitStore(tmpDir, nil)
 
-	if err := store.SetBranch("feat/auth"); err != nil {
-		t.Fatalf("SetBranch() error: %v", err)
+	if err := store.SetWorkspace("feat/auth"); err != nil {
+		t.Fatalf("SetWorkspace() error: %v", err)
 	}
 
 	e1 := makeEntry(t, validSHA("a1000000000000000000000000000000000000"), "feat: first on branch")
@@ -613,14 +627,14 @@ func TestFilesystemCommitStore_AfterSetBranch_ReadReturnsBranchEntries(t *testin
 	}
 }
 
-func TestFilesystemCommitStore_AfterSetBranch_ClearTruncatesBranchFile(t *testing.T) {
+func TestFilesystemCommitStore_AfterSetWorkspace_ClearTruncatesWorkspaceFile(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
 	store := NewFilesystemCommitStore(tmpDir, nil)
 
-	if err := store.SetBranch("feat/auth"); err != nil {
-		t.Fatalf("SetBranch() error: %v", err)
+	if err := store.SetWorkspace("feat/auth"); err != nil {
+		t.Fatalf("SetWorkspace() error: %v", err)
 	}
 
 	entry := makeEntry(t, validSHA("aa000000000000000000000000000000000000"), "feat: to be cleared")
@@ -638,31 +652,31 @@ func TestFilesystemCommitStore_AfterSetBranch_ClearTruncatesBranchFile(t *testin
 		t.Errorf("Read() after Clear() returned %d entries, want 0", len(entries))
 	}
 
-	// Verify branch directory still exists (only file truncated, dir preserved)
-	branchDir := filepath.Join(tmpDir, ".git/git-courer", "branches", "feat-auth")
-	info, err := os.Stat(branchDir)
+	// Verify workspace directory still exists (only file truncated, dir preserved)
+	workspaceDir := filepath.Join(tmpDir, ".git/git-courer", "workspace", "feat-auth")
+	info, err := os.Stat(workspaceDir)
 	if err != nil {
-		t.Fatalf("branch directory should still exist: %v", err)
+		t.Fatalf("workspace directory should still exist: %v", err)
 	}
 	if !info.IsDir() {
-		t.Errorf("branch path is not a directory")
+		t.Errorf("workspace path is not a directory")
 	}
 }
 
-func TestFilesystemCommitStore_AfterSetBranch_MkdirAllLazy(t *testing.T) {
+func TestFilesystemCommitStore_AfterSetWorkspace_MkdirAllLazy(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
 	store := NewFilesystemCommitStore(tmpDir, nil)
 
-	if err := store.SetBranch("feat/auth"); err != nil {
-		t.Fatalf("SetBranch() error: %v", err)
+	if err := store.SetWorkspace("feat/auth"); err != nil {
+		t.Fatalf("SetWorkspace() error: %v", err)
 	}
 
 	// Directory should NOT exist yet (lazy creation)
-	branchDir := filepath.Join(tmpDir, ".git/git-courer", "branches", "feat-auth")
-	if _, err := os.Stat(branchDir); !os.IsNotExist(err) {
-		t.Errorf("branch directory should not exist before Append, got err: %v", err)
+	workspaceDir := filepath.Join(tmpDir, ".git/git-courer", "workspace", "feat-auth")
+	if _, err := os.Stat(workspaceDir); !os.IsNotExist(err) {
+		t.Errorf("workspace directory should not exist before Append, got err: %v", err)
 	}
 
 	// After Append, directory should exist
@@ -671,29 +685,29 @@ func TestFilesystemCommitStore_AfterSetBranch_MkdirAllLazy(t *testing.T) {
 		t.Fatalf("Append() error: %v", err)
 	}
 
-	if _, err := os.Stat(branchDir); os.IsNotExist(err) {
-		t.Errorf("branch directory should exist after Append")
+	if _, err := os.Stat(workspaceDir); os.IsNotExist(err) {
+		t.Errorf("workspace directory should exist after Append")
 	}
 }
 
-func TestFilesystemCommitStore_BranchIsolation(t *testing.T) {
+func TestFilesystemCommitStore_WorkspaceIsolation(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
 
-	// Create store for feat/auth branch
+	// Create store for feat/auth workspace
 	storeAuth := NewFilesystemCommitStore(tmpDir, nil)
-	if err := storeAuth.SetBranch("feat/auth"); err != nil {
-		t.Fatalf("SetBranch(feat/auth) error: %v", err)
+	if err := storeAuth.SetWorkspace("feat/auth"); err != nil {
+		t.Fatalf("SetWorkspace(feat/auth) error: %v", err)
 	}
 
-	// Create store for main branch
+	// Create store for main workspace
 	storeMain := NewFilesystemCommitStore(tmpDir, nil)
-	if err := storeMain.SetBranch("main"); err != nil {
-		t.Fatalf("SetBranch(main) error: %v", err)
+	if err := storeMain.SetWorkspace("main"); err != nil {
+		t.Fatalf("SetWorkspace(main) error: %v", err)
 	}
 
-	// Write different entries to different branches
+	// Write different entries to different workspaces
 	authEntry := makeEntry(t, validSHA("a1000000000000000000000000000000000000"), "feat: auth feature")
 	mainEntry := makeEntry(t, validSHA("b2000000000000000000000000000000000000"), "fix: main bugfix")
 
@@ -813,6 +827,37 @@ func TestFilesystemCommitStore_JSONFormatAndFallback(t *testing.T) {
 
 // --- ReadAllBranches tests ---
 
+// writeBranchStore writes entries to a branches/<sanitized>/commits.json file
+// under the store's baseDir. Used to set up legacy branches/ data for
+// ReadAllBranches tests without going through SetWorkspace (which writes
+// to workspace/ instead).
+func writeBranchStore(t *testing.T, tmpDir, branchName string, entries []domain.CommitEntry) {
+	t.Helper()
+	sanitized := SanitizeBranchName(branchName)
+	branchDir := filepath.Join(tmpDir, ".git/git-courer", "branches", sanitized)
+	if err := os.MkdirAll(branchDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error: %v", branchDir, err)
+	}
+	var jEntries []jsonEntry
+	for _, e := range entries {
+		jEntries = append(jEntries, jsonEntry{
+			SHA:     e.SHA(),
+			Message:  e.Message(),
+			Author:   e.Author(),
+			Date:     e.Date(),
+			Branch:   e.Branch(),
+		})
+	}
+	data, err := json.MarshalIndent(jEntries, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent error: %v", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(filepath.Join(branchDir, "commits.json"), data, 0o644); err != nil {
+		t.Fatalf("WriteFile error: %v", err)
+	}
+}
+
 func TestFilesystemCommitStore_ReadAllBranches_EmptyDir(t *testing.T) {
 	t.Parallel()
 
@@ -834,15 +879,9 @@ func TestFilesystemCommitStore_ReadAllBranches_SingleBranch(t *testing.T) {
 	tmpDir := t.TempDir()
 	store := NewFilesystemCommitStore(tmpDir, nil)
 
-	if err := store.SetBranch("main"); err != nil {
-		t.Fatalf("SetBranch() error: %v", err)
-	}
-
 	e1 := makeEntry(t, validSHA("a1000000000000000000000000000000000000"), "feat: first")
 	e2 := makeEntry(t, validSHA("b2000000000000000000000000000000000000"), "fix: second")
-	if err := store.Append(e1, e2); err != nil {
-		t.Fatalf("Append() error: %v", err)
-	}
+	writeBranchStore(t, tmpDir, "main", []domain.CommitEntry{e1, e2})
 
 	result, err := store.ReadAllBranches()
 	if err != nil {
@@ -866,24 +905,16 @@ func TestFilesystemCommitStore_ReadAllBranches_MultipleBranches_Dedup(t *testing
 	tmpDir := t.TempDir()
 
 	// Create two branch stores with entries, one SHA shared
-	storeA := NewFilesystemCommitStore(tmpDir, nil)
-	if err := storeA.SetBranch("feature-a"); err != nil {
-		t.Fatalf("SetBranch(feature-a) error: %v", err)
-	}
 	sharedSHA := validSHA("a1000000000000000000000000000000000000")
 	eA1 := makeEntry(t, sharedSHA, "feat: shared commit")
 	eA2 := makeEntry(t, validSHA("a2000000000000000000000000000000000000"), "feat: feature-a only")
-	storeA.Append(eA1, eA2)
+	writeBranchStore(t, tmpDir, "feature-a", []domain.CommitEntry{eA1, eA2})
 
-	storeB := NewFilesystemCommitStore(tmpDir, nil)
-	if err := storeB.SetBranch("feature-b"); err != nil {
-		t.Fatalf("SetBranch(feature-b) error: %v", err)
-	}
 	eB1 := makeEntry(t, sharedSHA, "feat: shared commit") // same SHA as eA1
 	eB2 := makeEntry(t, validSHA("b2000000000000000000000000000000000000"), "fix: feature-b only")
-	storeB.Append(eB1, eB2)
+	writeBranchStore(t, tmpDir, "feature-b", []domain.CommitEntry{eB1, eB2})
 
-	// Now read from a fresh store (to ensure path is not set to a particular branch)
+	// Read from a fresh store
 	store := NewFilesystemCommitStore(tmpDir, nil)
 	result, err := store.ReadAllBranches()
 	if err != nil {
@@ -918,12 +949,8 @@ func TestFilesystemCommitStore_ReadAllBranches_CorruptBranchDir(t *testing.T) {
 	baseDir := filepath.Join(tmpDir, ".git/git-courer", "branches")
 
 	// Create a valid branch
-	storeValid := NewFilesystemCommitStore(tmpDir, nil)
-	if err := storeValid.SetBranch("valid-branch"); err != nil {
-		t.Fatalf("SetBranch() error: %v", err)
-	}
 	e1 := makeEntry(t, validSHA("a1000000000000000000000000000000000000"), "feat: valid")
-	storeValid.Append(e1)
+	writeBranchStore(t, tmpDir, "valid-branch", []domain.CommitEntry{e1})
 
 	// Create a corrupt branch manually (invalid JSON)
 	if err := os.MkdirAll(filepath.Join(baseDir, "corrupt-branch"), 0o755); err != nil {
@@ -967,14 +994,13 @@ func TestFilesystemCommitStore_RemoveAllBranchDirs_RemovesDir(t *testing.T) {
 	tmpDir := t.TempDir()
 	store := NewFilesystemCommitStore(tmpDir, nil)
 
-	// Create some branch directories
-	storeA := NewFilesystemCommitStore(tmpDir, nil)
-	storeA.SetBranch("feature-a")
-	storeA.Append(makeEntry(t, validSHA("aa000000000000000000000000000000000000"), "feat: a"))
-
-	storeB := NewFilesystemCommitStore(tmpDir, nil)
-	storeB.SetBranch("feature-b")
-	storeB.Append(makeEntry(t, validSHA("bb000000000000000000000000000000000000"), "feat: b"))
+	// Create some branch directories manually (legacy coexistence path)
+	writeBranchStore(t, tmpDir, "feature-a", []domain.CommitEntry{
+		makeEntry(t, validSHA("aa000000000000000000000000000000000000"), "feat: a"),
+	})
+	writeBranchStore(t, tmpDir, "feature-b", []domain.CommitEntry{
+		makeEntry(t, validSHA("bb000000000000000000000000000000000000"), "feat: b"),
+	})
 
 	// Verify branches directory exists
 	branchesDir := filepath.Join(tmpDir, ".git/git-courer", "branches")
@@ -1009,5 +1035,202 @@ func TestFilesystemCommitStore_RemoveAllBranchDirs_Idempotent(t *testing.T) {
 	err = store.RemoveAllBranchDirs()
 	if err != nil {
 		t.Errorf("RemoveAllBranchDirs() second call should return nil, got: %v", err)
+	}
+}
+
+// --- Phase 3.3: workspace storage tests ---
+
+// writeWorkspaceStore writes entries to a workspace/<id>/commits.json file
+// under the store's baseDir. Used to set up workspace/ data for
+// ReadAllWorkspaces tests.
+func writeWorkspaceStore(t *testing.T, tmpDir, workspaceID string, entries []domain.CommitEntry) {
+	t.Helper()
+	workspaceDir := filepath.Join(tmpDir, ".git/git-courer", "workspace", workspaceID)
+	if err := os.MkdirAll(workspaceDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error: %v", workspaceDir, err)
+	}
+	var jEntries []jsonEntry
+	for _, e := range entries {
+		jEntries = append(jEntries, jsonEntry{
+			SHA:     e.SHA(),
+			Message: e.Message(),
+			Author:  e.Author(),
+			Date:    e.Date(),
+			Branch:  e.Branch(),
+		})
+	}
+	data, err := json.MarshalIndent(jEntries, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent error: %v", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(filepath.Join(workspaceDir, "commits.json"), data, 0o644); err != nil {
+		t.Fatalf("WriteFile error: %v", err)
+	}
+}
+
+func TestFilesystemCommitStore_ReadAllWorkspaces_EmptyDir(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	store := NewFilesystemCommitStore(tmpDir, nil)
+
+	result, err := store.ReadAllWorkspaces()
+	if err != nil {
+		t.Fatalf("ReadAllWorkspaces() on empty dir returned error: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("ReadAllWorkspaces() on empty dir returned %d workspaces, want 0", len(result))
+	}
+}
+
+func TestFilesystemCommitStore_ReadAllWorkspaces_SingleWorkspace(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	store := NewFilesystemCommitStore(tmpDir, nil)
+
+	uuid := "a1b2c3d4-e5f6-4789-8a01-234567890abc"
+	e1 := makeEntry(t, validSHA("a1000000000000000000000000000000000000"), "feat: first")
+	e2 := makeEntry(t, validSHA("b2000000000000000000000000000000000000"), "fix: second")
+	writeWorkspaceStore(t, tmpDir, uuid, []domain.CommitEntry{e1, e2})
+
+	result, err := store.ReadAllWorkspaces()
+	if err != nil {
+		t.Fatalf("ReadAllWorkspaces() error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("ReadAllWorkspaces() returned %d workspaces, want 1", len(result))
+	}
+	entries, ok := result[uuid]
+	if !ok {
+		t.Fatalf("ReadAllWorkspaces() missing %q workspace", uuid)
+	}
+	if len(entries) != 2 {
+		t.Errorf("ReadAllWorkspaces()[%q] returned %d entries, want 2", uuid, len(entries))
+	}
+}
+
+func TestFilesystemCommitStore_ReadAllWorkspaces_MultipleWorkspaces(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	store := NewFilesystemCommitStore(tmpDir, nil)
+
+	uuidA := "11111111-1111-4111-8111-111111111111"
+	uuidB := "22222222-2222-4222-8222-222222222222"
+	writeWorkspaceStore(t, tmpDir, uuidA, []domain.CommitEntry{
+		makeEntry(t, validSHA("a1000000000000000000000000000000000000"), "feat: a"),
+	})
+	writeWorkspaceStore(t, tmpDir, uuidB, []domain.CommitEntry{
+		makeEntry(t, validSHA("b2000000000000000000000000000000000000"), "fix: b"),
+	})
+
+	result, err := store.ReadAllWorkspaces()
+	if err != nil {
+		t.Fatalf("ReadAllWorkspaces() error: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("ReadAllWorkspaces() returned %d workspaces, want 2", len(result))
+	}
+	if _, ok := result[uuidA]; !ok {
+		t.Errorf("ReadAllWorkspaces() missing %q", uuidA)
+	}
+	if _, ok := result[uuidB]; !ok {
+		t.Errorf("ReadAllWorkspaces() missing %q", uuidB)
+	}
+}
+
+func TestFilesystemCommitStore_RemoveAllWorkspaceDirs_RemovesDir(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	store := NewFilesystemCommitStore(tmpDir, nil)
+
+	// Create workspace directories
+	uuidA := "11111111-1111-4111-8111-111111111111"
+	uuidB := "22222222-2222-4222-8222-222222222222"
+	writeWorkspaceStore(t, tmpDir, uuidA, []domain.CommitEntry{
+		makeEntry(t, validSHA("a1000000000000000000000000000000000000"), "feat: a"),
+	})
+	writeWorkspaceStore(t, tmpDir, uuidB, []domain.CommitEntry{
+		makeEntry(t, validSHA("b2000000000000000000000000000000000000"), "feat: b"),
+	})
+
+	workspacesDir := filepath.Join(tmpDir, ".git/git-courer", "workspace")
+	if _, err := os.Stat(workspacesDir); os.IsNotExist(err) {
+		t.Fatalf("workspace directory should exist before RemoveAllWorkspaceDirs")
+	}
+
+	err := store.RemoveAllWorkspaceDirs()
+	if err != nil {
+		t.Fatalf("RemoveAllWorkspaceDirs() error: %v", err)
+	}
+
+	if _, err := os.Stat(workspacesDir); !os.IsNotExist(err) {
+		t.Errorf("workspace directory should not exist after RemoveAllWorkspaceDirs")
+	}
+}
+
+func TestFilesystemCommitStore_RemoveAllWorkspaceDirs_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	store := NewFilesystemCommitStore(tmpDir, nil)
+
+	err := store.RemoveAllWorkspaceDirs()
+	if err != nil {
+		t.Errorf("RemoveAllWorkspaceDirs() on non-existent dir should return nil, got: %v", err)
+	}
+
+	err = store.RemoveAllWorkspaceDirs()
+	if err != nil {
+		t.Errorf("RemoveAllWorkspaceDirs() second call should return nil, got: %v", err)
+	}
+}
+
+func TestFilesystemCommitStore_jsonEntry_BranchRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	store := NewFilesystemCommitStore(tmpDir, nil)
+
+	// Append an entry WITH a branch; verify it round-trips through the file.
+	entry := makeEntry(t, validSHA("a1000000000000000000000000000000000000"), "feat: with branch",
+		domain.WithBranch("feature/foo"))
+	if err := store.Append(entry); err != nil {
+		t.Fatalf("Append() error: %v", err)
+	}
+
+	entries, err := store.Read()
+	if err != nil {
+		t.Fatalf("Read() error: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("Read() returned %d entries, want 1", len(entries))
+	}
+	if got := entries[0].Branch(); got != "feature/foo" {
+		t.Errorf("entries[0].Branch() = %q, want %q", got, "feature/foo")
+	}
+}
+
+func TestFilesystemCommitStore_entriesEqual_BranchDifference(t *testing.T) {
+	t.Parallel()
+
+	store := NewFilesystemCommitStore(t.TempDir(), nil)
+
+	sha := validSHA("a1000000000000000000000000000000000000")
+	withBranchA := makeEntry(t, sha, "feat: same", domain.WithBranch("branch-a"))
+	withBranchB := makeEntry(t, sha, "feat: same", domain.WithBranch("branch-b"))
+	noBranch := makeEntry(t, sha, "feat: same")
+
+	if store.entriesEqual([]domain.CommitEntry{withBranchA}, []domain.CommitEntry{withBranchB}) {
+		t.Error("entriesEqual should return false when branches differ")
+	}
+	if store.entriesEqual([]domain.CommitEntry{withBranchA}, []domain.CommitEntry{noBranch}) {
+		t.Error("entriesEqual should return false when one entry has branch and the other does not")
+	}
+	if !store.entriesEqual([]domain.CommitEntry{withBranchA}, []domain.CommitEntry{withBranchA}) {
+		t.Error("entriesEqual should return true when entries are identical including branch")
 	}
 }

--- a/internal/adapters/commitstore/sanitize.go
+++ b/internal/adapters/commitstore/sanitize.go
@@ -2,7 +2,35 @@
 // that persists commit entries as JSONL in .git/git-courer/commits.json.
 package commitstore
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
+
+// uuidPattern matches RFC 4122 form: 8-4-4-4-12 hex digits.
+var uuidPattern = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+
+// isUUID reports whether workspaceID is a valid RFC 4122 UUID string.
+// It is used by SetWorkspace to decide whether sanitization can be skipped
+// (UUIDs are already filesystem-safe).
+func isUUID(workspaceID string) bool {
+	return uuidPattern.MatchString(workspaceID)
+}
+
+// SanitizeBranchName converts a git branch name into a safe directory name.
+// It is the single source of truth for branch-name sanitization; callers
+// (e.g. workflow/release.go) MUST import and reuse this instead of keeping
+// private duplicates.
+//
+// Rules:
+//   - Replace '/' with '-'
+//   - Remove '~', '^', ':', '\\', ' ' (space)
+//   - Collapse consecutive '-' into single '-'
+//   - Trim leading/trailing '-'
+//   - If result is empty, return "HEAD"
+func SanitizeBranchName(name string) string {
+	return sanitizeBranchName(name)
+}
 
 // sanitizeBranchName converts a git branch name into a safe directory name.
 // Rules:

--- a/internal/adapters/commitstore/sanitize_test.go
+++ b/internal/adapters/commitstore/sanitize_test.go
@@ -112,3 +112,60 @@ func TestSanitizeBranchName(t *testing.T) {
 		})
 	}
 }
+
+func TestSanitizeBranchName_Exported(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"simple branch", "main", "main"},
+		{"feature slash", "feature/foo", "feature-foo"},
+		{"nested slashes", "feature/auth/login", "feature-auth-login"},
+		{"empty returns HEAD", "", "HEAD"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := SanitizeBranchName(tt.input)
+			if got != tt.want {
+				t.Errorf("SanitizeBranchName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsUUID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"valid lowercase UUID", "a1b2c3d4-e5f6-4789-8a01-234567890abc", true},
+		{"valid uppercase UUID", "A1B2C3D4-E5F6-4789-8A01-234567890ABC", true},
+		{"valid mixed case UUID", "a1B2c3D4-e5F6-4789-8a01-234567890AbC", true},
+		{"branch name is not UUID", "feature/foo", false},
+		{"simple branch is not UUID", "main", false},
+		{"empty string is not UUID", "", false},
+		{"uuid missing dashes is not UUID", "a1b2c3d4e5f647898a01234567890abc", false},
+		{"uuid wrong segment lengths is not UUID", "a1b2c3d4-e5f6-478-8a01-234567890abc", false},
+		{"uuid with invalid hex is not UUID", "g1b2c3d4-e5f6-4789-8a01-234567890abc", false},
+		{"uuid too many segments is not UUID", "a1b2c3d4-e5f6-4789-8a01-234567890abc-extra", false},
+		{"uuid with braces is not UUID", "{a1b2c3d4-e5f6-4789-8a01-234567890abc}", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := isUUID(tt.input)
+			if got != tt.want {
+				t.Errorf("isUUID(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/core/domain/commit_entry.go
+++ b/internal/core/domain/commit_entry.go
@@ -18,6 +18,7 @@ var (
 type commitEntryConfig struct {
 	author string
 	date   string
+	branch string
 }
 
 // CommitEntryOption is a functional option for CommitEntry construction.
@@ -37,6 +38,15 @@ func WithDate(d string) CommitEntryOption {
 	}
 }
 
+// WithBranch sets the branch on a CommitEntry. When unset, Branch() returns
+// the empty string. It follows the same functional-option pattern as WithAuthor
+// and WithDate.
+func WithBranch(branch string) CommitEntryOption {
+	return func(c *commitEntryConfig) {
+		c.branch = branch
+	}
+}
+
 // CommitEntry is a value object representing structured commit metadata.
 // It is immutable after construction — all fields are accessed via getters.
 // Construction validates SHA and Message; invalid input returns an error.
@@ -45,12 +55,13 @@ type CommitEntry struct {
 	message string
 	author  string
 	date    string
+	branch  string
 }
 
 // NewCommitEntry constructs a CommitEntry with validation.
 // SHA must be exactly 40 hexadecimal characters.
 // Message must be non-empty (after trimming whitespace).
-// Author and Date are optional, set via CommitEntryOption.
+// Author, Date, and Branch are optional, set via CommitEntryOption.
 func NewCommitEntry(sha, message string, opts ...CommitEntryOption) (CommitEntry, error) {
 	if !isValidSHA(sha) {
 		return CommitEntry{}, ErrInvalidSHA
@@ -69,6 +80,7 @@ func NewCommitEntry(sha, message string, opts ...CommitEntryOption) (CommitEntry
 		message: message,
 		author:  cfg.author,
 		date:    cfg.date,
+		branch:  cfg.branch,
 	}, nil
 }
 
@@ -101,6 +113,9 @@ func (e CommitEntry) Author() string { return e.author }
 
 // Date returns the commit date in RFC 3339 format (may be empty if not set).
 func (e CommitEntry) Date() string { return e.date }
+
+// Branch returns the branch the commit was captured on (may be empty if not set).
+func (e CommitEntry) Branch() string { return e.branch }
 
 // String returns a human-readable representation of the CommitEntry.
 func (e CommitEntry) String() string {

--- a/internal/core/domain/commit_entry_test.go
+++ b/internal/core/domain/commit_entry_test.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -272,6 +273,147 @@ func TestMessages(t *testing.T) {
 		result := Messages(nil)
 		if result != nil {
 			t.Errorf("Messages(nil) = %v, want nil", result)
+		}
+	})
+}
+
+func TestWithBranch(t *testing.T) {
+	t.Parallel()
+
+	validSHA := "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+	message := "feat: add feature"
+
+	t.Run("WithBranch sets Branch field", func(t *testing.T) {
+		t.Parallel()
+		entry, err := NewCommitEntry(validSHA, message, WithBranch("feature/foo"))
+		if err != nil {
+			t.Fatalf("NewCommitEntry with WithBranch returned unexpected error: %v", err)
+		}
+		if got := entry.Branch(); got != "feature/foo" {
+			t.Errorf("entry.Branch() = %q, want %q", got, "feature/foo")
+		}
+	})
+
+	t.Run("WithBranch empty string yields zero-value Branch", func(t *testing.T) {
+		t.Parallel()
+		entry, err := NewCommitEntry(validSHA, message, WithBranch(""))
+		if err != nil {
+			t.Fatalf("NewCommitEntry with WithBranch(\"\") returned unexpected error: %v", err)
+		}
+		if got := entry.Branch(); got != "" {
+			t.Errorf("entry.Branch() = %q, want empty string", got)
+		}
+	})
+
+	t.Run("no WithBranch yields empty Branch", func(t *testing.T) {
+		t.Parallel()
+		entry, err := NewCommitEntry(validSHA, message)
+		if err != nil {
+			t.Fatalf("NewCommitEntry without WithBranch returned unexpected error: %v", err)
+		}
+		if got := entry.Branch(); got != "" {
+			t.Errorf("entry.Branch() = %q, want empty string", got)
+		}
+	})
+
+	t.Run("WithBranch composes with WithAuthor and WithDate", func(t *testing.T) {
+		t.Parallel()
+		entry, err := NewCommitEntry(validSHA, message,
+			WithAuthor("Jane"),
+			WithDate("2026-01-01T00:00:00Z"),
+			WithBranch("feature/bar"),
+		)
+		if err != nil {
+			t.Fatalf("NewCommitEntry returned unexpected error: %v", err)
+		}
+		if got := entry.Branch(); got != "feature/bar" {
+			t.Errorf("entry.Branch() = %q, want %q", got, "feature/bar")
+		}
+		if got := entry.Author(); got != "Jane" {
+			t.Errorf("entry.Author() = %q, want %q", got, "Jane")
+		}
+		if got := entry.Date(); got != "2026-01-01T00:00:00Z" {
+			t.Errorf("entry.Date() = %q, want %q", got, "2026-01-01T00:00:00Z")
+		}
+	})
+}
+
+func TestCommitEntry_Branch_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	validSHA := "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+
+	t.Run("branch round-trips through JSON via jsonEntry.Branch", func(t *testing.T) {
+		t.Parallel()
+		entry, err := NewCommitEntry(validSHA, "feat: add feature",
+			WithAuthor("John"),
+			WithDate("2026-05-23T12:00:00Z"),
+			WithBranch("feature/foo"),
+		)
+		if err != nil {
+			t.Fatalf("NewCommitEntry returned unexpected error: %v", err)
+		}
+
+		// Marshal a jsonEntry-shaped object mirroring the adapter's serialization.
+		type jsonEntry struct {
+			SHA     string `json:"sha"`
+			Message string `json:"message"`
+			Author  string `json:"author"`
+			Date    string `json:"date"`
+			Branch  string `json:"branch"`
+		}
+		je := jsonEntry{
+			SHA:     entry.SHA(),
+			Message: entry.Message(),
+			Author:  entry.Author(),
+			Date:    entry.Date(),
+			Branch:  entry.Branch(),
+		}
+		data, err := json.Marshal(je)
+		if err != nil {
+			t.Fatalf("json.Marshal returned unexpected error: %v", err)
+		}
+
+		var decoded jsonEntry
+		if err := json.Unmarshal(data, &decoded); err != nil {
+			t.Fatalf("json.Unmarshal returned unexpected error: %v", err)
+		}
+		if decoded.Branch != "feature/foo" {
+			t.Errorf("decoded.Branch = %q, want %q", decoded.Branch, "feature/foo")
+		}
+		// Verify the JSON text itself carries the branch field.
+		if !strings.Contains(string(data), `"branch":"feature/foo"`) {
+			t.Errorf("JSON payload %q does not contain branch field", string(data))
+		}
+	})
+
+	t.Run("unset branch marshals to empty string", func(t *testing.T) {
+		t.Parallel()
+		entry, err := NewCommitEntry(validSHA, "feat: add feature")
+		if err != nil {
+			t.Fatalf("NewCommitEntry returned unexpected error: %v", err)
+		}
+
+		type jsonEntry struct {
+			SHA     string `json:"sha"`
+			Message string `json:"message"`
+			Author  string `json:"author"`
+			Date    string `json:"date"`
+			Branch  string `json:"branch"`
+		}
+		je := jsonEntry{
+			SHA:     entry.SHA(),
+			Message: entry.Message(),
+			Author:  entry.Author(),
+			Date:    entry.Date(),
+			Branch:  entry.Branch(),
+		}
+		data, err := json.Marshal(je)
+		if err != nil {
+			t.Fatalf("json.Marshal returned unexpected error: %v", err)
+		}
+		if !strings.Contains(string(data), `"branch":""`) {
+			t.Errorf("JSON payload %q should contain empty branch field", string(data))
 		}
 	})
 }

--- a/internal/core/ports/commit_store.go
+++ b/internal/core/ports/commit_store.go
@@ -8,12 +8,16 @@ import "github.com/blak0p/git-courer/internal/core/domain"
 // after every release, so all entries belong to the current cycle),
 // and Clear empties the store after a successful release.
 //
-// SetBranch switches the store to a branch-scoped path:
+// SetWorkspace switches the store to a workspace-scoped path:
 //
-//	.git/git-courer/branches/<sanitized>/commits.json
+//	.git/git-courer/workspace/<id>/commits.json
 //
-// If SetBranch is never called, the store uses the legacy global
-// path .git/git-courer/commits.json.
+// where <id> is the active session ID (a UUID, passed unchanged) or,
+// when no session is active, the current branch name (sanitized).
+// SetBranchRef sets the branch used for the refs/courer/<branch> ref
+// update; it is separate from SetWorkspace because ref naming must
+// stay branch-keyed for push/pull while the workspace UUID is
+// meaningless as a ref name.
 //
 // RemoveBranch deletes the branch's store directory and all contents.
 type CommitStore interface {
@@ -28,18 +32,31 @@ type CommitStore interface {
 	// If the store is already empty, returns no error.
 	Clear() error
 
-	// SetBranch switches the store to read/write from a branch-scoped path:
-	//   .git/git-courer/branches/<sanitized>/commits.json
-	// If name is empty, returns an error.
-	// After calling SetBranch, Append/Read/Clear operate on the branch path.
+	// SetWorkspace switches the store to read/write from a workspace-scoped path:
+	//   .git/git-courer/workspace/<id>/commits.json
+	// The id is sanitized conditionally: a valid UUID passes unchanged; a non-UUID
+	// (e.g. a branch name) is sanitized via the adapter's branch-name sanitizer.
+	// If id is empty, returns an error.
+	// After calling SetWorkspace, Append/Read/Clear operate on the workspace path.
 	// Thread-safe: serialized by the adapter's mutex.
-	SetBranch(name string) error
+	SetWorkspace(workspaceID string) error
+
+	// SetBranchRef sets the branch name used for the refs/courer/<branch> ref
+	// update that accompanies Append. It is separate from SetWorkspace because
+	// ref naming must stay branch-keyed for push/pull while the workspace UUID
+	// is meaningless as a ref name. Empty branch disables the ref update.
+	// Thread-safe: serialized by the adapter's mutex.
+	SetBranchRef(branch string) error
 
 	// RemoveBranch removes the branch's store directory and all contents:
 	//   .git/git-courer/branches/<sanitized>/
 	// If the directory does not exist, returns nil (idempotent).
 	// If name is empty, returns an error.
 	// Thread-safe: serialized by the adapter's mutex.
+	//
+	// DEPRECATED: branches/ storage is kept for passive coexistence only.
+	// New captures write to workspace/ instead. Removal is a no-op for
+	// workspace-keyed stores.
 	RemoveBranch(name string) error
 
 	// Reconcile reconciles the store's entries with the current git log.
@@ -49,13 +66,27 @@ type CommitStore interface {
 	Reconcile(gitEntries []domain.CommitEntry) error
 
 	// ReadAllBranches returns all stored CommitEntry values from all branch stores.
-	// Returns entries deduplicated by SHA (first occurrence wins).
-	// Returns an empty slice (not nil) if no entries exist across any branch.
-	// Returns an error only if scanning fails or the branch directory structure is corrupt.
+	// Returns a map of branch name → entries. If no branches exist, returns
+	// an empty map with no error.
+	//
+	// DEPRECATED: branches/ storage is kept for passive coexistence only.
+	// Use ReadAllWorkspaces for new workspace-keyed captures.
 	ReadAllBranches() (map[string][]domain.CommitEntry, error)
 
 	// RemoveAllBranchDirs removes all branch directories under .git/git-courer/branches/.
 	// It is idempotent: if no directories exist, it returns nil.
 	// It removes the entire branches/ directory tree, not individual branch directories.
+	//
+	// DEPRECATED: branches/ storage is kept for passive coexistence only.
 	RemoveAllBranchDirs() error
+
+	// ReadAllWorkspaces returns all stored CommitEntry values from all workspace stores.
+	// Returns a map of workspace id → entries. If no workspaces exist, returns
+	// an empty map with no error. Malformed directories are skipped with a log warning.
+	ReadAllWorkspaces() (map[string][]domain.CommitEntry, error)
+
+	// RemoveAllWorkspaceDirs removes all workspace directories under
+	// .git/git-courer/workspace/. It is idempotent: if no directories exist,
+	// it returns nil. It removes the entire workspace/ directory tree.
+	RemoveAllWorkspaceDirs() error
 }

--- a/internal/core/ports/commit_store_test.go
+++ b/internal/core/ports/commit_store_test.go
@@ -23,7 +23,11 @@ func (m *mockCommitStore) Clear() error {
 	return m.clearErr
 }
 
-func (m *mockCommitStore) SetBranch(name string) error {
+func (m *mockCommitStore) SetWorkspace(workspaceID string) error {
+	return nil
+}
+
+func (m *mockCommitStore) SetBranchRef(branch string) error {
 	return nil
 }
 
@@ -45,6 +49,14 @@ func (m *mockCommitStore) ReadAllBranches() (map[string][]domain.CommitEntry, er
 }
 
 func (m *mockCommitStore) RemoveAllBranchDirs() error {
+	return nil
+}
+
+func (m *mockCommitStore) ReadAllWorkspaces() (map[string][]domain.CommitEntry, error) {
+	return make(map[string][]domain.CommitEntry), nil
+}
+
+func (m *mockCommitStore) RemoveAllWorkspaceDirs() error {
 	return nil
 }
 

--- a/internal/core/ports/pr_matcher.go
+++ b/internal/core/ports/pr_matcher.go
@@ -1,0 +1,14 @@
+package ports
+
+// PRMatcher matches branch names to their associated pull request numbers.
+//
+// This is a v2.8.0 interface contract stub. The real implementation is
+// deferred; for now the no-op stub returns zero matches for every branch.
+// Downstream code MUST treat an empty result as "no PR associated" and
+// degrade gracefully.
+type PRMatcher interface {
+	// MatchBranch returns the PR numbers associated with the given branch.
+	// Returns an empty (non-nil) slice when no PRs match. An error is
+	// returned only on infrastructure failure (not on "no match").
+	MatchBranch(branch string) ([]int, error)
+}

--- a/internal/core/ports/pr_matcher_test.go
+++ b/internal/core/ports/pr_matcher_test.go
@@ -1,0 +1,43 @@
+package ports
+
+import "testing"
+
+// stubPRMatcher is a no-op implementation of PRMatcher for testing.
+type stubPRMatcher struct{}
+
+func (m *stubPRMatcher) MatchBranch(branch string) ([]int, error) {
+	return []int{}, nil
+}
+
+func TestPRMatcher_Stub_ReturnsEmpty(t *testing.T) {
+	m := &stubPRMatcher{}
+
+	result, err := m.MatchBranch("feature/any-branch")
+	if err != nil {
+		t.Fatalf("MatchBranch() returned unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Error("MatchBranch() returned nil slice, want non-nil empty slice")
+	}
+	if len(result) != 0 {
+		t.Errorf("MatchBranch() returned %d PRs, want 0", len(result))
+	}
+}
+
+func TestPRMatcher_Stub_ReturnsEmptyForAllBranches(t *testing.T) {
+	m := &stubPRMatcher{}
+
+	branches := []string{"main", "feature/foo", "fix/bar", "chore/baz", ""}
+	for _, branch := range branches {
+		result, err := m.MatchBranch(branch)
+		if err != nil {
+			t.Errorf("MatchBranch(%q) returned error: %v", branch, err)
+		}
+		if len(result) != 0 {
+			t.Errorf("MatchBranch(%q) returned %d PRs, want 0", branch, len(result))
+		}
+	}
+}
+
+// Compile-time check that stubPRMatcher implements PRMatcher.
+var _ PRMatcher = (*stubPRMatcher)(nil)

--- a/internal/delivery/cli/release.go
+++ b/internal/delivery/cli/release.go
@@ -58,7 +58,7 @@ func NewReleaseCommand(git ports.Git, llm ports.LLM, cfg *config.Config, commitS
 	}
 }
 
-// InitBranchScoping scopes the commit store to the given branch.
+// InitBranchScoping scopes the commit store to the given branch/workspace id.
 // If branch is empty (detached HEAD), the store uses the legacy global path.
 // The caller is responsible for obtaining the current branch name
 // (typically via git.CurrentBranch()).
@@ -67,8 +67,8 @@ func (c *ReleaseCommand) InitBranchScoping(branch string) {
 		// Detached HEAD — use legacy global path
 		return
 	}
-	if err := c.commitStore.SetBranch(branch); err != nil {
-		fmt.Fprintf(os.Stderr, "Warning: failed to set branch store: %v\n", err)
+	if err := c.commitStore.SetWorkspace(branch); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to set workspace store: %v\n", err)
 	}
 }
 

--- a/internal/delivery/cli/release_test.go
+++ b/internal/delivery/cli/release_test.go
@@ -138,8 +138,11 @@ func (m *mockCommitStoreForCLI) Clear() error {
 	m.appended = nil
 	return nil
 }
-func (m *mockCommitStoreForCLI) SetBranch(name string) error {
-	m.branchSet = name
+func (m *mockCommitStoreForCLI) SetWorkspace(workspaceID string) error {
+	m.branchSet = workspaceID
+	return nil
+}
+func (m *mockCommitStoreForCLI) SetBranchRef(branch string) error {
 	return nil
 }
 func (m *mockCommitStoreForCLI) RemoveBranch(name string) error {
@@ -163,6 +166,14 @@ func (m *mockCommitStoreForCLI) RemoveAllBranchDirs() error {
 	return nil
 }
 
+func (m *mockCommitStoreForCLI) ReadAllWorkspaces() (map[string][]domain.CommitEntry, error) {
+	return make(map[string][]domain.CommitEntry), nil
+}
+
+func (m *mockCommitStoreForCLI) RemoveAllWorkspaceDirs() error {
+	return nil
+}
+
 // Compile-time check
 var _ ports.CommitStore = (*mockCommitStoreForCLI)(nil)
 
@@ -176,7 +187,7 @@ func TestReleaseCommand_DetachedHEAD_UsesGlobalStore(t *testing.T) {
 	cmd.InitBranchScoping("") // empty branch = detached HEAD
 
 	if store.branchSet != "" {
-		t.Errorf("SetBranch should NOT be called on detached HEAD, but got branchSet = %q", store.branchSet)
+		t.Errorf("SetWorkspace should NOT be called on detached HEAD, but got branchSet = %q", store.branchSet)
 	}
 }
 
@@ -186,7 +197,7 @@ func TestReleaseCommand_BranchSet_ScopesStore(t *testing.T) {
 	cmd.InitBranchScoping("feat/auth")
 
 	if store.branchSet != "feat/auth" {
-		t.Errorf("SetBranch should be called with 'feat/auth', got %q", store.branchSet)
+		t.Errorf("SetWorkspace should be called with 'feat/auth', got %q", store.branchSet)
 	}
 }
 
@@ -194,11 +205,11 @@ func TestReleaseCommand_InitBranchScoping_ErrorBranch(t *testing.T) {
 	store := &mockCommitStoreForCLI{}
 	cmd := NewReleaseCommand(nil, nil, nil, store, "/tmp")
 
-	// Empty string = detached HEAD = no SetBranch call
+	// Empty string = detached HEAD = no SetWorkspace call
 	cmd.InitBranchScoping("")
 
 	if store.branchSet != "" {
-		t.Errorf("SetBranch should NOT be called on empty branch, got %q", store.branchSet)
+		t.Errorf("SetWorkspace should NOT be called on empty branch, got %q", store.branchSet)
 	}
 }
 
@@ -206,12 +217,12 @@ func TestReleaseCommand_InitBranchScoping_SpecialCharacterBranch(t *testing.T) {
 	store := &mockCommitStoreForCLI{}
 	cmd := NewReleaseCommand(nil, nil, nil, store, "/tmp")
 
-	// Branch with slash — SetBranch is called with raw name.
+	// Branch with slash — SetWorkspace is called with raw name.
 	// The FilesystemCommitStore adapter sanitizes it internally.
 	cmd.InitBranchScoping("feat/auth")
 
 	if store.branchSet != "feat/auth" {
-		t.Errorf("SetBranch should be called with 'feat/auth', got %q", store.branchSet)
+		t.Errorf("SetWorkspace should be called with 'feat/auth', got %q", store.branchSet)
 	}
 }
 
@@ -444,12 +455,12 @@ func TestReleaseCommand_Interactive_CustomTag(t *testing.T) {
 
 // --- Integration tests — release clears branch store ---
 
-func TestReleaseCommand_Apply_ClearsBranchStore(t *testing.T) {
-	// AC-2.5: After `gcourer release apply` on `feat/auth`,
-	// `.git-courer/branches/feat-auth/commits.json` is empty.
+func TestReleaseCommand_Apply_ClearsWorkspaceStore(t *testing.T) {
+	// After `gcourer release apply` on `feat/auth`,
+	// `.git/git-courer/workspace/feat-auth/commits.json` is empty.
 	dir := t.TempDir()
 	store := commitstore.NewFilesystemCommitStore(dir, nil)
-	store.SetBranch("feat/auth")
+	store.SetWorkspace("feat/auth")
 
 	// Write some entries
 	entry, _ := domain.NewCommitEntry("a1b2c3d4e5f6071829a0b1c2d3e4f50617283940", "feat: new feature")
@@ -482,15 +493,15 @@ func TestReleaseCommand_Apply_ClearsBranchStore(t *testing.T) {
 }
 
 func TestReleaseCommand_ReleaseOnBranchDoesNotClearOtherBranch(t *testing.T) {
-	// AC-4.4: Other branches' stores are NOT cleared by a release on a different branch
+	// Other workspaces' stores are NOT cleared by a release on a different workspace
 	dir := t.TempDir()
 
-	// Create two branch stores
+	// Create two workspace stores
 	featStore := commitstore.NewFilesystemCommitStore(dir, nil)
-	featStore.SetBranch("feat/auth")
+	featStore.SetWorkspace("feat/auth")
 
 	mainStore := commitstore.NewFilesystemCommitStore(dir, nil)
-	mainStore.SetBranch("main")
+	mainStore.SetWorkspace("main")
 
 	// Write entries on feat/auth
 	featEntry, _ := domain.NewCommitEntry("a1b2c3d4e5f6071829a0b1c2d3e4f50617283940", "feat: auth feature")
@@ -531,14 +542,14 @@ func TestReleaseCommand_ReleaseOnBranchDoesNotClearOtherBranch(t *testing.T) {
 	}
 }
 
-func TestReleaseCommand_BranchStoreAfterSetBranchAndAppend(t *testing.T) {
-	// AC-2.9: On `feat/auth` branch, release creates tag and clears
-	// `.git-courer/branches/feat-auth/commits.json`
+func TestReleaseCommand_WorkspaceStoreAfterSetWorkspaceAndAppend(t *testing.T) {
+	// On `feat/auth` branch, release creates tag and clears
+	// `.git/git-courer/workspace/feat-auth/commits.json`
 	// This test verifies the store path resolution.
 	dir := t.TempDir()
 
 	store := commitstore.NewFilesystemCommitStore(dir, nil)
-	store.SetBranch("feat/auth")
+	store.SetWorkspace("feat/auth")
 
 	// Append and verify
 	entry, _ := domain.NewCommitEntry("a1b2c3d4e5f6071829a0b1c2d3e4f50617283940", "feat: something")

--- a/internal/delivery/mcp/core/commit_handler.go
+++ b/internal/delivery/mcp/core/commit_handler.go
@@ -315,12 +315,24 @@ func (h *Handler) handlePreview(ctx context.Context, params map[string]any, why 
 		}
 	}
 
-	// 2. Resolve branch and reconcile commit store
+	// 2. Resolve workspace and reconcile commit store
 	if store := h.commitSvc.CommitStore(); store != nil {
+		// Resolve the workspace id with the same logic as capture (active session
+		// id, else current branch) so the preview reflects the same group the
+		// release will generate.
+		workspaceID := h.commitSvc.ResolveWorkspace()
+		if workspaceID != "" {
+			if err := store.SetWorkspace(workspaceID); err != nil {
+				log.Printf("[WARN] Failed to set workspace store for %q: %v", workspaceID, err)
+			}
+		}
 		currentBranch, err := h.git.CurrentBranch()
-		if err == nil && currentBranch != "" {
-			if err := store.SetBranch(currentBranch); err != nil {
-				log.Printf("[WARN] Failed to set branch store for %q: %v", currentBranch, err)
+		if err != nil {
+			currentBranch = ""
+		}
+		if currentBranch != "" {
+			if err := store.SetBranchRef(currentBranch); err != nil {
+				log.Printf("[WARN] Failed to set branch ref for %q: %v", currentBranch, err)
 			}
 		}
 

--- a/internal/delivery/mcp/core/handler_test.go
+++ b/internal/delivery/mcp/core/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1627,8 +1628,13 @@ func (m *mockCommitStore) Clear() error {
 	return args.Error(0)
 }
 
-func (m *mockCommitStore) SetBranch(name string) error {
-	args := m.Called(name)
+func (m *mockCommitStore) SetWorkspace(workspaceID string) error {
+	args := m.Called(workspaceID)
+	return args.Error(0)
+}
+
+func (m *mockCommitStore) SetBranchRef(branch string) error {
+	args := m.Called(branch)
 	return args.Error(0)
 }
 
@@ -1648,6 +1654,16 @@ func (m *mockCommitStore) ReadAllBranches() (map[string][]domain.CommitEntry, er
 }
 
 func (m *mockCommitStore) RemoveAllBranchDirs() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *mockCommitStore) ReadAllWorkspaces() (map[string][]domain.CommitEntry, error) {
+	args := m.Called()
+	return args.Get(0).(map[string][]domain.CommitEntry), args.Error(1)
+}
+
+func (m *mockCommitStore) RemoveAllWorkspaceDirs() error {
 	args := m.Called()
 	return args.Error(0)
 }
@@ -1674,7 +1690,8 @@ func TestHandlePreview_StagesMetadataAndReconciles(t *testing.T) {
 
 	// Set up commit store mock:
 	mStore := new(mockCommitStore)
-	mStore.On("SetBranch", "feat/test-branch").Return(nil)
+	mStore.On("SetWorkspace", "feat/test-branch").Return(nil)
+	mStore.On("SetBranchRef", "feat/test-branch").Return(nil)
 
 	expectedEntry, _ := domain.NewCommitEntry("a1b2c3d4e5f6071829a0b1c2d3e4f50617283940", "feat: test message", domain.WithAuthor("author"), domain.WithDate("2026-05-31"))
 	mStore.On("Reconcile", []domain.CommitEntry{expectedEntry}).Return(nil)
@@ -1733,7 +1750,8 @@ func TestHandlePreview_BaseBranchConfigured_UsesMergeBase(t *testing.T) {
 	mGit.On("DiffStaged", mock.Anything).Return("diff --git a/auth.go b/auth.go\n+added line", nil)
 
 	mStore := new(mockCommitStore)
-	mStore.On("SetBranch", "feature/auth").Return(nil)
+	mStore.On("SetWorkspace", "feature/auth").Return(nil)
+	mStore.On("SetBranchRef", "feature/auth").Return(nil)
 	expectedEntry, _ := domain.NewCommitEntry("abc123def4560000000000000000000000000001", "feat: add auth", domain.WithAuthor("Alice"), domain.WithDate("2026-06-01"))
 	mStore.On("Reconcile", []domain.CommitEntry{expectedEntry}).Return(nil)
 
@@ -1792,7 +1810,8 @@ func TestHandlePreview_BaseBranchIsCurrentBranch_SkipsReconciliation(t *testing.
 	mGit.On("DiffStaged", mock.Anything).Return("diff --git a/main.go b/main.go\n+added line", nil)
 
 	mStore := new(mockCommitStore)
-	mStore.On("SetBranch", "main").Return(nil)
+	mStore.On("SetWorkspace", "main").Return(nil)
+	mStore.On("SetBranchRef", "main").Return(nil)
 	// Reconcile should NOT be called when on trunk — no mock setup for it
 
 	mLLM := new(mockLLM)
@@ -1850,7 +1869,8 @@ func TestHandlePreview_BaseBranchEmpty_FallsBackToHardcodedList(t *testing.T) {
 	mGit.On("DiffStaged", mock.Anything).Return("diff --git a/test.go b/test.go\n+added line", nil)
 
 	mStore := new(mockCommitStore)
-	mStore.On("SetBranch", "feature/test").Return(nil)
+	mStore.On("SetWorkspace", "feature/test").Return(nil)
+	mStore.On("SetBranchRef", "feature/test").Return(nil)
 	expectedEntry, _ := domain.NewCommitEntry("abc1230000000000000000000000000000000001", "feat: test", domain.WithAuthor("Alice"), domain.WithDate("2026-06-01"))
 	mStore.On("Reconcile", []domain.CommitEntry{expectedEntry}).Return(nil)
 
@@ -1905,7 +1925,8 @@ func TestHandlePreview_BaseBranchConfigured_MergeBaseError_ReturnsError(t *testi
 	// Log should NOT be called since we return error on MergeBase failure
 
 	mStore := new(mockCommitStore)
-	mStore.On("SetBranch", "feature/auth").Return(nil)
+	mStore.On("SetWorkspace", "feature/auth").Return(nil)
+	mStore.On("SetBranchRef", "feature/auth").Return(nil)
 	// Reconcile should NOT be called since we return error on MergeBase failure
 
 	mLLM := new(mockLLM)
@@ -2016,11 +2037,12 @@ func TestApplyPlumbing_AmendsMetadataAfterCaptureCommit(t *testing.T) {
 	mGit.On("CommitTree", "tree123", "abcd1234567890abcdef1234567890abcdef1234", "feat: test commit").Return("commitHash111111111111111111111111111111", nil)
 	// First UpdateRef: move HEAD to the initial commit
 	mGit.On("UpdateRef", "HEAD", "commitHash111111111111111111111111111111").Return("", nil)
-	// CaptureCommit is called (via commitSvc.CaptureCommit) - needs CurrentBranch for SetBranch
+	// CaptureCommit is called (via commitSvc.CaptureCommit) - needs CurrentBranch for SetWorkspace
 	mGit.On("CurrentBranch").Return("feature/test", nil)
 	mGit.On("ConfigGet", "user.name").Return("Test User", nil)
-	// mStore expects SetBranch and Append (variadic)
-	mStore.On("SetBranch", "feature/test").Return(nil)
+	// mStore expects SetWorkspace, SetBranchRef and Append (variadic)
+	mStore.On("SetWorkspace", "feature/test").Return(nil)
+	mStore.On("SetBranchRef", "feature/test").Return(nil)
 	// Append is variadic: Append(entries ...domain.CommitEntry)
 	// When Called(entries) is used inside the mock, it passes the slice as a single arg
 	mStore.On("Append", mock.AnythingOfType("[]domain.CommitEntry")).Return(nil)
@@ -2386,7 +2408,8 @@ func TestHandlePreview_UnstageMetadataTriangulation_HeadErrorAndResetError(t *te
 
 	// Set up commit store mock:
 	mStore := new(mockCommitStore)
-	mStore.On("SetBranch", "feat/test-branch").Return(nil)
+	mStore.On("SetWorkspace", "feat/test-branch").Return(nil)
+	mStore.On("SetBranchRef", "feat/test-branch").Return(nil)
 
 	expectedEntry, _ := domain.NewCommitEntry("a1b2c3d4e5f6071829a0b1c2d3e4f50617283940", "feat: test message", domain.WithAuthor("author"), domain.WithDate("2026-05-31"))
 	mStore.On("Reconcile", []domain.CommitEntry{expectedEntry}).Return(nil)
@@ -2408,6 +2431,80 @@ func TestHandlePreview_UnstageMetadataTriangulation_HeadErrorAndResetError(t *te
 		workflow.DefaultCommitServiceConfig(4096, 50, t.TempDir()+"/task.log"),
 		mStore,
 	)
+
+	confirm := confirm.NewInMemory(5 * time.Minute)
+	cfg := config.Default()
+	rev := workflow.New(mGit, mLLM, confirm, cfg, commitSvc, nil, mSecurity)
+
+	h := NewHandler(mGit, commitSvc, rev, mLLM, "", nil, nil)
+
+	args := map[string]any{"command": "PREVIEW", "why": "test preview", "target_paths": "."}
+	req := mcpgo.CallToolRequest{Params: mcpgo.CallToolParams{Arguments: args}}
+
+	res, err := h.HandleCommit(context.Background(), req)
+	assert.NoError(t, err)
+	assert.NotNil(t, res)
+
+	mGit.AssertExpectations(t)
+	mStore.AssertExpectations(t)
+}
+
+func TestHandlePreview_WithActiveSession_UsesSessionID(t *testing.T) {
+	mGit := new(mockGit)
+	mGit.On("Add", []string{"."}).Return(nil).Once()
+	mGit.On("CurrentBranch").Return("feature/session-branch", nil)
+
+	// Expectations for Reconcile log fetch:
+	mGit.On("MergeBase", "main", "feature/session-branch").Return("a1b2c3d4", nil)
+	mGit.On("LogRange", "a1b2c3d4", "HEAD").Return("a1b2c3d4e5f6071829a0b1c2d3e4f50617283940|author|2026-05-31|feat: session commit", nil)
+
+	// Staging expectation:
+	mGit.On("Add", []string{domain.MetadataDir}).Return(nil)
+
+	// Normal preview execution expectations:
+	mGit.On("WriteTree").Return("tree123", nil)
+	mGit.On("Head").Return("a1b2c3d4e5f6071829a0b1c2d3e4f50617283940", nil)
+	mGit.On("Reset", "HEAD", domain.MetadataDir).Return("reset output", nil)
+
+	mGit.On("Status").Return(domain.Status{Branch: "feature/session-branch", IsClean: false, Modified: 1, Files: []domain.FileStatus{{Path: "main.go", Status: "M ", Staged: true}}}, nil)
+	mGit.On("DiffStaged", mock.Anything).Return("diff --git a/main.go b/main.go\n+added line", nil)
+
+	// Set up commit store mock — expects session UUID, NOT branch name
+	sessionUUID := "a1b2c3d4-e5f6-4789-8a01-234567890abc"
+	mStore := new(mockCommitStore)
+	mStore.On("SetWorkspace", sessionUUID).Return(nil)
+	mStore.On("SetBranchRef", "feature/session-branch").Return(nil)
+
+	expectedEntry, _ := domain.NewCommitEntry("a1b2c3d4e5f6071829a0b1c2d3e4f50617283940", "feat: session commit", domain.WithAuthor("author"), domain.WithDate("2026-05-31"))
+	mStore.On("Reconcile", []domain.CommitEntry{expectedEntry}).Return(nil)
+
+	mLLM := new(mockLLM)
+	mLLM.On("GenerateChunkMessage", mock.Anything).Return("feat: test commit", nil)
+	mLLM.On("ClassifyBinary", mock.Anything).Return("feat", nil)
+
+	mChunker := new(mockDiffChunker)
+	mChunker.On("Chunk", mock.Anything, mock.Anything).
+		Return([]domain.DiffChunk{{Files: []string{"main.go"}, Diff: "test diff"}}, nil)
+
+	mSecurity := new(mockSecurityService)
+	mSecurity.On("CheckFiles", mock.Anything, mock.Anything).
+		Return(&ports.SecurityCheckResult{Blocked: false})
+
+	commitSvc := workflow.NewCommitService(
+		mGit, mLLM, mChunker, mSecurity,
+		workflow.DefaultCommitServiceConfig(4096, 50, t.TempDir()+"/task.log"),
+		mStore,
+	)
+
+	// Inject an active session so ResolveWorkspace returns the session ID
+	sessionVal := new(atomic.Value)
+	sessionVal.Store(&domain.Session{
+		ID:       sessionUUID,
+		Branch:   "feature/session-branch",
+		Worktree: "/tmp/worktree",
+		Status:   domain.SessionActive,
+	})
+	commitSvc.SetActiveSession(sessionVal)
 
 	confirm := confirm.NewInMemory(5 * time.Minute)
 	cfg := config.Default()

--- a/internal/delivery/mcp/server.go
+++ b/internal/delivery/mcp/server.go
@@ -118,12 +118,12 @@ func New(cfg *config.Config, git ports.Git, llm ports.LLM, lifecycle ports.Lifec
 
 	// Create specialized services.
 	commitStore := commitstore.NewFilesystemCommitStore(".", git)
-	// Branch-scope the store: if on a real branch, write to per-branch path.
+	// Workspace-scope the store: if on a real branch, write to per-workspace path.
 	// Detached HEAD (empty branch) falls back to the legacy global path.
 	if git != nil {
 		if currentBranch, err := git.CurrentBranch(); err == nil && currentBranch != "" {
-			if err := commitStore.SetBranch(currentBranch); err != nil {
-				log.Printf("Warning: failed to set branch store: %v", err)
+			if err := commitStore.SetWorkspace(currentBranch); err != nil {
+				log.Printf("Warning: failed to set workspace store: %v", err)
 			}
 		}
 	}
@@ -176,6 +176,9 @@ func New(cfg *config.Config, git ports.Git, llm ports.LLM, lifecycle ports.Lifec
 	// Seed activeSession with a typed nil so subsequent Store of
 	// *domain.Session values never panics on inconsistent-type assignment.
 	srv.activeSession.Store((*domain.Session)(nil))
+	// Inject the shared activeSession into the commit service so capture/preview
+	// resolve the workspace id from the active session when one is selected.
+	commitSvc.SetActiveSession(&srv.activeSession)
 
 	// Capture client info during initialize.
 	hooks := &server.Hooks{}

--- a/internal/workflow/commit.go
+++ b/internal/workflow/commit.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	gitadapter "github.com/blak0p/git-courer/internal/adapters/git"
 	"github.com/blak0p/git-courer/internal/core/domain"
@@ -57,7 +58,37 @@ type CommitService struct {
 	cfg             CommitServiceConfig
 	projectCfg      *domain.ProjectConfig // nil if init hasn't run
 	progress        ProgressFunc
-	commitStore     ports.CommitStore // nil means no-op (no capture)
+	commitStore     ports.CommitStore    // nil means no-op (no capture)
+	activeSession   *atomic.Value        // holds *domain.Session or nil; set via SetActiveSession
+}
+
+// SetActiveSession installs the shared *atomic.Value that holds the active
+// session (a *domain.Session, or nil when no session is active). Reads are
+// lock-free. Pass nil to disable session-aware workspace resolution.
+func (s *CommitService) SetActiveSession(v *atomic.Value) {
+	s.activeSession = v
+}
+
+// ResolveWorkspace returns the workspace id under which commits should be
+// captured: the active session's ID when a session is active, otherwise the
+// current git branch. This is the single source of truth for workspace-id
+// resolution shared by capture and preview.
+func (s *CommitService) ResolveWorkspace() string {
+	if s.activeSession != nil {
+		if v := s.activeSession.Load(); v != nil {
+			if sess, ok := v.(*domain.Session); ok && sess != nil && sess.ID != "" {
+				return sess.ID
+			}
+		}
+	}
+	if s.git == nil {
+		return ""
+	}
+	branch, err := s.git.CurrentBranch()
+	if err != nil || branch == "" {
+		return ""
+	}
+	return branch
 }
 
 // SetProgressCallback sets the callback for progress notifications.

--- a/internal/workflow/commit_capture_test.go
+++ b/internal/workflow/commit_capture_test.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/blak0p/git-courer/internal/core/domain"
@@ -39,7 +40,11 @@ func (m *mockCommitStore) Clear() error {
 	return nil
 }
 
-func (m *mockCommitStore) SetBranch(name string) error {
+func (m *mockCommitStore) SetWorkspace(workspaceID string) error {
+	return nil
+}
+
+func (m *mockCommitStore) SetBranchRef(branch string) error {
 	return nil
 }
 
@@ -68,12 +73,27 @@ func (m *mockCommitStore) RemoveAllBranchDirs() error {
 	return nil
 }
 
+func (m *mockCommitStore) ReadAllWorkspaces() (map[string][]domain.CommitEntry, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make(map[string][]domain.CommitEntry)
+	if len(m.appended) > 0 {
+		result["main"] = m.appended
+	}
+	return result, nil
+}
+
+func (m *mockCommitStore) RemoveAllWorkspaceDirs() error {
+	return nil
+}
+
 // captureTestGit extends stubGit to return a proper SHA from Head() and author from ConfigGet.
 type captureTestGit struct {
 	stubGit
-	headSHA  string
-	headErr  error
-	userName string
+	headSHA      string
+	headErr      error
+	userName     string
+	currentBranch string
 }
 
 func (g *captureTestGit) Head() (string, error) {
@@ -85,6 +105,13 @@ func (g *captureTestGit) ConfigGet(key string) (string, error) {
 		return g.userName, nil
 	}
 	return g.stubGit.ConfigGet(key)
+}
+
+func (g *captureTestGit) CurrentBranch() (string, error) {
+	if g.currentBranch != "" {
+		return g.currentBranch, nil
+	}
+	return g.stubGit.CurrentBranch()
 }
 
 // validSHA returns a 40-char hex string for testing.
@@ -274,6 +301,128 @@ func TestCommitService_Capture_FromPlanAppendsEntry(t *testing.T) {
 	}
 	if store.appended[0].Message() != "feat: from plan" {
 		t.Errorf("entry Message = %q, want %q", store.appended[0].Message(), "feat: from plan")
+	}
+}
+
+func TestCommitService_ResolveWorkspace_WithActiveSession_ReturnsSessionID(t *testing.T) {
+	git := &captureTestGit{
+		stubGit: stubGit{
+			statusResult: domain.Status{
+				Files: []domain.FileStatus{
+					{Path: "main.go", Status: "M "},
+				},
+			},
+			diffStagedResult: "diff --git a/main.go\n+line",
+		},
+		headSHA: validSHA("00000006"),
+	}
+	llm := &stubLLM{chunkMsg: "feat: session commit"}
+	security := &stubSecurity{}
+	store := &mockCommitStore{}
+
+	svc := newCommitSvcWithCapture(git, llm, security, t.TempDir()+"/c.log", store)
+
+	// Inject active session
+	sessionVal := new(atomic.Value)
+	sessionVal.Store(&domain.Session{
+		ID:       "a1b2c3d4-e5f6-4789-8a01-234567890abc",
+		Branch:   "feature/session",
+		Worktree: "/tmp/worktree",
+		Status:   domain.SessionActive,
+	})
+	svc.SetActiveSession(sessionVal)
+
+	workspaceID := svc.ResolveWorkspace()
+	if workspaceID != "a1b2c3d4-e5f6-4789-8a01-234567890abc" {
+		t.Errorf("ResolveWorkspace() = %q, want session UUID", workspaceID)
+	}
+}
+
+func TestCommitService_ResolveWorkspace_NoSession_FallsBackToBranch(t *testing.T) {
+	git := &captureTestGit{
+		stubGit: stubGit{
+			statusResult: domain.Status{
+				Files: []domain.FileStatus{
+					{Path: "main.go", Status: "M "},
+				},
+			},
+			diffStagedResult: "diff --git a/main.go\n+line",
+		},
+		headSHA:       validSHA("00000007"),
+		currentBranch: "feature/my-branch",
+	}
+	llm := &stubLLM{chunkMsg: "feat: branch commit"}
+	security := &stubSecurity{}
+	store := &mockCommitStore{}
+
+	svc := newCommitSvcWithCapture(git, llm, security, t.TempDir()+"/c.log", store)
+	// No active session set
+
+	workspaceID := svc.ResolveWorkspace()
+	if workspaceID != "feature/my-branch" {
+		t.Errorf("ResolveWorkspace() = %q, want branch name", workspaceID)
+	}
+}
+
+func TestCommitService_ResolveWorkspace_NilSession_ReturnsBranch(t *testing.T) {
+	git := &captureTestGit{
+		stubGit: stubGit{
+			statusResult: domain.Status{
+				Files: []domain.FileStatus{
+					{Path: "main.go", Status: "M "},
+				},
+			},
+			diffStagedResult: "diff --git a/main.go\n+line",
+		},
+		headSHA:       validSHA("00000008"),
+		currentBranch: "main",
+	}
+	llm := &stubLLM{chunkMsg: "feat: nil session"}
+	security := &stubSecurity{}
+	store := &mockCommitStore{}
+
+	svc := newCommitSvcWithCapture(git, llm, security, t.TempDir()+"/c.log", store)
+
+	// Set activeSession to a Value that holds nil (typed nil)
+	sessionVal := new(atomic.Value)
+	sessionVal.Store((*domain.Session)(nil))
+	svc.SetActiveSession(sessionVal)
+
+	workspaceID := svc.ResolveWorkspace()
+	if workspaceID != "main" {
+		t.Errorf("ResolveWorkspace() = %q, want branch name", workspaceID)
+	}
+}
+
+func TestCommitService_SetActiveSession_DoesNotPanic(t *testing.T) {
+	git := &captureTestGit{
+		stubGit: stubGit{
+			statusResult: domain.Status{
+				Files: []domain.FileStatus{
+					{Path: "main.go", Status: "M "},
+				},
+			},
+			diffStagedResult: "diff --git a/main.go\n+line",
+		},
+		headSHA: validSHA("00000009"),
+	}
+	llm := &stubLLM{chunkMsg: "feat: set session"}
+	security := &stubSecurity{}
+	store := &mockCommitStore{}
+
+	svc := newCommitSvcWithCapture(git, llm, security, t.TempDir()+"/c.log", store)
+
+	// Should not panic with nil
+	svc.SetActiveSession(nil)
+
+	// Should not panic with valid value
+	sessionVal := new(atomic.Value)
+	sessionVal.Store(&domain.Session{ID: "test-session"})
+	svc.SetActiveSession(sessionVal)
+
+	workspaceID := svc.ResolveWorkspace()
+	if workspaceID != "test-session" {
+		t.Errorf("ResolveWorkspace() = %q, want 'test-session'", workspaceID)
 	}
 }
 

--- a/internal/workflow/commit_execute.go
+++ b/internal/workflow/commit_execute.go
@@ -205,8 +205,9 @@ func (s *CommitService) CaptureCommit(msg string) {
 }
 
 // captureCommit captures the commit metadata after a successful git commit.
-// It calls git.Head() for the SHA, gets the author from git config and the
-// current date, constructs a CommitEntry, and appends it to the CommitStore.
+// It resolves the workspace id (active session id, else current branch),
+// configures the commit store workspace + branch ref, gets commit metadata,
+// and appends it to the CommitStore with the current branch attached.
 // If commitStore is nil, it's a no-op. Append failures are logged but do not
 // fail the commit operation.
 func (s *CommitService) captureCommit(msg string) {
@@ -214,10 +215,23 @@ func (s *CommitService) captureCommit(msg string) {
 		return
 	}
 
-	// Dynamically scope the branch on every capture to handle tardy repo initialization or switches
-	if currentBranch, err := s.git.CurrentBranch(); err == nil && currentBranch != "" {
-		if err := s.commitStore.SetBranch(currentBranch); err != nil {
-			log.Printf("[WARN] Failed to set branch store for %q: %v", currentBranch, err)
+	// Resolve the workspace id: active session id if present, else current branch.
+	workspaceID := s.ResolveWorkspace()
+	currentBranch := ""
+	if b, err := s.git.CurrentBranch(); err == nil {
+		currentBranch = b
+	}
+
+	// Configure the store to write under workspace/<id>.
+	if workspaceID != "" {
+		if err := s.commitStore.SetWorkspace(workspaceID); err != nil {
+			log.Printf("[WARN] Failed to set workspace store for %q: %v", workspaceID, err)
+		}
+	}
+	// Refs/courer/<branch> must stay branch-keyed for push/pull.
+	if currentBranch != "" {
+		if err := s.commitStore.SetBranchRef(currentBranch); err != nil {
+			log.Printf("[WARN] Failed to set branch ref for %q: %v", currentBranch, err)
 		}
 	}
 
@@ -234,6 +248,9 @@ func (s *CommitService) captureCommit(msg string) {
 	opts := []domain.CommitEntryOption{domain.WithDate(date)}
 	if author != "" {
 		opts = append(opts, domain.WithAuthor(author))
+	}
+	if currentBranch != "" {
+		opts = append(opts, domain.WithBranch(currentBranch))
 	}
 
 	entry, err := domain.NewCommitEntry(sha, msg, opts...)

--- a/internal/workflow/release.go
+++ b/internal/workflow/release.go
@@ -224,21 +224,6 @@ func migrateOldMetadata(oldDir, newDir string) error {
 	return nil
 }
 
-func sanitizeBranchName(name string) string {
-	r := strings.ReplaceAll(name, "/", "-")
-	for _, ch := range []string{"~", "^", ":", "\\", " "} {
-		r = strings.ReplaceAll(r, ch, "")
-	}
-	for strings.Contains(r, "--") {
-		r = strings.ReplaceAll(r, "--", "-")
-	}
-	r = strings.Trim(r, "-")
-	if r == "" {
-		return "HEAD"
-	}
-	return r
-}
-
 // commitsFromRefs reads commit entries from refs/courer/* blobs.
 // Returns empty string and nil error if no refs exist.
 func (s *ReleaseService) commitsFromRefs() (string, error) {
@@ -530,14 +515,14 @@ func (s *ReleaseService) Prepare(instruction string, userBump string) (*domain.R
 	}
 
 	if s.commitStore != nil && !fromStore {
-		// Try ReadAllBranches first (aggregates all branch stores)
+		// Merge entries from branches/ (DEPRECATED) and workspace/ (new).
+		// Deduplicate by SHA across both sources so the LLM sees each commit once.
+		seen := make(map[string]bool)
+		var deduped []domain.CommitEntry
+
+		// 1. Read legacy branches/ stores (DEPRECATED — passive coexistence).
 		branchEntries, allBranchesErr := s.commitStore.ReadAllBranches()
-		if allBranchesErr == nil && len(branchEntries) > 0 {
-			// Flatten and deduplicate by SHA (first occurrence wins)
-			seen := make(map[string]bool)
-			var deduped []domain.CommitEntry
-			// Iterate branches in stable order is not guaranteed,
-			// but dedup by SHA ensures correctness regardless of order.
+		if allBranchesErr == nil {
 			for _, entries := range branchEntries {
 				for _, entry := range entries {
 					if !seen[entry.SHA()] {
@@ -546,16 +531,31 @@ func (s *ReleaseService) Prepare(instruction string, userBump string) (*domain.R
 					}
 				}
 			}
-			if len(deduped) > 0 {
-				msgLines := domain.Messages(deduped)
-				commits = strings.Join(msgLines, "\n")
-				fromStore = true
-				s.pendingEntries = deduped // Store for stack grouping in Generate()
-				log.Printf("[DEBUG] Using %d deduplicated CommitStore entries from %d branches for release", len(deduped), len(branchEntries))
+		} else {
+			log.Printf("[WARN] ReadAllBranches failed: %v (continuing with workspace entries)", allBranchesErr)
+		}
+
+		// 2. Read workspace/ stores (new — session-keyed).
+		workspaceEntries, wsErr := s.commitStore.ReadAllWorkspaces()
+		if wsErr == nil {
+			for _, entries := range workspaceEntries {
+				for _, entry := range entries {
+					if !seen[entry.SHA()] {
+						seen[entry.SHA()] = true
+						deduped = append(deduped, entry)
+					}
+				}
 			}
-		} else if allBranchesErr != nil {
-			// ReadAllBranches failed — log and fall back to Read (single branch)
-			log.Printf("[WARN] ReadAllBranches failed: %v (falling back to current branch)", allBranchesErr)
+		} else {
+			log.Printf("[WARN] ReadAllWorkspaces failed: %v (continuing with branch entries)", wsErr)
+		}
+
+		if len(deduped) > 0 {
+			msgLines := domain.Messages(deduped)
+			commits = strings.Join(msgLines, "\n")
+			fromStore = true
+			s.pendingEntries = deduped // Store for stack grouping in Generate()
+			log.Printf("[DEBUG] Using %d deduplicated CommitStore entries from branches + workspaces for release", len(deduped))
 		}
 
 		// If ReadAllBranches returned empty or wasn't available, fall back to Read (single branch)

--- a/internal/workflow/release_capture_test.go
+++ b/internal/workflow/release_capture_test.go
@@ -12,15 +12,19 @@ import (
 
 // releaseStoreMock is a test double for CommitStore used in release tests.
 type releaseStoreMock struct {
-	mu                      sync.Mutex
-	entries                 []domain.CommitEntry
-	readErr                 error
-	clearErr                error
-	clearCalls              int
-	removeAllBranchDirErr   error
-	removeAllBranchDirCalls int
-	readAllBranchesResult   map[string][]domain.CommitEntry
-	readAllBranchesErr      error
+	mu                        sync.Mutex
+	entries                   []domain.CommitEntry
+	readErr                   error
+	clearErr                  error
+	clearCalls                int
+	removeAllBranchDirErr      error
+	removeAllBranchDirCalls    int
+	readAllBranchesResult      map[string][]domain.CommitEntry
+	readAllBranchesErr         error
+	readAllWorkspacesResult    map[string][]domain.CommitEntry
+	readAllWorkspacesErr       error
+	removeAllWorkspaceDirErr   error
+	removeAllWorkspaceDirCalls int
 }
 
 func (m *releaseStoreMock) Append(entries ...domain.CommitEntry) error {
@@ -52,7 +56,11 @@ func (m *releaseStoreMock) Clear() error {
 	return nil
 }
 
-func (m *releaseStoreMock) SetBranch(name string) error {
+func (m *releaseStoreMock) SetWorkspace(workspaceID string) error {
+	return nil
+}
+
+func (m *releaseStoreMock) SetBranchRef(branch string) error {
 	return nil
 }
 
@@ -89,6 +97,26 @@ func (m *releaseStoreMock) RemoveAllBranchDirs() error {
 	defer m.mu.Unlock()
 	m.removeAllBranchDirCalls++
 	return m.removeAllBranchDirErr
+}
+
+func (m *releaseStoreMock) ReadAllWorkspaces() (map[string][]domain.CommitEntry, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.readAllWorkspacesErr != nil {
+		return nil, m.readAllWorkspacesErr
+	}
+	if m.readAllWorkspacesResult != nil {
+		return m.readAllWorkspacesResult, nil
+	}
+	// Default: empty map (no workspace entries)
+	return make(map[string][]domain.CommitEntry), nil
+}
+
+func (m *releaseStoreMock) RemoveAllWorkspaceDirs() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.removeAllWorkspaceDirCalls++
+	return m.removeAllWorkspaceDirErr
 }
 
 // --- Phase 4.1 RED: Prepare with CommitStore ---
@@ -501,6 +529,62 @@ func TestReleaseService_Prepare_FallsBackOnReadAllBranchesError(t *testing.T) {
 	}
 }
 
+func TestReleaseService_Prepare_MergesBranchesAndWorkspaces(t *testing.T) {
+	git := &mockGitForRelease{
+		listTagsResult: []string{"v1.0.0"},
+		commitsResult:  "SHOULD NOT BE USED — git fallback data",
+	}
+	llm := &mockLLMForRelease{}
+
+	entry1, _ := domain.NewCommitEntry(
+		"a1b2c3d4e5f6071829a0b1c2d3e4f50617283940",
+		"feat: shared commit",
+	)
+	entry2, _ := domain.NewCommitEntry(
+		"b2c3d4e5f6071829a0b1c2d3e4f5061728394001",
+		"fix: branch-only commit",
+	)
+	entry3, _ := domain.NewCommitEntry(
+		"c3d4e5f6071829a0b1c2d3e4f506172839400002",
+		"feat: workspace-only commit",
+	)
+
+	// Simulate data in both branches/ and workspace/ with one SHA shared
+	store := &releaseStoreMock{
+		readAllBranchesResult: map[string][]domain.CommitEntry{
+			"feature-a": {entry1, entry2},
+		},
+		readAllWorkspacesResult: map[string][]domain.CommitEntry{
+			"session-1": {entry1, entry3},
+		},
+	}
+
+	svc := newReleaseSvcWithStore(t, git, llm, store)
+	intent, commits, _, err := svc.Prepare("release minor version", "")
+	if err != nil {
+		t.Fatalf("Prepare() error: %v", err)
+	}
+
+	if !intent.IsRelease {
+		t.Fatal("Prepare() should detect a releaseable change")
+	}
+
+	// Should contain messages from both sources, deduplicated by SHA
+	if !strings.Contains(commits, "shared commit") {
+		t.Error("Prepare() should contain 'shared commit' from branches")
+	}
+	if !strings.Contains(commits, "branch-only commit") {
+		t.Error("Prepare() should contain 'branch-only commit' from branches")
+	}
+	if !strings.Contains(commits, "workspace-only commit") {
+		t.Error("Prepare() should contain 'workspace-only commit' from workspaces")
+	}
+	// Should NOT fall back to git
+	if strings.Contains(commits, "SHOULD NOT BE USED") {
+		t.Error("Prepare() should NOT use git fallback when store has data")
+	}
+}
+
 func TestReleaseService_Execute_CleansUpBranchDirs(t *testing.T) {
 	git := &mockGitForRelease{}
 	llm := &mockLLMForRelease{}
@@ -524,6 +608,9 @@ func TestReleaseService_Execute_CleansUpBranchDirs(t *testing.T) {
 
 	if store.removeAllBranchDirCalls != 1 {
 		t.Errorf("RemoveAllBranchDirs() called %d times, want 1", store.removeAllBranchDirCalls)
+	}
+	if store.removeAllWorkspaceDirCalls != 1 {
+		t.Errorf("RemoveAllWorkspaceDirs() called %d times, want 1", store.removeAllWorkspaceDirCalls)
 	}
 }
 

--- a/internal/workflow/release_execute.go
+++ b/internal/workflow/release_execute.go
@@ -103,9 +103,13 @@ func (s *ReleaseService) Execute(intent *domain.ReleaseIntent, changelog string)
 		if err := s.commitStore.Clear(); err != nil {
 			log.Printf("[WARN] Failed to clear CommitStore: %v", err)
 		}
-		// Clean up all branch directories after release
+		// Clean up all branch directories after release (DEPRECATED — passive coexistence)
 		if err := s.commitStore.RemoveAllBranchDirs(); err != nil {
 			log.Printf("[WARN] Failed to remove branch directories: %v", err)
+		}
+		// Clean up all workspace directories after release
+		if err := s.commitStore.RemoveAllWorkspaceDirs(); err != nil {
+			log.Printf("[WARN] Failed to remove workspace directories: %v", err)
 		}
 	}
 

--- a/test/release/e2e_test.go
+++ b/test/release/e2e_test.go
@@ -88,8 +88,8 @@ func setupTestRepo(t *testing.T) (repoDir string, store *commitstore.FilesystemC
 	}
 
 	store = commitstore.NewFilesystemCommitStore(dir, nil)
-	if err := store.SetBranch("e2e/test"); err != nil {
-		t.Fatalf("SetBranch: %v", err)
+	if err := store.SetWorkspace("e2e/test"); err != nil {
+		t.Fatalf("SetWorkspace: %v", err)
 	}
 	for _, e := range entries {
 		entry, err := domain.NewCommitEntry(e.sha, e.message)


### PR DESCRIPTION
<!--
  Thank you for contributing to git-courer!
  Please follow the conventional commit format and ensure tests pass.
-->

Closes #215

## Summary

Change commit metadata grouping from `branch` to `workspace_id` (= `session_id`) so the release changelog LLM sees full feature context instead of fragments from individual branches in chained PRs.

## Changes

| File | Change |
|------|--------|
| `internal/core/domain/commit_entry.go` | +`branch` field, `WithBranch()`, `Branch()` getter |
| `internal/core/ports/commit_store.go` | `SetBranch` → `SetWorkspace`, +`SetBranchRef`, +`ReadAllWorkspaces`, +`RemoveAllWorkspaceDirs` |
| `internal/adapters/commitstore/adapter.go` | Workspace implementation, conditional UUID vs branch sanitization, `entriesEqual` +branch |
| `internal/adapters/commitstore/sanitize.go` | Export `SanitizeBranchName`, +`isUUID` helper |
| `internal/workflow/commit.go` | +`activeSession`, `SetActiveSession()`, `ResolveWorkspace()` |
| `internal/workflow/commit_execute.go` | `captureCommit` workspace-aware |
| `internal/delivery/mcp/server.go` | Wire `activeSession` → `CommitService` |
| `internal/delivery/mcp/core/commit_handler.go` | `handlePreview` workspace-aware |
| `internal/workflow/release.go` | Merge `branches/` + `workspace/` with SHA dedup |
| `internal/workflow/release_execute.go` | +`RemoveAllWorkspaceDirs()` |
| `internal/core/ports/pr_matcher.go` | Port stub for v2.8.0 (branch→PR matching) |
| `cmd/main.go`, `internal/delivery/cli/release.go` | `SetBranch` → `SetWorkspace` |

## Test Plan

- [x] `make test-unit` — 40/40 packages pass, 0 failures
- [x] New tests for `WithBranch`, `ResolveWorkspace`, `SetActiveSession`, `PRMatcher`, workspace merge in release, preview with active session
- [x] All mocks updated for `SetWorkspace`/`SetBranchRef`
- [x] No regressions in existing tests